### PR TITLE
[DS-281] Multiple trailing slashes not supported

### DIFF
--- a/src/dso_api/urls.py
+++ b/src/dso_api/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path("v1/", include(dso_api.dynamic_api.urls)),
     path("v1/openapi.yaml", get_openapi_yaml_view(), name="openapi.yaml",),
     path("", RedirectView.as_view(url="/v1/"), name="root-redirect"),
-    re_path(r"^.*/{2,}.*", multiple_slashes, name="error-trailing-slashes",),
+    re_path(r"^.*/{2,}.*$", multiple_slashes, name="error-trailing-slashes",),
 ]
 
 handler400 = exceptions.bad_request

--- a/src/dso_api/urls.py
+++ b/src/dso_api/urls.py
@@ -6,14 +6,14 @@ from rest_framework import exceptions
 
 import dso_api.dynamic_api.urls
 from dso_api.dynamic_api.oas3 import get_openapi_yaml_view
-from rest_framework_dso.views import multiple_trailing_slashes
+from rest_framework_dso.views import multiple_slashes
 
 urlpatterns = [
     path("status/health/", include(django_healthchecks.urls)),
     path("v1/", include(dso_api.dynamic_api.urls)),
     path("v1/openapi.yaml", get_openapi_yaml_view(), name="openapi.yaml",),
     path("", RedirectView.as_view(url="/v1/"), name="root-redirect"),
-    re_path(r"^.*/{2,}.*", multiple_trailing_slashes, name="error-trailing-slashes",),
+    re_path(r"^.*/{2,}.*", multiple_slashes, name="error-trailing-slashes",),
 ]
 
 handler400 = exceptions.bad_request

--- a/src/dso_api/urls.py
+++ b/src/dso_api/urls.py
@@ -13,11 +13,7 @@ urlpatterns = [
     path("v1/", include(dso_api.dynamic_api.urls)),
     path("v1/openapi.yaml", get_openapi_yaml_view(), name="openapi.yaml",),
     path("", RedirectView.as_view(url="/v1/"), name="root-redirect"),
-    re_path(
-        r"^v1/[A-Z,a-z,0-9]+/[A-Z,a-z,0-9]+/{2,}$",
-        multiple_trailing_slashes,
-        name="error-trailing-slashes",
-    ),
+    re_path(r"^.*/{2,}.*", multiple_trailing_slashes, name="error-trailing-slashes",),
 ]
 
 handler400 = exceptions.bad_request

--- a/src/dso_api/urls.py
+++ b/src/dso_api/urls.py
@@ -1,17 +1,23 @@
 import django_healthchecks.urls
 from django.conf import settings
-from django.urls import include, path
+from django.urls import include, path, re_path
 from django.views.generic import RedirectView
 from rest_framework import exceptions
 
 import dso_api.dynamic_api.urls
 from dso_api.dynamic_api.oas3 import get_openapi_yaml_view
+from rest_framework_dso.views import multiple_trailing_slashes
 
 urlpatterns = [
     path("status/health/", include(django_healthchecks.urls)),
     path("v1/", include(dso_api.dynamic_api.urls)),
     path("v1/openapi.yaml", get_openapi_yaml_view(), name="openapi.yaml",),
     path("", RedirectView.as_view(url="/v1/"), name="root-redirect"),
+    re_path(
+        r"^v1/[A-Z,a-z,0-9]+/[A-Z,a-z,0-9]+/{2,}$",
+        multiple_trailing_slashes,
+        name="error-trailing-slashes",
+    ),
 ]
 
 handler400 = exceptions.bad_request

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -12,7 +12,7 @@ from rest_framework_dso import crs, filters, parsers
 from rest_framework_dso.exceptions import PreconditionFailed
 
 
-def multiple_trailing_slashes(request):
+def multiple_slashes(request):
     response_data = {}
     response_data = {
         "type": "error",

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -17,7 +17,7 @@ def multiple_trailing_slashes(request):
     response_data = {
         "type": "error",
         "code": "HTTP_404_NOT_FOUND",
-        "title": "Multiple trailing slashes not supported",
+        "title": "Multiple slashes not supported",
         "status": "404",
         "instance": request.path,
     }

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -1,3 +1,7 @@
+import json
+
+from django.http import HttpResponseNotFound
+
 from typing import Optional, Type, Union
 
 from dso_api.lib.exceptions import RemoteAPIException
@@ -6,6 +10,21 @@ from rest_framework.exceptions import ErrorDetail, NotAcceptable, ValidationErro
 from rest_framework.views import exception_handler as drf_exception_handler
 from rest_framework_dso import crs, filters, parsers
 from rest_framework_dso.exceptions import PreconditionFailed
+
+
+def multiple_trailing_slashes(request):
+    response_data = {}
+    response_data = {
+        "type": "error",
+        "code": "HTTP_404_NOT_FOUND",
+        "title": "Multiple trailing slashes not supported",
+        "status": "404",
+        "instance": request.path,
+    }
+
+    return HttpResponseNotFound(
+        json.dumps(response_data), content_type="application/json"
+    )
 
 
 def exception_handler(exc, context):


### PR DESCRIPTION
When multiple trailing slashes are added to the endpoint it raises a 404 error. This is replaced by a custom error message in JSON stating that multiple trailing slashes are not supported to guide the user to correct the error.

Resolves: DS-281