### PR TITLE
[DS-232] Allow filtering with lookup operators

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 import re
+from collections import OrderedDict
 from functools import lru_cache
 from typing import Type
-from collections import OrderedDict
 
 from django.db import models
 
-from dso_api.lib.schematools.models import DynamicModel
 from amsterdam_schema.types import DatasetTableSchema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework_dso.fields import EmbeddedField
 from rest_framework_dso.serializers import DSOSerializer
+
 from dso_api.dynamic_api.permissions import get_unauthorized_fields
 from dso_api.dynamic_api.utils import snake_to_camel_case
+from dso_api.lib.schematools.models import DynamicModel
 
 
 class _DynamicLinksField(DSOSerializer.serializer_url_field):
@@ -64,6 +67,7 @@ class DynamicSerializer(DSOSerializer):
         request = self.context.get("request")
         return getattr(request, "is_authorized_for", None) if request else None
 
+    @extend_schema_field(OpenApiTypes.URI)
     def get_schema(self, instance):
         """The schema field is exposed with every record"""
         name = instance.get_dataset_id()

--- a/src/dso_api/dynamic_api/views.py
+++ b/src/dso_api/dynamic_api/views.py
@@ -84,11 +84,6 @@ class DynamicApiViewSet(
     #: Custom permission that checks amsterdam schema auth settings
     permission_classes = [permissions.HasOAuth2Scopes]
 
-    def get_queryset(self):
-        # XXX use objects.only or objects.defer to filter columns
-        # scopes = fetch_scopes_for_model(self.model)
-        return self.model.objects.all()
-
 
 def _get_viewset_api_docs(
     serializer_class: Type[serializers.DynamicSerializer],
@@ -146,6 +141,7 @@ def viewset_factory(model: Type[DynamicModel]) -> Type[DynamicApiViewSet]:
             serializer_class, filterset_class, ordering_fields
         ),
         "model": model,
+        "queryset": model.objects.all(),  # also for OpenAPI schema parsing.
         "serializer_class": serializer_class,
         "filterset_class": filterset_class,
         "ordering_fields": ordering_fields,

--- a/src/rest_framework_dso/openapi.py
+++ b/src/rest_framework_dso/openapi.py
@@ -1,8 +1,205 @@
+"""Improve the OpenAPI schema output """
 from typing import List
 
+from django.core.exceptions import FieldDoesNotExist
+from django.db import models
 from drf_spectacular import openapi
-from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.types import OpenApiTypes, resolve_basic_type
 from drf_spectacular.utils import ExtraParameter
+from rest_framework import serializers
+from rest_framework.fields import ReadOnlyField
+from rest_framework_gis.fields import GeometryField
+
+from rest_framework_dso.serializers import _LinksField
+
+__all__ = ["DSOSchemaGenerator", "DSOAutoSchema"]
+
+GEOS_TO_GEOJSON = {}
+GEOJSON_TYPES = [
+    "Point",
+    "LineString",
+    "Polygon",
+    "MultiPoint",
+    "MultiLineString",
+    "MultiPolygon",
+]
+GEOM_TYPES_TO_GEOJSON = {x.upper(): x for x in GEOJSON_TYPES}
+
+
+class DSOSchemaGenerator(openapi.SchemaGenerator):
+    """Extended OpenAPI schema generator, that includes:
+
+    - GeoJSON components
+    - Override OpenAPI parts
+    """
+
+    #: Allow to override the schema
+    schema_overrides = {}
+
+    schema_override_components = {
+        "_SelfLink": {
+            "type": "object",
+            "properties": {
+                "self": {
+                    "type": "object",
+                    "properties": {
+                        "href": {"type": "string", "readOnly": True,},
+                        "title": {"type": "string", "format": "uri", "readOnly": True,},
+                    },
+                }
+            },
+        },
+        # Used from https://gist.github.com/codan-telcikt/e1d59ccc9a3af83e083f1a514c84026c
+        # Parsed with yaml.load()
+        "Geometry": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "discriminator": "type",
+            "required": ["type"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": GEOJSON_TYPES,
+                    "description": "the geometry type",
+                }
+            },
+        },
+        "Point3D": {
+            "type": "array",
+            "description": "Point in 3D space",
+            "minItems": 2,
+            "maxItems": 3,
+            "items": {"type": "number"},
+        },
+        "Point": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "allOf": [
+                {"$ref": "#/components/schemas/Geometry"},
+                {
+                    "properties": {
+                        "coordinates": {"$ref": "#/components/schemas/Point3D"}
+                    }
+                },
+            ],
+        },
+        "LineString": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "allOf": [
+                {"$ref": "#/components/schemas/Geometry"},
+                {
+                    "properties": {
+                        "coordinates": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Point3D"},
+                        }
+                    }
+                },
+            ],
+        },
+        "Polygon": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "allOf": [
+                {"$ref": "#/components/schemas/Geometry"},
+                {
+                    "properties": {
+                        "coordinates": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {"$ref": "#/components/schemas/Point3D"},
+                            },
+                        }
+                    }
+                },
+            ],
+        },
+        "MultiPoint": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "allOf": [
+                {"$ref": "#/components/schemas/Geometry"},
+                {
+                    "properties": {
+                        "coordinates": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Point3D"},
+                        }
+                    }
+                },
+            ],
+        },
+        "MultiLineString": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "allOf": [
+                {"$ref": "#/components/schemas/Geometry"},
+                {
+                    "properties": {
+                        "coordinates": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {"$ref": "#/components/schemas/Point3D"},
+                            },
+                        }
+                    }
+                },
+            ],
+        },
+        "MultiPolygon": {
+            "type": "object",
+            "description": "GeoJSON geometry",
+            "allOf": [
+                {"$ref": "#/components/schemas/Geometry"},
+                {
+                    "properties": {
+                        "coordinates": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/components/schemas/Point3D"},
+                                },
+                            },
+                        }
+                    }
+                },
+            ],
+        },
+        "GeometryCollection": {
+            "type": "object",
+            "description": "GeoJSON geometry collection",
+            "required": ["type", "geometries"],
+            "properties": {
+                "type": {"type": "string", "enum": ["GeometryCollection"]},
+                "geometries": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/Geometry"},
+                },
+            },
+        },
+    }
+
+    extra_schema = {}
+
+    def get_schema(self, request=None, public=False):
+        """Provide the missing data that DRF get_schema_view() doesn't yet offer."""
+        schema = super().get_schema(request=request, public=public)
+        for key, value in self.schema_overrides.items():
+            if isinstance(value, dict):
+                try:
+                    schema[key].update(value)
+                except KeyError:
+                    schema[key] = value
+            else:
+                schema[key] = value
+
+        schema["components"]["schemas"].update(self.schema_override_components)
+        return schema
 
 
 class DSOAutoSchema(openapi.AutoSchema):
@@ -17,6 +214,48 @@ class DSOAutoSchema(openapi.AutoSchema):
             return tokenized_path[1:2]
         else:
             return tokenized_path[:1]
+
+    def _map_serializer_field(self, method, field) -> dict:
+        """Transform the serializer field into a OpenAPI definition.
+        This method is overwritten to fix some missing field types.
+        """
+        if not hasattr(field, "_spectacular_annotation"):
+            if isinstance(field, _LinksField):
+                return {"$ref": "#/components/schemas/_SelfLink"}
+
+            # Fix support for missing field types:
+            if isinstance(field, serializers.HyperlinkedRelatedField):
+                return resolve_basic_type(OpenApiTypes.URI)
+
+            if isinstance(field, GeometryField):
+                # or use $ref when examples are included.
+                # model_field.geom_type is uppercase
+                model_field = field.parent.Meta.model._meta.get_field(field.field_name)
+                geojson_type = GEOM_TYPES_TO_GEOJSON.get(
+                    model_field.geom_type, "Geometry"
+                )
+                return {"$ref": f"#/components/schemas/{geojson_type}"}
+
+            if isinstance(field, ReadOnlyField):
+                try:
+                    model_field = field.parent.Meta.model._meta.get_field(field.source)
+                except FieldDoesNotExist:
+                    pass
+                else:
+                    return self._map_model_field(model_field)
+
+        return super()._map_serializer_field(method, field)
+
+    def _map_model_field(self, field) -> dict:
+        """Transform model fields into an OpenAPI definition.
+        This method is overwritten to fix some missing field types.
+        """
+        if isinstance(field, models.CharField):
+            return resolve_basic_type(OpenApiTypes.STR)
+        elif isinstance(field, models.ForeignKey):
+            return self._map_model_field(field.target_field)
+
+        return super()._map_model_field(field)
 
     def get_extra_parameters(self, path, method):
         """Expose the DSO-specific HTTP headers in all API methods."""

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -156,7 +156,7 @@ def bommen_dataset(bommen_schema_json) -> Dataset:
 @pytest.fixture
 def category() -> Category:
     """A dummy model to test our API with"""
-    return Category.objects.create(name="bar")
+    return Category.objects.create(pk=1, name="bar")
 
 
 @pytest.fixture

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -1,0 +1,54 @@
+import logging
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_openapi_json(api_client, filled_router, caplog):
+    """Prove that the OpenAPI page can be rendered."""
+    caplog.set_level(logging.WARNING)
+
+    url = reverse("openapi.json")
+    response = api_client.get(url)
+    assert response.status_code == 200, response.data
+    schema = response.data
+
+    # Prove that the oauth model is exposed
+    assert schema["components"]["securitySchemes"]["oauth2"]["type"] == "oauth2"
+
+    # Prove that the serializer field types are reasonably converted
+    component_schemas = schema["components"]["schemas"]
+    container_properties = component_schemas["afvalwegingenContainers"]["properties"]
+    assert "MultiPolygon" in component_schemas, list(component_schemas)
+    assert container_properties["geometry"]["$ref"] == "#/components/schemas/Point"
+    assert container_properties["id"]["type"] == "integer"
+    assert container_properties["datumLeegmaken"]["format"] == "date-time"
+
+    # Prove that the filter help text is exposed as description
+    afval_parameters = {
+        param["name"]: param
+        for param in schema["paths"]["/v1/afvalwegingen/containers/"]["get"][
+            "parameters"
+        ]
+    }
+    assert "datumCreatie" in afval_parameters, ", ".join(afval_parameters.keys())
+    assert afval_parameters["datumCreatie"]["description"] == "yyyy-mm-dd"
+
+    # Prove that DSOOrderingFilter exposes parameters
+    assert "sort" in afval_parameters, ", ".join(afval_parameters.keys())
+
+    # Prove that the lookups of LOOKUPS_BY_TYPE are parsed
+    # ([lt] for dates, [in] for keys)
+    assert "datumCreatie[lt]" in afval_parameters, ", ".join(afval_parameters.keys())
+    assert "clusterId[in]" in afval_parameters, ", ".join(afval_parameters.keys())
+
+    assert not caplog.messages
+
+
+@pytest.mark.django_db
+def test_openapi_yaml(api_client, filled_router):
+    """Prove that the OpenAPI page can be rendered."""
+    url = reverse("openapi.yaml")
+    response = api_client.get(url)
+    assert response.status_code == 200, response.data

--- a/src/tests/test_rest_framework_dso/models.py
+++ b/src/tests/test_rest_framework_dso/models.py
@@ -20,6 +20,9 @@ class Movie(models.Model):
         app_label = "test_rest_framework_dso"
         ordering = ("name",)
 
+    def __str__(self):
+        return self.name
+
 
 class Location(models.Model):
     geometry = gis_models.PointField(srid=RD_NEW.srid)

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -155,10 +155,12 @@ class TestListFilters:
                 {
                     "type": "urn:apiexception:invalid:invalid",
                     "name": "date_added",
-                    "reason": "Enter a valid date.",
+                    "reason": "Enter a valid ISO date-time, or single date.",
                 }
             ],
-            "x-validation-errors": {"date_added": ["Enter a valid date."]},
+            "x-validation-errors": {
+                "date_added": ["Enter a valid ISO date-time, or single date."]
+            },
         }
 
 


### PR DESCRIPTION
- Added [lt], [lte], [gt], [gte], [in] operators.
- Fixed using FOREIGNKEY_id field for filters (by using attname).
- Fixed OpenAPI types for FK parameters.
- Fixed OpenAPI types for geometry fields.
- Fixed OpenAPI types for _links field.
- Avoid value checks for IN fields (may pass non-existing values)