### PR TITLE
Feature/limit fields

### DIFF
--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -212,7 +212,6 @@ class DSOSerializer(_SideloadMixin, serializers.HyperlinkedModelSerializer):
 
         display_fields = self.get_fields_to_display()
         if display_fields is not None:
-            # display_fields.append("_links")
             # Limit result to requested fields only
             self.fields = OrderedDict(
                 [

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -62,6 +62,8 @@ def get_invalid_params(
             full_name = f"{field_name}[{i}]" if isinstance(error, dict) else field_name
             result.extend(get_invalid_params(exc, error, field_name=full_name))
     elif isinstance(detail, ErrorDetail):
+        if field_name is None:
+            field_name = detail.code
         # flattened is now RFC7807 mandates it
         result.append(
             {

--- a/src/tests/test_rest_framework_dso/test_serializers.py
+++ b/src/tests/test_rest_framework_dso/test_serializers.py
@@ -1,4 +1,5 @@
 import pytest
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
 from rest_framework_dso.crs import RD_NEW, WGS84
@@ -78,6 +79,50 @@ def test_pagination_many(api_request, movie):
             "category": [{"name": "bar"}],
         },
     }
+
+
+@pytest.mark.django_db
+def test_fields_limit_works(api_rf, movie):
+    """Prove that serializer can limit output fields."""
+    django_request = api_rf.get("/", {"fields": "name"})
+    request = Request(django_request)
+    queryset = Movie.objects.all()
+
+    serializer = MovieSerializer(
+        many=True, instance=queryset, context={"request": request}
+    )
+    paginator = DSOPageNumberPagination()
+    paginator.paginate_queryset(queryset, request)
+    response = paginator.get_paginated_response(serializer.data)
+
+    assert response.data == {
+        "_links": {
+            "self": {"href": "http://testserver/"},
+            "next": {"href": None},
+            "previous": {"href": None},
+        },
+        "count": 1,
+        "page_size": 20,
+        "_embedded": {"movie": [{"name": "foo123"}]},
+    }
+
+
+@pytest.mark.django_db
+def test_fields_limit_by_incorrect_field_gives_error(api_rf, movie):
+    """Prove that serializer can limit output fields."""
+    django_request = api_rf.get("/", {"fields": "batman"})
+    request = Request(django_request)
+    queryset = Movie.objects.all()
+
+    serializer = MovieSerializer(
+        many=True, instance=queryset, context={"request": request}
+    )
+    paginator = DSOPageNumberPagination()
+    paginator.paginate_queryset(queryset, request)
+    with pytest.raises(ValidationError) as exec_info:
+        paginator.get_paginated_response(serializer.data)
+
+    assert "'batman' is not one of available options" in str(exec_info.value)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Optionally limit serialized output to fields specified in `?fields=` request parameter.