### PR TITLE
Add loose relation field and make it work for expand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ ENV/
 # Testdata
 /data
 
+# Local experiments
+/scratch
+
 # Docs
 /docs/source/datasets/
 /docs/source/wfs-datasets/

--- a/src/dso_api/dynamic_api/app_config.py
+++ b/src/dso_api/dynamic_api/app_config.py
@@ -29,6 +29,8 @@ class VirtualAppConfig(apps_config.AppConfig):
         except TypeError as e:
             logger.warning(f"Failed to disable migrations for {self.label}: {e}")
 
+        self.ready()
+
     def _path_from_module(self, module):
         """
         Disable OS loading for this App Config.
@@ -41,6 +43,15 @@ class VirtualAppConfig(apps_config.AppConfig):
         """
         self.apps.register_model(self.label, model)
         self.models = self.apps.all_models[self.label]
+
+
+def add_custom_serializers():
+    from rest_framework.serializers import ModelSerializer
+    from schematools.contrib.django.models import LooseRelationField
+    from dso_api.dynamic_api.fields import LooseRelationUrlField
+
+    field_mapping = ModelSerializer.serializer_field_mapping
+    field_mapping.update({LooseRelationField: LooseRelationUrlField},)
 
 
 def register_model(dataset, model):

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -12,7 +12,7 @@ from rest_framework import routers
 from schematools.contrib.django.models import Dataset
 from schematools.utils import to_snake_case
 
-from dso_api.dynamic_api.app_config import register_model
+from dso_api.dynamic_api.app_config import register_model, add_custom_serializers
 from dso_api.dynamic_api.locking import lock_for_writing
 from dso_api.dynamic_api.oas3 import get_openapi_json_view
 from dso_api.dynamic_api.remote import remote_serializer_factory, remote_viewset_factory
@@ -76,6 +76,7 @@ class DynamicRouter(routers.DefaultRouter):
         tmp_router = routers.SimpleRouter()
         generated_models = []
 
+        add_custom_serializers()
         datasets = {}
         for dataset in Dataset.objects.db_enabled():  # type: Dataset
             dataset_id = dataset.schema.id  # not dataset.name!

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -59,6 +59,11 @@ class AbstractEmbeddedField:
         """Return the Django model class"""
         return self.serializer_class.Meta.model
 
+    @cached_property
+    def parent_model(self) -> Type[models.Model]:
+        """Return the Django model class"""
+        return self.parent_serializer.Meta.model
+
 
 class EmbeddedField(AbstractEmbeddedField):
     """An embedded field for a foreign-key relation."""
@@ -78,7 +83,7 @@ class EmbeddedField(AbstractEmbeddedField):
         field_name = self.source or self.field_name
         try:
             # For ForeignKey/OneToOneField this resolves to "{field_name}_id"
-            return self.related_model._meta.get_field(field_name).attname
+            return self.parent_model._meta.get_field(field_name).attname
         except models.FieldDoesNotExist:
             # Allow non-FK relations, e.g. a "bag_id" to a completely different database
             if not field_name.endswith("_id"):

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -260,6 +260,9 @@ class DSOModelListSerializer(DSOListSerializer):
     https://tools.ietf.org/html/draft-kelly-json-hal-08
     """
 
+    # Fetcher function to be overridden by subclasses if needed
+    id_based_fetcher = None
+
     def get_embeds(self, instances: Iterable[models.Model], items: List[dict]) -> dict:
         """Generate the embed sections for this listing."""
         expand = self.get_fields_to_expand()
@@ -299,6 +302,9 @@ class DSOModelSerializer(DSOSerializer, serializers.HyperlinkedModelSerializer):
     # Make sure the _links bit is generated:
     url_field_name = "_links"
     serializer_url_field = LinksField
+
+    # Fetcher function to be overridden by subclasses if needed
+    id_based_fetcher = None
 
     def to_representation(self, instance):
         """Check whether the geofields need to be transformed."""

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -578,9 +578,7 @@ def explosieven_schema_json() -> dict:
 
 
 @pytest.fixture()
-def explosieven_schema(
-    explosieven_schema_json,
-) -> DatasetSchema:
+def explosieven_schema(explosieven_schema_json,) -> DatasetSchema:
     return DatasetSchema.from_dict(explosieven_schema_json)
 
 
@@ -645,12 +643,14 @@ def download_url_dataset(download_url_schema_json) -> Dataset:
     )
 
 
+@pytest.fixture()
 def meldingen_schema_json() -> dict:
     """ Fixture to return the schema json """
     path = HERE / "files/meldingen.json"
     return json.loads(path.read_text())
 
 
+@pytest.fixture()
 def meldingen_schema(meldingen_schema_json) -> DatasetSchema:
     return DatasetSchema.from_dict(meldingen_schema_json)
 
@@ -690,8 +690,7 @@ def buurten_model(filled_router):
 @pytest.fixture()
 def statistieken_data(statistieken_model):
     statistieken_model.objects.create(
-        id=1,
-        buurt="03630000000078",
+        id=1, buurt="03630000000078",
     )
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -18,7 +18,11 @@ from schematools.contrib.django.models import Dataset
 from schematools.contrib.django.db import create_tables
 from schematools.types import DatasetSchema
 from rest_framework_dso.crs import RD_NEW
-from tests.test_rest_framework_dso.models import Category, Movie, Location
+from tests.test_rest_framework_dso.models import (
+    Category,
+    Movie,
+    Location,
+)
 
 HERE = Path(__file__).parent
 
@@ -92,6 +96,8 @@ def filled_router(
     explosieven_dataset,
     indirect_self_ref_dataset,
     download_url_dataset,
+    meldingen_dataset,
+    gebieden_dataset,
 ):
     # Prove that the router URLs are extended on adding a model
     router.reload()
@@ -112,6 +118,8 @@ def filled_router(
         explosieven_dataset: "explosieven_verdachtgebied",
         indirect_self_ref_dataset: "selfref_selfref",
         download_url_dataset: "download_url",
+        meldingen_dataset: "meldingen_statistieken",
+        gebieden_dataset: "gebieden_buurten",
     }
 
     # Based on datasets, create test table if not exists
@@ -570,7 +578,9 @@ def explosieven_schema_json() -> dict:
 
 
 @pytest.fixture()
-def explosieven_schema(explosieven_schema_json,) -> DatasetSchema:
+def explosieven_schema(
+    explosieven_schema_json,
+) -> DatasetSchema:
     return DatasetSchema.from_dict(explosieven_schema_json)
 
 
@@ -633,3 +643,59 @@ def download_url_dataset(download_url_schema_json) -> Dataset:
     return Dataset.objects.create(
         name="download_url", schema_data=download_url_schema_json
     )
+
+
+def meldingen_schema_json() -> dict:
+    """ Fixture to return the schema json """
+    path = HERE / "files/meldingen.json"
+    return json.loads(path.read_text())
+
+
+def meldingen_schema(meldingen_schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(meldingen_schema_json)
+
+
+@pytest.fixture()
+def meldingen_dataset(meldingen_schema_json) -> Dataset:
+    return Dataset.objects.create(name="meldingen", schema_data=meldingen_schema_json)
+
+
+@pytest.fixture()
+def gebieden_schema_json() -> dict:
+    """ Fixture to return the schema json """
+    path = HERE / "files/gebieden.json"
+    return json.loads(path.read_text())
+
+
+@pytest.fixture()
+def gebieden_schema(gebieden_schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(gebieden_schema_json)
+
+
+@pytest.fixture()
+def gebieden_dataset(gebieden_schema_json) -> Dataset:
+    return Dataset.objects.create(name="gebieden", schema_data=gebieden_schema_json)
+
+
+@pytest.fixture()
+def statistieken_model(filled_router):
+    return filled_router.all_models["meldingen"]["statistieken"]
+
+
+@pytest.fixture()
+def buurten_model(filled_router):
+    return filled_router.all_models["gebieden"]["buurten"]
+
+
+@pytest.fixture()
+def statistieken_data(statistieken_model):
+    statistieken_model.objects.create(
+        id=1,
+        buurt="03630000000078",
+    )
+
+
+@pytest.fixture()
+def buurten_data(buurten_model):
+    buurten_model.objects.create(id=1, identificatie="03630000000078", volgnummer=1)
+    buurten_model.objects.create(id=2, identificatie="03630000000078", volgnummer=2)

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -1,0 +1,58 @@
+{
+  "type": "dataset",
+  "id": "gebieden",
+  "title": "gebieden",
+  "status": "beschikbaar",
+  "version": "0.0.1",
+  "identifier": "identificatie",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+    }
+  },
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "buurten",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "mainGeometry": "geometrie",
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Geometry.json",
+            "description": "Geometrische beschrijving van een object."
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/files/meldingen.json
+++ b/src/tests/files/meldingen.json
@@ -1,0 +1,37 @@
+{
+  "type": "dataset",
+  "id": "meldingen",
+  "title": "Meldingen",
+  "status": "beschikbaar",
+  "description": "SIA (Signalen Informatievoorziening Amsterdam) meldingen",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "statistieken",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema", "id"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "type": "integer",
+            "description": "Unieke aanduiding van de melding."
+          },
+          "buurt": {
+            "type": "string",
+            "relation": "gebieden:buurten:identificatie",
+            "description": "Buurt identificatie waaronder de melding valt."
+          }
+        }
+      }
+    }
+  ]
+}
+

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -684,7 +684,7 @@ class TestDynamicSerializer:
         assert "sr=b" in dossiers_serializer.data["dossiers"][0]["url"]
         assert "sp=r" in dossiers_serializer.data["dossiers"][0]["url"]
 
-
+    @staticmethod
     def test_loose_relation_serialization(
         api_request, meldingen_schema, statistieken_model,
     ):

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -147,8 +147,7 @@ class TestDynamicSerializer:
         api_request.dataset = afval_schema
         ContainerSerializer = serializer_factory(afval_container_model, 0)
         container_without_cluster = afval_container_model.objects.create(
-            id=3,
-            cluster=None,
+            id=3, cluster=None,
         )
         container_serializer = ContainerSerializer(
             container_without_cluster,
@@ -184,8 +183,7 @@ class TestDynamicSerializer:
         api_request.dataset = afval_schema
         ContainerSerializer = serializer_factory(afval_container_model, 0)
         container_invalid_cluster = afval_container_model.objects.create(
-            id=4,
-            cluster_id=99,
+            id=4, cluster_id=99,
         )
         container_serializer = ContainerSerializer(
             container_invalid_cluster,
@@ -228,8 +226,7 @@ class TestDynamicSerializer:
         api_request.dataset_temporal_slice = None
         GemeenteSerializer = serializer_factory(bagh_gemeente_model, 0)
         gemeente_serializer = GemeenteSerializer(
-            bagh_gemeente,
-            context={"request": api_request},
+            bagh_gemeente, context={"request": api_request},
         )
         assert gemeente_serializer.data == {
             "_links": {
@@ -271,8 +268,7 @@ class TestDynamicSerializer:
         VestigingSerializer = serializer_factory(vestiging_vestiging_model, 0)
 
         vestiging_serializer = VestigingSerializer(
-            vestiging1,
-            context={"request": api_request},
+            vestiging1, context={"request": api_request},
         )
 
         assert vestiging_serializer.data == {
@@ -292,8 +288,7 @@ class TestDynamicSerializer:
         }
 
         vestiging_serializer = VestigingSerializer(
-            vestiging2,
-            context={"request": api_request},
+            vestiging2, context={"request": api_request},
         )
         assert vestiging_serializer.data == {
             "_links": {
@@ -313,8 +308,7 @@ class TestDynamicSerializer:
 
         AdresSerializer = serializer_factory(vestiging_adres_model, 0)
         adres_serializer = AdresSerializer(
-            post_adres1,
-            context={"request": api_request},
+            post_adres1, context={"request": api_request},
         )
         assert adres_serializer.data == {
             "_links": {
@@ -483,10 +477,7 @@ class TestDynamicSerializer:
 
     @staticmethod
     def test_display_title_present(
-        api_request,
-        fietspaaltjes_schema,
-        fietspaaltjes_model,
-        fietspaaltjes_data,
+        api_request, fietspaaltjes_schema, fietspaaltjes_model, fietspaaltjes_data,
     ):
         """ Prove that title element shows display value if display field is specified """
 
@@ -589,44 +580,6 @@ class TestDynamicSerializer:
 
         # Validation passes if outcome is None
         assert validate_email(explosieven_serializer.data["emailadres"]) is None
-
-    @staticmethod
-    def test_email_field_can_validate(
-        api_request, explosieven_schema, explosieven_model, explosieven_data
-    ):
-        """ Prove that a EmailField can be validated by the EmailValidator """
-
-        ExplosievenSerializer = serializer_factory(explosieven_model, 0, flat=True)
-
-        api_request.dataset = explosieven_schema
-
-        validate_email = EmailValidator()
-
-        explosieven_serializer = ExplosievenSerializer(
-            explosieven_data, context={"request": api_request}
-        )
-
-        # Validation passes if outcome is None
-        assert validate_email(explosieven_serializer.data["emailadres"]) is None
-
-    @staticmethod
-    def test_uri_field_is_URL_encoded(
-        api_request, explosieven_schema, explosieven_model, explosieven_data
-    ):
-        """ Prove that a URLfield content is URL encoded i.e. space to %20 """
-
-        ExplosievenSerializer = serializer_factory(explosieven_model, 0, flat=True)
-
-        api_request.dataset = explosieven_schema
-
-        explosieven_serializer = ExplosievenSerializer(
-            explosieven_data, context={"request": api_request}
-        )
-
-        # Validation passes if a space does not exists (translated to %20)
-        assert " " not in str(explosieven_serializer.data["pdf"]) and "%20" in str(
-            explosieven_serializer.data["pdf"]
-        )
 
     @staticmethod
     def test_indirect_self_reference(
@@ -733,9 +686,7 @@ class TestDynamicSerializer:
 
 
     def test_loose_relation_serialization(
-        api_request,
-        meldingen_schema,
-        statistieken_model,
+        api_request, meldingen_schema, statistieken_model,
     ):
         """Prove that the serializer factory generates the right link
         for a loose relation field
@@ -746,10 +697,7 @@ class TestDynamicSerializer:
                 self.model = model
 
         api_request.dataset = meldingen_schema
-        statistiek = statistieken_model.objects.create(
-            id=1,
-            buurt="03630000000078",
-        )
+        statistiek = statistieken_model.objects.create(id=1, buurt="03630000000078",)
         StatistiekenSerializer = serializer_factory(statistieken_model, 0)
 
         statistieken_serializer = StatistiekenSerializer(

--- a/src/tests/test_dynamic_api/test_views.py
+++ b/src/tests/test_dynamic_api/test_views.py
@@ -134,8 +134,7 @@ class TestAuth:
     def test_auth_on_dataset_schema_protects_containers(
         self, api_client, filled_router, afval_schema
     ):
-        """ Prove that auth protection at dataset level leads to a 403 on the container listview.
-        """
+        """Prove that auth protection at dataset level leads to a 403 on the container listview."""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.get(url)
@@ -144,8 +143,7 @@ class TestAuth:
     def test_auth_on_dataset_schema_protects_cluster(
         self, api_client, filled_router, afval_schema
     ):
-        """ Prove that auth protection at dataset level leads to a 403 on the cluster listview.
-        """
+        """Prove that auth protection at dataset level leads to a 403 on the cluster listview."""
         url = reverse("dynamic_api:afvalwegingen-clusters-list")
         models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.get(url)
@@ -154,8 +152,8 @@ class TestAuth:
     def test_auth_on_table_schema_protects(
         self, api_client, filled_router, afval_schema
     ):
-        """ Prove that auth protection at table level (container) leads to a 403 on the container listview.
-        """
+        """Prove that auth protection at table level (container)
+        leads to a 403 on the container listview."""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
         response = api_client.get(url)
@@ -164,8 +162,8 @@ class TestAuth:
     def test_auth_on_table_schema_does_not_protect_sibling_tables(
         self, api_client, filled_router, afval_schema, fetch_auth_token
     ):
-        """ Prove that auth protection at table level (cluster) does not protect the container list view.
-        """
+        """Prove that auth protection at table level (cluster)
+        does not protect the container list view."""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
         response = api_client.get(url)
@@ -174,8 +172,8 @@ class TestAuth:
     def test_auth_on_table_schema_with_token_for_valid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that auth protected table (container) can be viewed with a token with the correct scope.
-        """
+        """Prove that auth protected table (container) can be
+        viewed with a token with the correct scope."""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/R"])
@@ -185,8 +183,8 @@ class TestAuth:
     def test_auth_on_table_schema_with_token_for_invalid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token
     ):
-        """ Prove that auth protected table (container) cannot be
-            viewed with a token with an incorrect scope.
+        """Prove that auth protected table (container) cannot be
+        viewed with a token with an incorrect scope.
         """
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
@@ -197,8 +195,8 @@ class TestAuth:
     def test_auth_on_embedded_fields_with_token_for_valid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that expanded fields are shown when a reference field is protected
-            with an auth scope and there is a valid token """
+        """Prove that expanded fields are shown when a reference field is protected
+        with an auth scope and there is a valid token"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         url = f"{url}?_expand=true"
         models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
@@ -210,9 +208,9 @@ class TestAuth:
     def test_auth_on_embedded_fields_without_token_for_valid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that expanded fields are *not* shown when a reference field is protected
-            with an auth scope. For expand=true, we return a result,
-            without the fields that are protected """
+        """Prove that expanded fields are *not* shown when a reference field is protected
+        with an auth scope. For expand=true, we return a result,
+        without the fields that are protected"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         url = f"{url}?_expand=true"
         models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
@@ -223,8 +221,8 @@ class TestAuth:
     def test_auth_on_specified_embedded_fields_without_token_for_valid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that a 403 is returned when asked for a specific expanded field that is protected
-            and there is no authorization in the token for that field.
+        """Prove that a 403 is returned when asked for a specific expanded field that is protected
+        and there is no authorization in the token for that field.
         """
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         url = f"{url}?_expandScope=cluster"
@@ -235,8 +233,8 @@ class TestAuth:
     def test_auth_on_individual_fields_with_token_for_valid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that protected fields are shown
-            with an auth scope and there is a valid token """
+        """Prove that protected fields are shown
+        with an auth scope and there is a valid token"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.DatasetField.objects.filter(name="eigenaar_naam").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/R"])
@@ -252,8 +250,8 @@ class TestAuth:
     def test_auth_on_individual_fields_with_token_for_valid_scope_per_profile(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that protected fields are shown
-            with an auth scope connected to Profile that gives access to specific field."""
+        """Prove that protected fields are shown
+        with an auth scope connected to Profile that gives access to specific field."""
         models.Profile.objects.create(
             name="brk_readall",
             scopes="BRK/RSN",
@@ -280,8 +278,8 @@ class TestAuth:
     def test_auth_on_individual_fields_without_token_for_valid_scope(
         self, api_client, filled_router, afval_schema, fetch_auth_token, afval_container
     ):
-        """ Prove that protected fields are *not* shown
-            with an auth scope and there is not a valid token """
+        """Prove that protected fields are *not* shown
+        with an auth scope and there is not a valid token"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         models.DatasetField.objects.filter(name="eigenaar_naam").update(auth="BAG/R")
         response = api_client.get(url)
@@ -301,8 +299,7 @@ class TestAuth:
         parkeervakken_parkeervak_model,
         parkeervakken_regime_model,
     ):
-        """ Prove that Auth is not cached.
-        """
+        """Prove that Auth is not cached."""
         # Router reload is needed to make sure that viewsets are using relations.
         from dso_api.dynamic_api.urls import router
 
@@ -385,8 +382,7 @@ class TestAuth:
     def test_auth_options_requests_are_not_protected(
         self, api_client, filled_router, afval_schema
     ):
-        """ Prove that options requests are not protected
-        """
+        """Prove that options requests are not protected"""
         url = reverse("dynamic_api:afvalwegingen-clusters-list")
         models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.options(url)
@@ -395,8 +391,7 @@ class TestAuth:
     def test_sort_by_accepts_camel_case(
         self, api_client, filled_router, afval_schema, afval_container
     ):
-        """ Prove that _sort is accepting camelCase parameters.
-        """
+        """Prove that _sort is accepting camelCase parameters."""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         response = api_client.get(f"{url}?_sort=datumCreatie")
         assert response.status_code == 200, response.data
@@ -405,11 +400,51 @@ class TestAuth:
     def test_sort_by_not_accepting_db_column_names(
         self, api_client, filled_router, afval_schema, afval_container
     ):
-        """ Prove that _sort is not accepting db column names.
-        """
+        """Prove that _sort is not accepting db column names."""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         response = api_client.get(f"{url}?_sort=datum_creatie")
         assert response.status_code == 400, response.data
         assert response.data["x-validation-errors"] == [
             "Invalid sort fields: datum_creatie"
         ], response.data
+
+
+@pytest.mark.django_db
+class TestEmbedTemporalTables:
+    def test_detail_expand_true(
+        self,
+        api_client,
+        filled_router,
+        statistieken_model,
+        buurten_model,
+        statistieken_data,
+        buurten_data,
+    ):
+        """Prove that buurt shows up when expanded and uses the
+        latest volgnummer
+        """
+
+        url = reverse("dynamic_api:meldingen-statistieken-detail", args=[1])
+        url = f"{url}?_expand=true"
+        response = api_client.get(url)
+        assert response.status_code == 200, response.data
+        assert response.data["_embedded"]["buurt"]["id"] == "2"
+
+    def test_list_expand_true(
+        self,
+        api_client,
+        filled_router,
+        statistieken_model,
+        buurten_model,
+        statistieken_data,
+        buurten_data,
+    ):
+        """Prove that buurt shows up when listview is expanded and uses the
+        latest volgnummer
+        """
+
+        url = reverse("dynamic_api:meldingen-statistieken-list")
+        url = f"{url}?_expand=true"
+        response = api_client.get(url)
+        assert response.status_code == 200, response.data
+        assert response.data["_embedded"]["buurt"][0]["id"] == "2"

--- a/src/tests/test_rest_framework_dso/models.py
+++ b/src/tests/test_rest_framework_dso/models.py
@@ -4,14 +4,20 @@ from django.contrib.gis.db import models as gis_models
 from rest_framework_dso.crs import RD_NEW
 
 
-class Category(models.Model):
+class NonTemporalMixin:
+    @classmethod
+    def is_temporal(cls):
+        return False
+
+
+class Category(models.Model, NonTemporalMixin):
     name = models.CharField(max_length=100)
 
     class Meta:
         app_label = "test_rest_framework_dso"
 
 
-class Movie(models.Model):
+class Movie(models.Model, NonTemporalMixin):
     name = models.CharField(max_length=100)
     category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True)
     date_added = models.DateTimeField(null=True)
@@ -24,7 +30,7 @@ class Movie(models.Model):
         return self.name
 
 
-class Location(models.Model):
+class Location(models.Model, NonTemporalMixin):
     geometry = gis_models.PointField(srid=RD_NEW.srid)
 
     class Meta:


### PR DESCRIPTION
Er is een custom Django model-veld geintroduceerd (in schema-tools) dat een 'losse' relatie kan leggen naar een temporele dataset (alleen obv de 'identificatie'). In de DSO is een mapping naar een DRF-type veld gemaakt voor dit Django model veld.
Dit zorgt voor het construeren van de juiste urls.
Verder is geregeld dat dit type velden ook werkt bij gebruik in een 'expand' en dat evt. temporele hyperlinks binnen de 'expanded' objecten ook weer correct worden geconstrueerd. 