### PR TITLE
Postgres schemas

### DIFF
--- a/src/dso_api/dbrouters.py
+++ b/src/dso_api/dbrouters.py
@@ -1,17 +1,35 @@
-class ExternDatabaseRouter:
-    """
-    A router to control all database operations on models in the
-    apps that have data in other databases like bag
-    """
+from django.conf import settings
+from django.db import connections
 
-    route_app_labels = {"bag"}
+
+class DisableMigrationsRouter:
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        Do not allow migration for 'bag'
+        """
+        if app_label in settings.DATABASE_DISABLE_MIGRATIONS:
+            return False
+        return None
+
+
+class DatabaseSchemasRouter(DisableMigrationsRouter):
+    """
+    Database Router to allow use of PostgreSQL schemas.
+    """
 
     def db_for_read(self, model, **hints):
         """
         Attempts to read bag go to bag_v11.
         """
-        if model._meta.app_label in self.route_app_labels:
-            return "bag_v11"
+        if model._meta.app_label in settings.DATABASE_SCHEMAS:
+            schema_name = settings.DATABASE_SCHEMAS[model._meta.app_label]
+            if schema_name not in connections.databases:
+                new_connection = connections.databases["default"]
+                new_connection["OPTIONS"] = {
+                    "options": f"-c search_path={schema_name},public"
+                }
+                connections.databases[schema_name] = new_connection
+            return schema_name
         return None
 
     def db_for_write(self, model, **hints):
@@ -24,12 +42,4 @@ class ExternDatabaseRouter:
         """
         For now return None. Then relations are only allowed id they are in the same database.
         """
-        return None
-
-    def allow_migrate(self, db, app_label, model_name=None, **hints):
-        """
-        Do not allow migration for 'bag'
-        """
-        if app_label in self.route_app_labels:
-            return False
         return None

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -122,7 +122,7 @@ DATABASES = {
     ),
     "bag_v11": env.db_url(
         "BAG_V11_DATABASE_URL",
-        default="postgres://bag_v11_read:insecure@localhost:5434/bag_v11",
+        default="postgres://bag_v11:insecure@localhost:5434/bag_v11",
         engine="django.contrib.gis.db.backends.postgis",
     ),
 }

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -122,7 +122,7 @@ DATABASES = {
     ),
     "bag_v11": env.db_url(
         "BAG_V11_DATABASE_URL",
-        default="postgres://bag_v11:insecure@localhost:5434/bag_v11",
+        default="postgres://bag_v11_read:insecure@localhost:5434/bag_v11",
         engine="django.contrib.gis.db.backends.postgis",
     ),
 }

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -127,7 +127,12 @@ DATABASES = {
     ),
 }
 
-DATABASE_ROUTERS = ["dso_api.dbrouters.ExternDatabaseRouter"]
+DATABASE_SCHEMAS = {
+    "bag": "bag_v11",  # Important to have 'bag_v11' connection defined in DATABASES.
+}
+DATABASE_DISABLE_MIGRATIONS = ["bag"]
+
+DATABASE_ROUTERS = ["dso_api.dbrouters.DatabaseSchemasRouter"]
 
 locals().update(env.email_url(default="smtp://"))
 

--- a/src/tests/test_database_schemas_router.py
+++ b/src/tests/test_database_schemas_router.py
@@ -1,0 +1,51 @@
+import pytest
+from django.conf import settings
+from django.db import connections
+
+from dso_api.dbrouters import DatabaseSchemasRouter
+
+
+@pytest.mark.django_db
+class TestDatabaseSchemasRotuer:
+    def test_db_for_read_returns_none_by_default(self, bagh_schema, bagh_models):
+        db_router = DatabaseSchemasRouter()
+        assert db_router.db_for_read(bagh_models["buurt"]) is None
+
+    def test_db_for_read_returns_schema_name_if_set(self, bagh_schema, bagh_models):
+        default_settings = settings.DATABASE_SCHEMAS
+        settings.DATABASE_SCHEMAS["bagh"] = "test"
+        db_router = DatabaseSchemasRouter()
+
+        assert db_router.db_for_read(bagh_models["buurt"]) == "test"
+
+        settings.DATABASE_SCHEMAS = default_settings
+
+    def test_db_for_read_creates_new_connection_if_set(self, bagh_schema, bagh_models):
+        default_settings = settings.DATABASE_SCHEMAS
+        settings.DATABASE_SCHEMAS["bagh"] = "test"
+        db_router = DatabaseSchemasRouter()
+
+        db_router.db_for_read(bagh_models["buurt"])
+        assert "test" in connections.databases
+        assert (
+            connections.databases["test"]["OPTIONS"]["options"]
+            == "-c search_path=test,public"
+        )
+
+        settings.DATABASE_SCHEMAS = default_settings
+
+
+@pytest.mark.django_db
+class TestDisableMigrationsRouter:
+    def test_allow_migrate_returns_none_by_default(self, bagh_schema, bagh_models):
+        db_router = DatabaseSchemasRouter()
+        assert db_router.allow_migrate(None, "bagh", "buurt") is None
+
+    def test_allow_migrate_returns_false_if_set(self, bagh_schema, bagh_models):
+        default_settings = settings.DATABASE_DISABLE_MIGRATIONS
+        settings.DATABASE_DISABLE_MIGRATIONS = ["bagh"]
+        db_router = DatabaseSchemasRouter()
+
+        assert db_router.allow_migrate(None, "bagh", "buurt") is False
+
+        settings.DATABASE_DISABLE_MIGRATIONS = default_settings

--- a/src/tests/test_database_schemas_router.py
+++ b/src/tests/test_database_schemas_router.py
@@ -1,7 +1,6 @@
 import pytest
 from django.conf import settings
 from django.db import connections
-
 from dso_api.dbrouters import DatabaseSchemasRouter
 
 
@@ -12,7 +11,7 @@ class TestDatabaseSchemasRotuer:
         assert db_router.db_for_read(bagh_models["buurt"]) is None
 
     def test_db_for_read_returns_schema_name_if_set(self, bagh_schema, bagh_models):
-        default_settings = settings.DATABASE_SCHEMAS
+        default_settings = settings.DATABASE_SCHEMAS.copy()
         settings.DATABASE_SCHEMAS["bagh"] = "test"
         db_router = DatabaseSchemasRouter()
 
@@ -21,7 +20,7 @@ class TestDatabaseSchemasRotuer:
         settings.DATABASE_SCHEMAS = default_settings
 
     def test_db_for_read_creates_new_connection_if_set(self, bagh_schema, bagh_models):
-        default_settings = settings.DATABASE_SCHEMAS
+        default_settings = settings.DATABASE_SCHEMAS.copy()
         settings.DATABASE_SCHEMAS["bagh"] = "test"
         db_router = DatabaseSchemasRouter()
 
@@ -42,7 +41,7 @@ class TestDisableMigrationsRouter:
         assert db_router.allow_migrate(None, "bagh", "buurt") is None
 
     def test_allow_migrate_returns_false_if_set(self, bagh_schema, bagh_models):
-        default_settings = settings.DATABASE_DISABLE_MIGRATIONS
+        default_settings = settings.DATABASE_DISABLE_MIGRATIONS.copy()
         settings.DATABASE_DISABLE_MIGRATIONS = ["bagh"]
         db_router = DatabaseSchemasRouter()
 


### PR DESCRIPTION
Use Postgresql Schemas for datasets.

Currently set up to use `settings.DATABASE_SCHEMAS` variable, so we do not have to store this sensitive data in amsterdam-schema.

Expands across multiple postgres schemas/datasets work fine.