### PR TITLE
Upgrade python-string-utils pinning to 1.0.0

### DIFF
--- a/src/dso_api/dynamic_api/remote/serializers.py
+++ b/src/dso_api/dynamic_api/remote/serializers.py
@@ -113,7 +113,7 @@ def _remote_object_field_factory(
     """Generate a serializer for an sub-object field"""
     table_schema = field.table
     dataset = table_schema.dataset
-    safe_dataset_id = slugify(dataset.id, sign="_")
+    safe_dataset_id = slugify(dataset.id, separator="_")
     serializer_name = (
         f"{dataset.id.title()}{table_schema.id.title()}"
         f"_{field.name.title()}Serializer"

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -109,8 +109,8 @@ def get_view_name(model: Type[DynamicModel], suffix: str):
 
     :param suffix: This can be "detail" or "list".
     """
-    dataset_id = slugify(model.get_dataset_id(), sign="_")
-    table_id = slugify(model.get_table_id(), sign="_")
+    dataset_id = slugify(model.get_dataset_id(), separator="_")
+    table_id = slugify(model.get_table_id(), separator="_")
     return f"dynamic_api:{dataset_id}-{table_id}-{suffix}"
 
 
@@ -122,7 +122,7 @@ def serializer_factory(model: Type[DynamicModel], flat=None) -> Type[DynamicSeri
         # Inner tables have no schema or links defined.
         fields = []
 
-    safe_dataset_id = slugify(model.get_dataset_id(), sign="_")
+    safe_dataset_id = slugify(model.get_dataset_id(), separator="_")
     serializer_name = f"{safe_dataset_id.title()}{model.__name__}Serializer"
     new_attrs = {
         "table_schema": model._table_schema,

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -23,7 +23,7 @@ def snake_to_camel_case(key: str) -> str:
 def format_field_name(key):
     """Convert space separated Amsterdam Schema key into snake_case model property name.
     """
-    return slugify(key, sign="_")
+    return slugify(key, separator="_")
 
 
 def format_api_field_name(key):

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,13 +8,13 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 0.6
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.6.0
+amsterdam-schema-tools[django] == 0.7.0
 datapunt-authorization-django==1.0.0
 drf-amsterdam == 0.3.2
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0
 psycopg2-binary == 2.8.4
-python-string-utils == 0.6.0
+python-string-utils == 1.0.0
 readerwriterlock == 1.0.6
 orjson == 2.5.1
 requests == 2.23.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.6.0  # via -r requirements.in
+amsterdam-schema-tools[django]==0.7.0  # via -r requirements.in
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via jsonschema, pytest
 cachetools==4.0.0         # via -r requirements.in
@@ -17,7 +17,7 @@ cryptography==2.8         # via jwcrypto
 datapunt-authorization-django==1.0.0  # via -r requirements.in
 defusedxml==0.6.0         # via django-gisserver, djangorestframework-xml
 django-cors-headers==3.2.1  # via -r requirements.in
-django-environ==0.4.5     # via -r requirements.in
+django-environ==0.4.5     # via -r requirements.in, amsterdam-schema-tools
 django-filter==2.2.0      # via -r requirements.in
 django-gisserver==0.6     # via -r requirements.in, amsterdam-schema-tools
 django-healthchecks==1.4.2  # via -r requirements.in

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -64,7 +64,7 @@ pytest-cov==2.8.1         # via -r requirements.in
 pytest-django==3.8.0      # via -r requirements.in
 pytest==5.3.5             # via -r requirements.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via amsterdam-schema-tools
-python-string-utils==0.6.0  # via -r requirements.in, amsterdam-schema-tools
+python-string-utils==1.0.0  # via -r requirements.in, amsterdam-schema-tools
 pytz==2019.3              # via django
 pyyaml==5.3               # via drf-spectacular
 readerwriterlock==1.0.6   # via -r requirements.in


### PR DESCRIPTION
The api of slugify has changed, kwarg "sign" -> "separator"
So schematools 0.7.0 is needed, because that version has the same
new dependency