### PR TITLE
Use two different split chars

### DIFF
--- a/src/dso_api/dynamic_api/fields.py
+++ b/src/dso_api/dynamic_api/fields.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from rest_framework_dso.fields import LinksField
+from .utils import split_on_separator
 
 
 class TemporalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
@@ -14,7 +15,7 @@ class TemporalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
 
         if request.versioned:
             # note that `obj` has only PK field.
-            lookup_value, version = obj.pk.split("_")
+            lookup_value, version = split_on_separator(obj.pk)
             kwargs = {self.lookup_field: lookup_value}
 
             base_url = self.reverse(
@@ -46,7 +47,7 @@ class TemporalReadOnlyField(serializers.ReadOnlyField):
             "request" in self.parent.context
             and self.parent.context["request"].versioned
         ):
-            value = value.split("_")[0]
+            value = split_on_separator(value)[0]
         return value
 
 

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -2,6 +2,8 @@ import re
 
 RE_CAMELIZE = re.compile(r"[a-z0-9]_[a-z0-9]")
 
+PK_SPLIT = re.compile("[_.]")
+
 
 def _underscore_to_camel(match):
     chars = match.group()  # take complete match, it's only 3 chars
@@ -17,3 +19,8 @@ def snake_to_camel_case(key: str) -> str:
     various other places that would otherwise response to snake_case input.
     """
     return re.sub(RE_CAMELIZE, _underscore_to_camel, key)
+
+
+def split_on_separator(instr):
+    # reversal is king
+    return [part[::-1] for part in PK_SPLIT.split(instr[::-1], 1)][::-1]

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 0.9.1
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.9.3
+amsterdam-schema-tools[django] == 0.9.4
 datapunt-authorization-django==1.0.0
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0

--- a/src/tests/test_dynamic_api/test_fields.py
+++ b/src/tests/test_dynamic_api/test_fields.py
@@ -1,0 +1,16 @@
+import pytest
+from dso_api.dynamic_api.utils import split_on_separator
+
+
+@pytest.mark.parametrize(
+    "instr,result",
+    [
+        ("aa_bb", ["aa", "bb"]),
+        ("aa.bb", ["aa", "bb"]),
+        ("aa.bb.cc", ["aa.bb", "cc"]),
+        ("aa_bb.cc", ["aa_bb", "cc"]),
+        ("aa.bb_cc", ["aa.bb", "cc"]),
+    ],
+)
+def test_split(instr, result):
+    assert split_on_separator(instr) == result


### PR DESCRIPTION
GOB uses ".", we already introduced "_" in bagh dataset.
Should be merged into one approach in the future.