### PR TITLE
Make is possible to choose a name for backwards relations.

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -194,11 +194,10 @@ def generate_field_serializer(  # noqa: C901
         if (
             depth <= 1
             and relation
-            and relation["table"]
-            == toCamelCase(model_field.related_model._meta.model_name)
             and relation["field"] == toCamelCase(model_field.field.name)
         ):
             depth += 1
+            name = relation.get("name", camel_name)
             format = relation.get("format", "summary")
             att_name = model_field.name + "_set"
             if format == "embedded":
@@ -206,16 +205,16 @@ def generate_field_serializer(  # noqa: C901
                     to_snake_case(model._table_schema.dataset.id),
                     to_snake_case(model_field.related_model._table_schema.id),
                 )
-                new_attrs[camel_name] = TemporalHyperlinkedRelatedField(
+                new_attrs[name] = TemporalHyperlinkedRelatedField(
                     many=True,
                     view_name=view_name,
                     queryset=getattr(model, att_name),
                     source=att_name,
                 )
-                fields.append(camel_name)
+                fields.append(name)
             elif format == "summary":
-                new_attrs[camel_name] = _RelatedSummaryField(source=att_name)
-                fields.append(camel_name)
+                new_attrs[name] = _RelatedSummaryField(source=att_name)
+                fields.append(name)
 
         return
     if model.has_parent_table() and model_field.name in ["id", "parent"]:

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 0.8
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.8.11
+amsterdam-schema-tools[django] == 0.8.13
 datapunt-authorization-django==1.0.0
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.8.11  # via -r requirements.in
+amsterdam-schema-tools[django]==0.8.13  # via -r requirements.in
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via jsonschema, pytest
 cachetools==4.0.0         # via -r requirements.in

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -78,7 +78,12 @@ def router():
 
 @pytest.fixture()
 def filled_router(
-    router, afval_dataset, bommen_dataset, parkeervakken_dataset, bagh_dataset
+    router,
+    afval_dataset,
+    bommen_dataset,
+    parkeervakken_dataset,
+    bagh_dataset,
+    vestiging_dataset,
 ):
     # Prove that the router URLs are extended on adding a model
     router.reload()
@@ -95,6 +100,8 @@ def filled_router(
         create_tables(parkeervakken_dataset.schema)
     if "bagh_buurt" not in table_names:
         create_tables(bagh_dataset.schema)
+    if "vestiging_vestiging" not in table_names:
+        create_tables(vestiging_dataset.schema)
 
     return router
 
@@ -331,6 +338,73 @@ def bagh_wijk(bagh_wijk_model, bagh_stadsdeel):
         naam="Sloterdijk",
         stadsdeel=bagh_stadsdeel,
     )
+
+
+@pytest.fixture()
+def vestiging_schema_json() -> dict():
+    path = HERE / "files/vestiging.json"
+    return json.loads(path.read_text())
+
+
+@pytest.fixture()
+def vestiging_schema(vestiging_schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(vestiging_schema_json)
+
+
+@pytest.fixture()
+def vestiging_adres_model(vestiging_models):
+    return vestiging_models["adres"]
+
+
+@pytest.fixture()
+def vestiging_vestiging_model(vestiging_models):
+    return vestiging_models["vestiging"]
+
+
+@pytest.fixture()
+def bezoek_adres1(vestiging_adres_model):
+    return vestiging_adres_model.objects.create(
+        id=1, plaats="Amsterdam", straat="Strawinskylaan", nummer=123, postcode="1234AB"
+    )
+
+
+@pytest.fixture()
+def bezoek_adres2(vestiging_adres_model):
+    return vestiging_adres_model.objects.create(
+        id=2, plaats="Amsterdam", straat="Singel", nummer=321, postcode="1011ZZ"
+    )
+
+
+@pytest.fixture()
+def post_adres1(vestiging_adres_model):
+    return vestiging_adres_model.objects.create(
+        id=3, plaats="Amsterdam", straat="Dam", nummer=1, postcode="1000AA"
+    )
+
+
+@pytest.fixture()
+def vestiging1(vestiging_vestiging_model, bezoek_adres1, post_adres1):
+    return vestiging_vestiging_model.objects.create(
+        id=1, naam="Snake Oil", bezoek_adres=bezoek_adres1, post_adres=post_adres1
+    )
+
+
+@pytest.fixture()
+def vestiging2(vestiging_vestiging_model, bezoek_adres2, post_adres1):
+    return vestiging_vestiging_model.objects.create(
+        id=2, naam="Haarlemmer olie", bezoek_adres=bezoek_adres2, post_adres=post_adres1
+    )
+
+
+@pytest.fixture()
+def vestiging_dataset(vestiging_schema_json) -> Dataset:
+    return Dataset.objects.create(name="vestiging", schema_data=vestiging_schema_json)
+
+
+@pytest.fixture()
+def vestiging_models(filled_router):
+    # Using filled_router so all urls can be generated too.
+    return filled_router.all_models["vestiging"]
 
 
 @pytest.fixture

--- a/src/tests/files/bagh.json
+++ b/src/tests/files/bagh.json
@@ -158,8 +158,8 @@
         ],
         "display": "id",
         "additionalRelations": {
-          "stadsdeel": {
-            "name": "stadsdelen",
+          "stadsdelen": {
+            "table": "stadsdeel",
             "field": "gemeente",
             "format": "embedded"
           }
@@ -668,8 +668,8 @@
         ],
         "display": "id",
         "additionalRelations": {
-          "buurt": {
-            "name": "buurten",
+          "buurten": {
+            "table": "buurt",
             "field": "stadsdeel",
             "format": "summary"
           }

--- a/src/tests/files/bagh.json
+++ b/src/tests/files/bagh.json
@@ -131,9 +131,9 @@
             "type": "string",
             "relation": "bagh:wijk"
           },
-          "ggw gebied": {
+          "ggwGebied": {
             "type": "string",
-            "relation": "bagh:ggw_gebied"
+            "relation": "bagh:ggwGebied"
           },
           "stadsdeel": {
             "type": "string",
@@ -159,7 +159,7 @@
         "display": "id",
         "additionalRelations": {
           "stadsdeel": {
-            "table": "stadsdeel",
+            "name": "stadsdelen",
             "field": "gemeente",
             "format": "embedded"
           }
@@ -199,7 +199,7 @@
       }
     },
     {
-      "id": "ggw_gebied",
+      "id": "ggwGebied",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -264,7 +264,7 @@
       }
     },
     {
-      "id": "ggw_praktijkgebied",
+      "id": "ggwPraktijkgebied",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -463,9 +463,9 @@
           "postcode": {
             "type": "string"
           },
-          "openbare ruimte": {
+          "openbareRuimte": {
             "type": "string",
-            "relation": "bagh:openbare_ruimte"
+            "relation": "bagh:openbareRuimte"
           },
           "ligplaats": {
             "type": "string",
@@ -489,7 +489,7 @@
       }
     },
     {
-      "id": "openbare_ruimte",
+      "id": "openbareRuimte",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -669,7 +669,7 @@
         "display": "id",
         "additionalRelations": {
           "buurt": {
-            "table": "buurt",
+            "name": "buurten",
             "field": "stadsdeel",
             "format": "summary"
           }
@@ -1024,9 +1024,9 @@
           "geometrie": {
             "$ref": "https://geojson.org/schema/MultiPolygon.json"
           },
-          "ggw gebied": {
+          "ggwGebied": {
             "type": "string",
-            "relation": "bagh:ggw_gebied"
+            "relation": "bagh:ggwGebied"
           },
           "stadsdeel": {
             "type": "string",

--- a/src/tests/files/vestiging.json
+++ b/src/tests/files/vestiging.json
@@ -1,0 +1,94 @@
+{
+  "type": "dataset",
+  "id": "vestiging",
+  "title": "vestiging",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "adres",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "id",
+          "plaats",
+          "straat",
+          "nummer",
+          "postcode"
+        ],
+        "display": "id",
+        "additionalRelations": {
+          "vestigingenBezoek": {
+            "table": "vestiging",
+            "field": "bezoekAdres",
+            "format": "embedded"
+          },
+          "vestigingenPost": {
+            "table": "vestiging",
+            "field": "postAdres",
+            "format": "embedded"
+          }
+        },
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "plaats": {
+            "type": "string"
+          },
+          "straat": {
+            "type": "string"
+          },
+          "nummer": {
+            "type": "integer"
+          },
+          "postcode": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "id": "vestiging",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "id",
+          "naam"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "naam": {
+            "type": "string"
+          },
+          "bezoekAdres": {
+            "type": "integer",
+            "relation": "vestiging:adres"
+          },
+          "postAdres": {
+            "type": "integer",
+            "relation": "vestiging:adres"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -230,7 +230,7 @@ class TestDynamicSerializer:
                 }
             },
             "schema": "https://schemas.data.amsterdam.nl/datasets/bagh/bagh#gemeente",
-            "stadsdeel": ["http://testserver/v1/bagh/stadsdeel/03630000000001_001/",],
+            "stadsdelen": ["http://testserver/v1/bagh/stadsdeel/03630000000001_001/",],
             "id": "0363_001",
             "naam": "Amsterdam",
             "volgnummer": 1,

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -242,6 +242,84 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
+    def test_multiple_backwards_relations(
+        api_request,
+        vestiging_schema,
+        vestiging_adres_model,
+        vestiging_vestiging_model,
+        vestiging1,
+        vestiging2,
+        post_adres1,
+    ):
+        """Show backwards
+
+        The _embedded part has a None value instead.
+        """
+        api_request.dataset = vestiging_schema
+        VestigingSerializer = serializer_factory(vestiging_vestiging_model, 0)
+        vestiging_serializer = VestigingSerializer(
+            vestiging1, context={"request": api_request},
+        )
+        assert vestiging_serializer.data == {
+            "_links": {
+                "self": {
+                    "href": "http://testserver/v1/vestiging/vestiging/1/",
+                    "title": "(no title: vestiging #1)",
+                }
+            },
+            "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",
+            "id": 1,
+            "naam": "Snake Oil",
+            "postAdresId": 3,
+            "postAdres": "http://testserver/v1/vestiging/adres/3/",
+            "bezoekAdresId": 1,
+            "bezoekAdres": "http://testserver/v1/vestiging/adres/1/",
+        }
+
+        vestiging_serializer = VestigingSerializer(
+            vestiging2, context={"request": api_request},
+        )
+        assert vestiging_serializer.data == {
+            "_links": {
+                "self": {
+                    "href": "http://testserver/v1/vestiging/vestiging/2/",
+                    "title": "(no title: vestiging #2)",
+                }
+            },
+            "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",
+            "id": 2,
+            "naam": "Haarlemmer olie",
+            "postAdresId": 3,
+            "postAdres": "http://testserver/v1/vestiging/adres/3/",
+            "bezoekAdresId": 2,
+            "bezoekAdres": "http://testserver/v1/vestiging/adres/2/",
+        }
+
+        AdresSerializer = serializer_factory(vestiging_adres_model, 0)
+        adres_serializer = AdresSerializer(
+            post_adres1, context={"request": api_request},
+        )
+        assert adres_serializer.data == {
+            "_links": {
+                "self": {
+                    "href": "http://testserver/v1/vestiging/adres/3/",
+                    "title": "(no title: adres #3)",
+                }
+            },
+            "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#adres",
+            "vestigingenBezoek": [],
+            "vestigingenPost": [
+                "http://testserver/v1/vestiging/vestiging/1/",
+                "http://testserver/v1/vestiging/vestiging/2/",
+            ],
+            "id": 3,
+            "nummer": 1,
+            "plaats": "Amsterdam",
+            "straat": "Dam",
+            "postcode": "1000AA",
+        }
+
+    @staticmethod
     def test_serializer_has_nested_table(
         api_request,
         parkeervakken_schema,


### PR DESCRIPTION
For example stadsdelen ipv stadsdeel

Also remove test for model name that is always equal