### PR TITLE
Remove wildcard setting for Access-Control-Allow-Origin: *

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -178,6 +178,12 @@ LOGGING = {
 
 # -- Third party app settings
 
+# Do not set CORS_ALLOW_ALL_ORIGINS to True
+# The Access-Control-Allow-Origin should  ot de set to *
+# That will conflict with the  Access-Control-Allow-Credentials: true
+# set by HAProxy. If Access-Control-Allow-Origin is not set here it will
+# be set correctly  to the Origin by HAProxy
+
 CORS_ALLOW_HEADERS = list(default_headers) + [
     "Accept-Crs",
     "Content-Crs",

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -178,9 +178,6 @@ LOGGING = {
 
 # -- Third party app settings
 
-CORS_ORIGIN_ALLOW_ALL = True
-
-
 CORS_ALLOW_HEADERS = list(default_headers) + [
     "Accept-Crs",
     "Content-Crs",


### PR DESCRIPTION
This does not work with the CORS setting by HAProxy : Access-Control-Allow-Credentials: true
Now the Access-Control-Allow-Origin will be set by HAProxy to the Origin
in the request. Then it will work correcly with the other CORS settings