### PR TITLE
Revert filterset change

### DIFF
--- a/src/dso_api/dynamic_api/filterset.py
+++ b/src/dso_api/dynamic_api/filterset.py
@@ -171,7 +171,9 @@ def generate_additional_filters(model: Type[DynamicModel]):
             continue
 
         filters[filter_name] = filter_class(
-            label=filter_class.label, **options.get("kwargs")
+            start_field=options.get("start"),
+            end_field=options.get("end"),
+            label=filter_class.label,
         )
 
     return filters

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-postgres-unlimited-varchar == 1.1.0
 django-gisserver == 1.1.1
 djangorestframework == 3.11.0
 djangorestframework-gis == 0.15
-amsterdam-schema-tools[django] == 0.15.11
+amsterdam-schema-tools[django] == 0.16.2
 datapunt-authorization-django==1.0.0
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.15.11  # via -r requirements.in
+amsterdam-schema-tools[django]==0.16.2  # via -r requirements.in
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via jsonschema, pg-grant, pytest
 azure-core==1.8.2         # via azure-storage-blob

--- a/src/tests/files/parkeervakken.json
+++ b/src/tests/files/parkeervakken.json
@@ -12,17 +12,12 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "id",
-          "schema"
-        ],
+        "required": ["id", "schema"],
         "additionalFilters": {
           "regimes.inWerkingOp": {
             "type": "range",
-            "kwargs": {
-              "start_field": "regimes.begin tijd",
-              "end_field": "regimes.eind tijd"
-            }
+            "start": "regimes.begin tijd",
+            "end": "regimes.eind tijd"
           }
         },
         "properties": {
@@ -108,8 +103,8 @@
                   }
                 },
                 "opmerking": {
-                    "type": "string",
-                    "description": ""
+                  "type": "string",
+                  "description": ""
                 }
               }
             }


### PR DESCRIPTION
The definition of filtersets in amsterdam schema was changed.
However, this was done for a test and the implementation in the filters.
So, existing datasets were crashing (at django startup).

The schema change was not very sensible, introducing a "kwargs" keyword
in amsterdam schema and using (and being dependent on) snake_case attributes.

So, this change has been reverted.