### PR TITLE
Use certificate for production HaalCentraal

### DIFF
--- a/src/dso_api/dynamic_api/remote/views.py
+++ b/src/dso_api/dynamic_api/remote/views.py
@@ -25,7 +25,10 @@ from . import serializers
 from .. import permissions
 
 logger = logging.getLogger(__name__)
-http_pool = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
+http_pool_generic = urllib3.PoolManager(
+    cert_reqs="CERT_REQUIRED", ca_certs=certifi.where()
+)
+http_pool_kadaster = None
 
 
 def del_none(d):
@@ -83,14 +86,44 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
         """The GET request for listings"""
         data = self._call_remote(query_params=request.query_params)
         if "_embedded" in data and isinstance(data["_embedded"], dict):
-            data = next(iter(data["_embedded"].values())) if data["_embedded"] else []
-        serializer = self.get_serializer(data=data, many=True)
-        self.validate(serializer, data)
+            if data["_embedded"]:
+                ldata = None
+                for k, v in data["_embedded"].items():
+                    if not ldata:
+                        ldata = v
+                        if (
+                            self.dataset_id == "hcbrk"
+                            and self.table_id == "kadasternatuurlijkpersonen"
+                            and k.lower() == "kadasternatuurlijkpersonen"
+                        ):
+                            new_ldata = []
+                            for element in ldata:
+                                new_ldata.append(
+                                    self.filter_sensitive_data(request, element)
+                                )
+                            data["_embedded"][k] = new_ldata
+            else:
+                ldata = []
+        serializer = self.get_serializer(data=ldata, many=True)
+        self.validate(serializer, ldata)
 
-        # TODO: add pagination:
-        # paginator = self.pagination_class()
-        # paginator.get_paginated_response(serializer.data)
-        return Response(serializer.data)
+        if self.dataset_id == "hcbrk":
+            return Response(data)
+        else:
+            # TODO: add pagination:
+            # paginator = self.pagination_class()
+            # paginator.get_paginated_response(serializer.data)
+            return Response(serializer.data)
+
+    def filter_sensitive_data(self, request, data):
+        if request.method != "OPTIONS" and not request.is_authorized_for("BRK/RSN"):
+            filtered_data = dict(data)
+            filtered_data.pop("kadastraalOnroerendeZaakIdentificaties")
+            filtered_data["_links"].pop("kadastraalOnroerendeZaken")
+            filtered_data["_links"].pop("zakelijkGerechtigden")
+            return filtered_data
+        else:
+            return data
 
     def retrieve(self, request, *args, **kwargs):
         """The GET request for detail"""
@@ -104,7 +137,13 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
         self_link = self.request.build_absolute_uri(self.request.path)
         if "_links" not in serialized_data:
             serialized_data["_links"] = {"self": {"href": self_link}}
-        return Response(serialized_data)
+        if self.dataset_id == "hcbrk":
+            if self.table_id == "kadasternatuurlijkpersonen":
+                data = self.filter_sensitive_data(request, data)
+
+            return Response(data)
+        else:
+            return Response(serializer.data)
 
     def validate(self, serializer, raw_data):
         if not serializer.is_valid():
@@ -139,6 +178,20 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
         # Using urllib directly instead of requests for performance
         logger.debug("Forwarding call to %s", url)
         headers = self.get_headers()
+
+        if self.dataset_id == "hcbrk" and "acceptatie" not in self.endpoint_url:
+            global http_pool_kadaster
+            if http_pool_kadaster is None:
+                http_pool_kadaster = urllib3.PoolManager(
+                    cert_file=settings.HAAL_CENTRAAL_CERTFILE,
+                    cert_reqs="CERT_REQUIRED",
+                    key_file=settings.HAAL_CENTRAAL_API_KEY,
+                    ca_certs=certifi.where(),
+                )
+            http_pool = http_pool_kadaster
+        else:
+            http_pool = http_pool_generic
+
         try:
             response: HTTPResponse = http_pool.request(
                 "GET",

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -283,3 +283,5 @@ for key, value in env.ENVIRON.items():
         locals()[key] = value
 
 HAAL_CENTRAAL_API_KEY = os.getenv("HAAL_CENTRAAL_API_KEY", "UNKNOWN")
+HAAL_CENTRAAL_KEYFILE = os.getenv("HC_KEYFILE")
+HAAL_CENTRAAL_CERTFILE = os.getenv("HC_CERTFILE")


### PR DESCRIPTION
Explicit filter kadastrale objecten for natuurelijk persoon if not
BRK/RSN.

Use schema only for validation of response, but return complete
HaalCentraal response

# This Pull request contains changes to:

<Please fill information>

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extraq details describing reasoning: ...
