### PR TITLE
Added id field for loose FK fields using original fieldname with suff…

### DIFF
--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -875,7 +875,7 @@ class TestEmbedTemporalTables:
                 },
             },
             "id": 1,
-            "buurt": "03630000000078",
+            "buurtId": "03630000000078",
         }
 
     def test_detail_expand_true_for_loose_relation(
@@ -904,7 +904,7 @@ class TestEmbedTemporalTables:
                 },
             },
             "id": 1,
-            "buurt": "03630000000078",
+            "buurtId": "03630000000078",
             "_embedded": {
                 "buurt": {
                     "_links": {


### PR DESCRIPTION
Added an Id field for loose FK fields using the original fieldname with suffix "Id".
- Removed previous solution which kept the original fieldname without suffix
- Added an additional CharField to the dynamic serializer referencing the loose FK field.