### PR TITLE
Fixing crash on load due to duplicate Model names.

### DIFF
--- a/src/dso_api/dynamic_api/app_config.py
+++ b/src/dso_api/dynamic_api/app_config.py
@@ -1,0 +1,56 @@
+import os
+import logging
+from django.apps import apps, config as apps_config
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class VirtualAppConfig(apps_config.AppConfig):
+    """
+    Virtualt App Config, allowing to add models for datasets on the fly.
+    """
+    def __init__(self, apps, *args, **kwargs):
+        super(VirtualAppConfig, self).__init__(*args, **kwargs)
+        # Make django think that App is initiated already.
+        self.models = dict()
+        # Path is required for Django to think this APP is real.
+        self.path = os.path.dirname(__file__)
+
+        self.apps = apps
+        apps.app_configs[self.label] = self
+
+        # Disable migrations for this model.
+        if not hasattr(settings, "MIGRATION_MODULES"):
+            settings.MIGRATION_MODULES = dict()
+        try:
+            settings.MIGRATION_MODULES[self.label] = None
+        except TypeError as e:
+            logger.warn(f"Failed to disable migrations for {self.label}: {e}")
+
+    def _path_from_module(self, module):
+        """
+        Disable OS loading for this App Config.
+        """
+        return None
+
+    def register_model(self, model):
+        """
+        Register model in django registry and update models.
+        """
+        self.apps.register_model(self.label, model)
+        self.models = self.apps.all_models[self.label]
+
+
+def register_model(dataset, model):
+    """
+    Register model in django.apps
+    """
+
+    dataset_id = dataset.schema.id
+    if dataset_id in apps.app_configs:
+        app_config = apps.app_configs[dataset_id]
+    else:
+        app_config = VirtualAppConfig(apps, dataset_id, app_module=__file__)
+
+    app_config.register_model(model)

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 0.5
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.5.0
+amsterdam-schema-tools[django] == 0.5.1
 datapunt-authorization-django==1.0.0
 drf-amsterdam == 0.3.2
 drf-spectacular == 0.8.5

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.5.0  # via -r requirements.in
+amsterdam-schema-tools[django]==0.5.1  # via -r requirements.in
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via jsonschema, pytest
 cachetools==4.0.0         # via -r requirements.in

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,8 +4,9 @@ from datetime import date
 from pathlib import Path
 
 import pytest
-from django.core.handlers.wsgi import WSGIRequest
 from jwcrypto.jwt import JWT
+from django.apps import apps
+from django.core.handlers.wsgi import WSGIRequest
 from django.db import connection
 from django.utils.timezone import now
 from django.contrib.gis.geos import GEOSGeometry, Point
@@ -89,6 +90,11 @@ def filled_router(router, afval_dataset, bommen_dataset, parkeervakken_dataset):
     if "parkeervakken_parkeervakken" not in table_names:
         create_tables(parkeervakken_dataset.schema)
 
+    apps.register_model("afvalwegingen", router.all_models["afvalwegingen"]["clusters"])
+    apps.register_model("afvalwegingen", router.all_models["afvalwegingen"]["containers"])
+
+    apps.register_model("parkeervakken", router.all_models["parkeervakken"]["parkeervakken"])
+    apps.register_model("parkeervakken", router.all_models["parkeervakken"]["parkeervakken_regimes"])
     return router
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -90,11 +90,6 @@ def filled_router(router, afval_dataset, bommen_dataset, parkeervakken_dataset):
     if "parkeervakken_parkeervakken" not in table_names:
         create_tables(parkeervakken_dataset.schema)
 
-    apps.register_model("afvalwegingen", router.all_models["afvalwegingen"]["clusters"])
-    apps.register_model("afvalwegingen", router.all_models["afvalwegingen"]["containers"])
-
-    apps.register_model("parkeervakken", router.all_models["parkeervakken"]["parkeervakken"])
-    apps.register_model("parkeervakken", router.all_models["parkeervakken"]["parkeervakken_regimes"])
     return router
 
 


### PR DESCRIPTION
This PR is adding VirtualAppConfigs, allowing django to think that all of Dynamic Models belong to real apps.

All of this is needed to allow models with same name being registered in django apps registry (to allow relations to resolve).
Alternative is to prefix all models with Dataset.id, but I'm afraid it will turn into much bigger mess.

But first: https://github.com/Amsterdam/schema-tools/pull/21