### PR TITLE
Johan/relaties in hal envelop

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -367,10 +367,10 @@ class DynamicLinksSerializer(DynamicSerializer):
         ]
         # add the relation_fields to _links if there is not going to be an _embedded
         # or if we are part of a list-view
-        if embedded_fields is False or (
+        if not embedded_fields or (
             "view" in self.context
             and hasattr(self.context["view"], "detail")
-            and self.context["view"].detail is False
+            and not self.context["view"].detail
         ):
             link_fields += relation_fields
         elif isinstance(embedded_fields, list):

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -167,11 +167,11 @@ class LinksField(serializers.HyperlinkedIdentityField):
     def to_representation(self, value):
         request = self.context.get("request")
 
-        output = {"self": {"href": self.get_url(value, self.view_name, request, None)}}
+        output = {"href": self.get_url(value, self.view_name, request, None)}
 
         # if no display field, ommit the title element from output
         if value._display_field:
-            output["self"].update({"title": str(value)})
+            output.update({"title": str(value)})
 
         return output
 
@@ -192,3 +192,11 @@ class DSOGeometryField(GeometryField):
         else:
             # Return GeoJSON for json/html/api formats
             return super().to_representation(value)
+
+
+class HALHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+    """Wrap the url from the HyperlinkedRelatedField according to HAL specs"""
+
+    def to_representation(self, value):
+        href = super().to_representation(value)
+        return {"href": href, "title": str(value.pk)}

--- a/src/rest_framework_dso/pagination.py
+++ b/src/rest_framework_dso/pagination.py
@@ -115,7 +115,6 @@ class DSOPageNumberPagination(DSOHTTPHeaderPageNumberPagination):
                 if isinstance(data.serializer, ListSerializer):
                     serializer = serializer.child
                 results_field = serializer.Meta.model._meta.model_name
-
             return {
                 "_links": _links,
                 "_embedded": {results_field: data},

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -349,8 +349,7 @@ class DSOModelSerializer(DSOSerializer, serializers.HyperlinkedModelSerializer):
             return False
         if (
             "view" in self.context
-            and hasattr(self.context["view"], "detail")
-            and self.context["view"].detail is False
+            and not getattr(self.context["view"], "detail", True)
         ):
             return False
         return is_root and accepted_renderer.format != "csv"

--- a/src/rest_framework_dso/utils.py
+++ b/src/rest_framework_dso/utils.py
@@ -124,7 +124,6 @@ class EmbeddedHelper:
                 for id in ids_per_relation[name]
                 if id in data
             ]
-
         return _embedded
 
     def get_embedded(self, instance: models.Model) -> dict:

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -73,20 +73,23 @@ class TestDynamicSerializer:
         )
         assert container_serializer.data == {
             "_links": {
+                "cluster": {
+                    "href": "http://testserver/v1/afvalwegingen/clusters/123.456/",
+                    "title": "123.456",
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/2/",
                     "title": "2",
-                }
+                },
             },
-            "id": 2,
-            "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
             "clusterId": "123.456",
-            "cluster": "http://testserver/v1/afvalwegingen/clusters/123.456/",
-            "serienummer": "serie123",
             "datumCreatie": "2020-02-03",
             "datumLeegmaken": None,
-            "geometry": None,
             "eigenaarNaam": "datapunt",
+            "geometry": None,
+            "id": 2,
+            "serienummer": "serie123",
         }
 
     @staticmethod
@@ -109,15 +112,14 @@ class TestDynamicSerializer:
         )
         assert container_serializer.data == {
             "_links": {
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/2/",
                     "title": "2",
-                }
+                },
             },
             "id": 2,
-            "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
             "clusterId": "123.456",
-            "cluster": "http://testserver/v1/afvalwegingen/clusters/123.456/",
             "serienummer": None,
             "datumCreatie": None,
             "datumLeegmaken": None,
@@ -129,10 +131,10 @@ class TestDynamicSerializer:
                         "self": {
                             "href": "http://testserver/v1/afvalwegingen/clusters/123.456/",
                             "title": "123.456",
-                        }
+                        },
+                        "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#clusters",  # noqa: E501
                     },
                     "id": "123.456",
-                    "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#clusters",  # noqa: E501
                     "status": "open",
                 }
             },
@@ -157,15 +159,14 @@ class TestDynamicSerializer:
         )
         assert container_serializer.data == {
             "_links": {
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/3/",
                     "title": "3",
-                }
+                },
             },
             "id": 3,
-            "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
             "clusterId": None,
-            "cluster": None,
             "serienummer": None,
             "datumCreatie": None,
             "datumLeegmaken": None,
@@ -197,12 +198,11 @@ class TestDynamicSerializer:
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/4/",
                     "title": "4",
-                }
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
             },
             "id": 4,
-            "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
             "clusterId": 99,
-            "cluster": "http://testserver/v1/afvalwegingen/clusters/99/",
             "serienummer": None,
             "datumCreatie": None,
             "datumLeegmaken": None,
@@ -236,12 +236,15 @@ class TestDynamicSerializer:
                 "self": {
                     "href": "http://testserver/v1/bagh/gemeente/0363/?volgnummer=1",
                     "title": "0363_001",
-                }
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/bagh/bagh#gemeente",
+                "stadsdelen": [
+                    {
+                        "href": "http://testserver/v1/bagh/stadsdeel/03630000000001/?volgnummer=001",  # noqa: E501
+                        "title": "03630000000001_001",
+                    }
+                ],
             },
-            "schema": "https://schemas.data.amsterdam.nl/datasets/bagh/bagh#gemeente",
-            "stadsdelen": [
-                "http://testserver/v1/bagh/stadsdeel/03630000000001/?volgnummer=001",
-            ],
             "id": "0363_001",
             "naam": "Amsterdam",
             "volgnummer": 1,
@@ -280,15 +283,21 @@ class TestDynamicSerializer:
                 "self": {
                     "href": "http://testserver/v1/vestiging/vestiging/1/",
                     "title": "1",
-                }
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",  # noqa: E501
+                "postAdres": {
+                    "href": "http://testserver/v1/vestiging/adres/3/",
+                    "title": "3",
+                },
+                "bezoekAdres": {
+                    "href": "http://testserver/v1/vestiging/adres/1/",
+                    "title": "1",
+                },
             },
-            "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",
             "id": 1,
             "naam": "Snake Oil",
             "postAdresId": 3,
-            "postAdres": "http://testserver/v1/vestiging/adres/3/",
             "bezoekAdresId": 1,
-            "bezoekAdres": "http://testserver/v1/vestiging/adres/1/",
         }
 
         vestiging_serializer = VestigingSerializer(
@@ -300,15 +309,21 @@ class TestDynamicSerializer:
                 "self": {
                     "href": "http://testserver/v1/vestiging/vestiging/2/",
                     "title": "2",
-                }
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",  # noqa: E501
+                "postAdres": {
+                    "href": "http://testserver/v1/vestiging/adres/3/",
+                    "title": "3",
+                },
+                "bezoekAdres": {
+                    "href": "http://testserver/v1/vestiging/adres/2/",
+                    "title": "2",
+                },
             },
-            "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",
             "id": 2,
             "naam": "Haarlemmer olie",
             "postAdresId": 3,
-            "postAdres": "http://testserver/v1/vestiging/adres/3/",
             "bezoekAdresId": 2,
-            "bezoekAdres": "http://testserver/v1/vestiging/adres/2/",
         }
 
         AdresSerializer = serializer_factory(vestiging_adres_model, 0)
@@ -318,22 +333,28 @@ class TestDynamicSerializer:
         )
         assert adres_serializer.data == {
             "_links": {
+                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#adres",
                 "self": {
                     "href": "http://testserver/v1/vestiging/adres/3/",
                     "title": "3",
-                }
+                },
+                "vestigingenBezoek": [],
+                "vestigingenPost": [
+                    {
+                        "href": "http://testserver/v1/vestiging/vestiging/1/",
+                        "title": "1",
+                    },
+                    {
+                        "href": "http://testserver/v1/vestiging/vestiging/2/",
+                        "title": "2",
+                    },
+                ],
             },
-            "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#adres",
-            "vestigingenBezoek": [],
-            "vestigingenPost": [
-                "http://testserver/v1/vestiging/vestiging/1/",
-                "http://testserver/v1/vestiging/vestiging/2/",
-            ],
             "id": 3,
             "nummer": 1,
             "plaats": "Amsterdam",
-            "straat": "Dam",
             "postcode": "1000AA",
+            "straat": "Dam",
         }
 
     @staticmethod
@@ -372,25 +393,26 @@ class TestDynamicSerializer:
             begin_datum=None,
         )
 
-        ParkeervaakSerializer = serializer_factory(parkeervakken_parkeervak_model, 0)
+        ParkeervakSerializer = serializer_factory(parkeervakken_parkeervak_model, 0)
 
         # Prove that no reverse relation to containers here.
-        assert "regimes" in ParkeervaakSerializer._declared_fields
+        assert "regimes" in ParkeervakSerializer._declared_fields
 
         # Prove that data is serialized with relations.
         # Both the cluster_id field and 'cluster' field are generated.
-        parkeervaak_serializer = ParkeervaakSerializer(
+
+        parkeervak_serializer = ParkeervakSerializer(
             parkeervak, context={"request": drf_request}
         )
-        assert parkeervaak_serializer.data == {
+        assert parkeervak_serializer.data == {
             "_links": {
                 "self": {
                     "href": "http://testserver/v1/parkeervakken/parkeervakken/121138489047/",
-                }
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/parkeervakken#parkeervakken",  # noqa: E501
             },
             "geometry": None,
             "id": "121138489047",
-            "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/parkeervakken#parkeervakken",  # noqa: E501
             "type": "File",
             "soort": "MULDER",
             "aantal": 1.0,
@@ -452,27 +474,28 @@ class TestDynamicSerializer:
             begin_datum=None,
         )
 
-        ParkeervaakSerializer = serializer_factory(
+        ParkeervakSerializer = serializer_factory(
             parkeervakken_parkeervak_model, 0, flat=True
         )
 
         # Prove that no reverse relation to containers here.
-        assert "regimes" not in ParkeervaakSerializer._declared_fields
+        assert "regimes" not in ParkeervakSerializer._declared_fields
 
         # Prove that data is serialized with relations.
         # Both the cluster_id field and 'cluster' field are generated.
-        parkeervaak_serializer = ParkeervaakSerializer(
+
+        parkeervak_serializer = ParkeervakSerializer(
             parkeervak, context={"request": drf_request}
         )
-        assert parkeervaak_serializer.data == {
+        assert parkeervak_serializer.data == {
             "_links": {
                 "self": {
                     "href": "http://testserver/v1/parkeervakken/parkeervakken/121138489047/"
-                }
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/parkeervakken#parkeervakken",  # noqa: E501
             },
             "geometry": None,
             "id": "121138489047",
-            "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/parkeervakken#parkeervakken",  # noqa: E501
             "type": "File",
             "soort": "MULDER",
             "aantal": 1.0,
@@ -750,6 +773,6 @@ class TestDynamicSerializer:
         )
 
         assert (
-            statistieken_serializer.data["buurt"]
+            statistieken_serializer.data["_links"]["buurt"]["href"]
             == "http://testserver/v1/gebieden/buurten/03630000000078/"
         ), statistieken_serializer.data

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -199,9 +199,9 @@ class TestViews:
         expected_url = "/{}/?volgnummer=002".format(
             bagh_gebieden.stadsdeel.identificatie
         )
-        assert response.data["stadsdeel"].endswith(expected_url), response.data[
-            "stadsdeel"
-        ]
+        assert response.data["_links"]["stadsdeel"]["href"].endswith(
+            expected_url
+        ), response.data["_links"]["stadsdeel"]["href"]
 
     def test_serializer_temporal_request_corrects_link_to_temporal(
         self, api_client, filled_router, bagh_schema, bagh_gebieden
@@ -216,6 +216,6 @@ class TestViews:
         expected_url = "/{}/?geldigOp=2014-05-01".format(
             bagh_gebieden.stadsdeel.identificatie
         )
-        assert response.data["stadsdeel"].endswith(expected_url), response.data[
-            "stadsdeel"
-        ]
+        assert response.data["_links"]["stadsdeel"]["href"].endswith(
+            expected_url
+        ), response.data["stadsdeel"]


### PR DESCRIPTION
Relations moved into HAL envelope according to DSO standard [DS-543] 

- The `_links` field is now a SerializerMethodField
- It is serialized with a dynamically generated serializer from the `serializer_factory`
- It contains the `self`, `schema`, and non-expanded relational fields
- In a list view it also contains the relational fields that are expanded in `_embedded`, to be able to piece it back together.
- The relational fields have been removed from the detail body (they are either in `_links` or in `_embedded`); id fields and all other properties stay.
- URLs in FK and M2M fields are wrapped in a `href` together with a `title` according to HAL specs.
- CSV output is without the `_links` field; it does not contain relational fields yet.
- GeoJSON output is kept the same by taking and unwrapping the FK fields from `_links`.
- All relevant pytests have been adapted and extended.


[DS-543]: https://datapunt.atlassian.net/browse/DS-543