### PR TITLE
Downgrade schema-tools to fix issue with missing temporal fields

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 1.1.1
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.16.0
+amsterdam-schema-tools[django] == 0.15.11
 datapunt-authorization-django==1.0.0
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.16.0  # via -r requirements.in
+amsterdam-schema-tools[django]==0.15.11  # via -r requirements.in
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via jsonschema, pg-grant, pytest
 azure-core==1.8.2         # via azure-storage-blob


### PR DESCRIPTION
For events, extra temporal fields have been introduced in the
dynamic schemas. However, these fields are not yet in the
postgresql tables. First downgrade to avoid these issues
in production.