### PR TITLE
Fixing error with embedding non-existing relations.

### DIFF
--- a/src/rest_framework_dso/utils.py
+++ b/src/rest_framework_dso/utils.py
@@ -101,6 +101,7 @@ class EmbeddedHelper:
             _embedded[name] = [
                 embedded_serializer.to_representation(data[id])
                 for id in ids_per_relation[name]
+                if id in data
             ]
 
         return _embedded


### PR DESCRIPTION
API would crash into `KeyError` if relation is not found (`BAG` relations inside `meetbouten` as example).