### PR TITLE
Keep loose FK verbatim in body

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -290,6 +290,11 @@ class DynamicBodySerializer(DynamicSerializer):
     parameters
     """
 
+    serializer_field_mapping = {
+        **DynamicSerializer.serializer_field_mapping,
+        LooseRelationField: serializers.CharField,
+    }
+
     @property
     def fields(self):
         fields = super().fields

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -869,6 +869,7 @@ class TestEmbedTemporalTables:
                 },
             },
             "id": 1,
+            "buurt": "03630000000078",
         }
 
     def test_detail_expand_true_for_loose_relation(
@@ -897,6 +898,7 @@ class TestEmbedTemporalTables:
                 },
             },
             "id": 1,
+            "buurt": "03630000000078",
             "_embedded": {
                 "buurt": {
                     "_links": {


### PR DESCRIPTION
Since loose FK fields are transformed into links wrapped in a HAL envelope, the value of the original field "disappeard". With this fix, the original field is included in the body of the object as a char field, while also keeping the `_links` references as before.

- Changed the type of the loose FK field into CharField for simple rendering in the body serializer.
- Updated two pytests with the additional field.