### PR TITLE
Make life easier, add `dataset` to every request.

### DIFF
--- a/src/dso_api/dynamic_api/middleware.py
+++ b/src/dso_api/dynamic_api/middleware.py
@@ -1,0 +1,23 @@
+class BaseMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+
+class DatasetMiddleware(BaseMiddleware):
+    """
+    Assign `dataset` to request, for easy access.
+    """
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        """
+        Make current dataset available across whole application.
+        """
+        if not hasattr(request, "dataset"):
+            try:
+                request.dataset = view_func.cls.model._dataset_schema
+            except AttributeError:
+                request.dataset = None
+        return None

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -65,6 +65,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authorization_django.authorization_middleware",
+    "dso_api.dynamic_api.middleware.DatasetMiddleware",
 ]
 
 if DEBUG:


### PR DESCRIPTION
Addition of `dataset` to every request will make filtering/limiting output based on Schema specification easier.

To  be used by both Historical API and Embeded relations.