### PR TITLE
new version to be able to use schema permissions

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,38 +1,38 @@
-cachetools == 4.0.0
-Django == 3.0.7
+cachetools == 4.1.1
+Django == 3.0.11
 django-environ == 0.4.5
-django-cors-headers == 3.2.1
-django-filter == 2.2.0
+django-cors-headers == 3.5.0
+django-filter == 2.4.0
 django-healthchecks == 1.4.2
 django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 1.1.1
-djangorestframework == 3.11.0
-djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.14.5
+djangorestframework == 3.12.1
+djangorestframework-gis == 0.16
+amsterdam-schema-tools[django] == 0.15.0
 datapunt-authorization-django==1.0.0
-drf-spectacular == 0.8.5
+drf-spectacular == 0.10.0
 jsonschema == 3.2.0
-psycopg2-binary == 2.8.4
+psycopg2-binary == 2.8.6
 python-string-utils == 1.0.0
-readerwriterlock == 1.0.6
-orjson == 2.5.1
-requests == 2.23.0
-sentry-sdk == 0.14.2
-urllib3 == 1.25.8
+readerwriterlock == 1.0.7
+orjson == 3.4.3
+requests == 2.24.0
+sentry-sdk == 0.19.2
+urllib3 == 1.25.11
 urllib3-mock == 0.3.3
 
 # When installed, it's used for API doc markup:
-markdown == 3.2.1
+markdown == 3.3.3
 
 # Testing
-flake8 == 3.7.9
+flake8 == 3.8.4
 flake8-blind-except == 0.1.1
 flake8-colors == 0.1.6
 flake8-debugger == 3.2.1
 flake8-raise == 0.0.5
-pytest == 5.3.5
-pytest-django == 3.8.0
-pytest-cov == 2.8.1
-python-owasp-zap-v2.4 == 0.0.16
+pytest == 6.1.2
+pytest-django == 4.1.0
+pytest-cov == 2.10.1
+python-owasp-zap-v2.4 == 0.0.17
 
 azure-storage-blob == 12.5.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,87 +4,88 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.14.5  # via -r requirements.in
-asgiref==3.2.3            # via django
-attrs==19.3.0             # via jsonschema, pytest
+amsterdam-schema-tools[django]==0.15.0  # via -r requirements.in
+asgiref==3.3.0            # via django
+attrs==20.3.0             # via jsonschema, pg-grant, pytest
 azure-core==1.8.2         # via azure-storage-blob
 azure-storage-blob==12.5.0  # via -r requirements.in
-cachetools==4.0.0         # via -r requirements.in, amsterdam-schema-tools
-certifi==2019.11.28       # via msrest, requests, sentry-sdk
-cffi==1.14.0              # via cryptography
+cachetools==4.1.1         # via -r requirements.in, amsterdam-schema-tools
+certifi==2020.6.20        # via msrest, requests, sentry-sdk
+cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.1              # via amsterdam-schema-tools, mappyfile
-coverage==5.0.3           # via pytest-cov
-cryptography==3.2         # via azure-storage-blob, jwcrypto
+click==7.1.2              # via amsterdam-schema-tools, mappyfile
+coverage==5.3             # via pytest-cov
+cryptography==3.2.1       # via azure-storage-blob, jwcrypto
 datapunt-authorization-django==1.0.0  # via -r requirements.in
 decorator==4.4.2          # via jsonpath-rw
 defusedxml==0.6.0         # via django-gisserver
-django-cors-headers==3.2.1  # via -r requirements.in
+django-cors-headers==3.5.0  # via -r requirements.in
 django-environ==0.4.5     # via -r requirements.in, amsterdam-schema-tools
-django-filter==2.2.0      # via -r requirements.in
+django-filter==2.4.0      # via -r requirements.in
 django-gisserver==1.1.1   # via -r requirements.in, amsterdam-schema-tools
 django-healthchecks==1.4.2  # via -r requirements.in
 django-postgres-unlimited-varchar==1.1.0  # via -r requirements.in, amsterdam-schema-tools
-django==3.0.7             # via -r requirements.in, amsterdam-schema-tools, datapunt-authorization-django, django-cors-headers, django-filter, django-gisserver, django-healthchecks, django-postgres-unlimited-varchar, djangorestframework
-djangorestframework-gis==0.15  # via -r requirements.in
-djangorestframework==3.11.0  # via -r requirements.in, djangorestframework-gis
-drf-spectacular==0.8.5    # via -r requirements.in
-entrypoints==0.3          # via flake8
+django==3.0.11            # via -r requirements.in, amsterdam-schema-tools, datapunt-authorization-django, django-cors-headers, django-filter, django-gisserver, django-healthchecks, django-postgres-unlimited-varchar, djangorestframework, drf-spectacular
+djangorestframework-gis==0.16  # via -r requirements.in
+djangorestframework==3.12.1  # via -r requirements.in, djangorestframework-gis, drf-spectacular
+drf-spectacular==0.10.0   # via -r requirements.in
 flake8-blind-except==0.1.1  # via -r requirements.in
 flake8-colors==0.1.6      # via -r requirements.in
 flake8-debugger==3.2.1    # via -r requirements.in
 flake8-raise==0.0.5       # via -r requirements.in
-flake8==3.7.9             # via -r requirements.in, flake8-colors, flake8-debugger, flake8-raise
-geoalchemy2==0.7.0        # via amsterdam-schema-tools
-idna==2.9                 # via requests
+flake8==3.8.4             # via -r requirements.in, flake8-colors, flake8-debugger, flake8-raise
+geoalchemy2==0.8.4        # via amsterdam-schema-tools
+idna==2.10                # via requests
+inflection==0.5.1         # via drf-spectacular
+iniconfig==1.1.1          # via pytest
 isodate==0.6.0            # via msrest
 jinja2==2.11.2            # via amsterdam-schema-tools
 jsonpath-rw==1.4.0        # via amsterdam-schema-tools
 jsonref==0.2              # via mappyfile
-jsonschema==3.2.0         # via -r requirements.in, amsterdam-schema-tools, mappyfile
-jwcrypto==0.7             # via datapunt-authorization-django
-lark-parser==0.7.8        # via mappyfile
-mappyfile==0.8.4          # via amsterdam-schema-tools
-markdown==3.2.1           # via -r requirements.in
+jsonschema==3.2.0         # via -r requirements.in, amsterdam-schema-tools, drf-spectacular, mappyfile
+jwcrypto==0.8             # via datapunt-authorization-django
+lark-parser==0.9.0        # via mappyfile
+mappyfile==0.9.0          # via amsterdam-schema-tools
+markdown==3.3.3           # via -r requirements.in
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
 msrest==0.6.19            # via azure-storage-blob
 ndjson==0.3.1             # via amsterdam-schema-tools
 oauthlib==3.1.0           # via requests-oauthlib
-orjson==2.5.1             # via -r requirements.in, django-gisserver
-packaging==20.1           # via pytest
+orjson==3.4.3             # via -r requirements.in, django-gisserver
+packaging==20.4           # via pytest
+pg-grant==0.3.2           # via amsterdam-schema-tools
 pluggy==0.13.1            # via pytest
 ply==3.11                 # via jsonpath-rw
-psycopg2-binary==2.8.4    # via -r requirements.in
-psycopg2==2.8.5           # via amsterdam-schema-tools
-py==1.8.1                 # via pytest
-pycodestyle==2.5.0        # via flake8, flake8-debugger
-pycparser==2.19           # via cffi
-pyflakes==2.1.1           # via flake8
-pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.7        # via jsonschema
-pytest-cov==2.8.1         # via -r requirements.in
-pytest-django==3.8.0      # via -r requirements.in
-pytest==5.3.5             # via -r requirements.in, pytest-cov, pytest-django
+psycopg2-binary==2.8.6    # via -r requirements.in
+psycopg2==2.8.6           # via amsterdam-schema-tools
+py==1.9.0                 # via pytest
+pycodestyle==2.6.0        # via flake8, flake8-debugger
+pycparser==2.20           # via cffi
+pyflakes==2.2.0           # via flake8
+pyparsing==2.4.7          # via packaging
+pyrsistent==0.17.3        # via jsonschema
+pytest-cov==2.10.1        # via -r requirements.in
+pytest-django==4.1.0      # via -r requirements.in
+pytest==6.1.2             # via -r requirements.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via amsterdam-schema-tools
-python-owasp-zap-v2.4==0.0.16  # via -r requirements.in
+python-owasp-zap-v2.4==0.0.17  # via -r requirements.in
 python-string-utils==1.0.0  # via -r requirements.in, amsterdam-schema-tools
-pytz==2019.3              # via django
-pyyaml==5.3               # via drf-spectacular
-readerwriterlock==1.0.6   # via -r requirements.in
+pytz==2020.4              # via django
+pyyaml==5.3.1             # via drf-spectacular
+readerwriterlock==1.0.7   # via -r requirements.in
 requests-oauthlib==1.3.0  # via msrest
-requests==2.23.0          # via -r requirements.in, amsterdam-schema-tools, azure-core, datapunt-authorization-django, django-healthchecks, msrest, python-owasp-zap-v2.4, requests-oauthlib
-sentry-sdk==0.14.2        # via -r requirements.in
-shapely==1.7.0            # via amsterdam-schema-tools
-six==1.14.0               # via azure-core, cryptography, django-healthchecks, isodate, jsonpath-rw, jsonschema, packaging, pyrsistent, python-dateutil, python-owasp-zap-v2.4
-sqlalchemy==1.3.16        # via geoalchemy2
-sqlparse==0.3.1           # via django
-typing-extensions==3.7.4.1  # via readerwriterlock
+requests==2.24.0          # via -r requirements.in, amsterdam-schema-tools, azure-core, datapunt-authorization-django, django-healthchecks, msrest, python-owasp-zap-v2.4, requests-oauthlib
+sentry-sdk==0.19.2        # via -r requirements.in
+shapely==1.7.1            # via amsterdam-schema-tools
+six==1.15.0               # via azure-core, cryptography, django-healthchecks, isodate, jsonpath-rw, jsonschema, packaging, python-dateutil, python-owasp-zap-v2.4
+sqlalchemy==1.3.20        # via geoalchemy2
+sqlparse==0.4.1           # via django
+toml==0.10.2              # via pytest
+typing-extensions==3.7.4.3  # via readerwriterlock
 uritemplate==3.0.1        # via drf-spectacular
 urllib3-mock==0.3.3       # via -r requirements.in
-urllib3==1.25.8           # via -r requirements.in, requests, sentry-sdk
-wcwidth==0.1.8            # via pytest
+urllib3==1.25.11          # via -r requirements.in, requests, sentry-sdk
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -2,14 +2,14 @@
 -r ./requirements.txt
 
 # Tools for maintaining requirements.txt:
-pip-tools == 4.5.1
+pip-tools == 5.3.1
 pur == 5.3.0
 
 # Useful extra developer packages:
-pytest-sugar == 0.9.2
+pytest-sugar == 0.9.4
 termcolor >= 1.1.0  # for pytest-sugar
-pre-commit == 2.1.1
+pre-commit == 2.8.2
 
 # Debugging
-django-debug-toolbar == 2.2
-django-extensions == 2.2.8
+django-debug-toolbar == 3.1.1
+django-extensions == 3.0.9


### PR DESCRIPTION
Het gaat me alleen om de amsterdam-schema-tools[django] == 0.15.0
Maar vanwege `make upgrade` werd alles geupgrade.
Ik vind dit nogal spannend, kan niet goed overzien of dit potentieel kwaad kan.
