### PR TITLE
Remove bag_v11_read useage

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -134,11 +134,9 @@ DATABASES = {
         engine="django.contrib.gis.db.backends.postgis",
     ),
 }
-
-DATABASE_SCHEMAS = {
-    "bag": "bag_v11_read",  # Important to have 'bag_v11' connection defined in DATABASES.
-}
-DATABASE_DISABLE_MIGRATIONS = ["bag"]
+# Important to have keys define in DATABASE_SCHEMAS available as in DATABASES.
+DATABASE_SCHEMAS = {}
+DATABASE_DISABLE_MIGRATIONS = []
 
 DATABASE_ROUTERS = ["dso_api.dbrouters.DatabaseSchemasRouter"]
 


### PR DESCRIPTION
Bag will be imported in the masterdb.

# This Pull request contains changes to:

Use the 'bag' name for the data that previously was coming from bag_v11
