### PR TITLE
Csv support

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -94,7 +94,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
                 request, dataset_id=view.dataset_id, table_id=view.table_id
             )
         else:
-            model = view.serializer_class.Meta.model
+            model = view.get_serializer_class().Meta.model
             return self._has_permission(request, model=model)
 
     def has_object_permission(self, request, view, obj):

--- a/src/dso_api/dynamic_api/urls.py
+++ b/src/dso_api/dynamic_api/urls.py
@@ -11,6 +11,7 @@ def get_patterns(router_urls):
     return [
         path("reload/", views.reload_patterns),
         path("wfs/<dataset_name>/", views.DatasetWFSView.as_view()),
+        path("csv/<dataset_name>/<table_name>/", views.DatasetCSVView.as_view()),
         path("", include(router_urls)),
     ]
 

--- a/src/dso_api/dynamic_api/views.py
+++ b/src/dso_api/dynamic_api/views.py
@@ -332,7 +332,7 @@ class DatasetCSVView(PandasView):
             raise Http404("Invalid dataset") from None
 
     #: Custom permission that checks amsterdam schema auth settings
-    # permission_classes = [permissions.HasOAuth2Scopes]
+    permission_classes = [permissions.HasOAuth2Scopes]
 
     def get_queryset(self):
         return self.model.objects.all()

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 0.7
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.8.5
+amsterdam-schema-tools[django] == 0.8.7
 datapunt-authorization-django==1.0.0
 drf-amsterdam == 0.3.2
 drf-spectacular == 0.8.5
@@ -16,6 +16,7 @@ jsonschema == 3.2.0
 psycopg2-binary == 2.8.4
 python-string-utils == 1.0.0
 readerwriterlock == 1.0.6
+rest-pandas == 1.1.0
 orjson == 2.5.1
 requests == 2.23.0
 sentry-sdk == 0.14.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.8.5  # via -r requirements.in
+amsterdam-schema-tools[django]==0.8.7  # via -r requirements.in
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via jsonschema, pytest
 cachetools==4.0.0         # via -r requirements.in
@@ -26,7 +26,7 @@ django==3.0.7             # via -r requirements.in, amsterdam-schema-tools, data
 djangorestframework-csv==2.1.0  # via drf-amsterdam
 djangorestframework-gis==0.15  # via -r requirements.in
 djangorestframework-xml==1.4.0  # via drf-amsterdam
-djangorestframework==3.11.0  # via -r requirements.in, djangorestframework-csv, djangorestframework-gis, drf-amsterdam, drf-extensions
+djangorestframework==3.11.0  # via -r requirements.in, djangorestframework-csv, djangorestframework-gis, drf-amsterdam, drf-extensions, rest-pandas
 drf-amsterdam==0.3.2      # via -r requirements.in
 drf-extensions==0.6.0     # via drf-amsterdam
 drf-spectacular==0.8.5    # via -r requirements.in
@@ -49,8 +49,10 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
 ndjson==0.3.1             # via amsterdam-schema-tools
+numpy==1.18.5             # via pandas
 orjson==2.5.1             # via -r requirements.in, django-gisserver
 packaging==20.1           # via pytest
+pandas==1.0.5             # via rest-pandas
 pluggy==0.13.1            # via pytest
 psycopg2-binary==2.8.4    # via -r requirements.in
 psycopg2==2.8.5           # via amsterdam-schema-tools
@@ -63,12 +65,13 @@ pyrsistent==0.15.7        # via jsonschema
 pytest-cov==2.8.1         # via -r requirements.in
 pytest-django==3.8.0      # via -r requirements.in
 pytest==5.3.5             # via -r requirements.in, pytest-cov, pytest-django
-python-dateutil==2.8.1    # via amsterdam-schema-tools
+python-dateutil==2.8.1    # via amsterdam-schema-tools, pandas
 python-string-utils==1.0.0  # via -r requirements.in, amsterdam-schema-tools
-pytz==2019.3              # via django
+pytz==2019.3              # via django, pandas
 pyyaml==5.3               # via drf-spectacular
 readerwriterlock==1.0.6   # via -r requirements.in
 requests==2.23.0          # via -r requirements.in, amsterdam-schema-tools, datapunt-authorization-django, django-healthchecks
+rest-pandas==1.1.0        # via -r requirements.in
 sentry-sdk==0.14.2        # via -r requirements.in
 shapely==1.7.0            # via amsterdam-schema-tools
 six==1.14.0               # via cryptography, django-healthchecks, djangorestframework-csv, jsonschema, packaging, pyrsistent, python-dateutil


### PR DESCRIPTION
Very minimal csv download implementation.

Uses rest-pandas. Added view to download the full dataset as csv. 
Is still incomplete, no filtering. Permissions are enable, needs testing.
Some dirty hack needed to silence  drf_spectacular (openapi)
