### PR TITLE
Fix attribute errors from fields for non-temporal datasets.

### DIFF
--- a/src/dso_api/dynamic_api/middleware.py
+++ b/src/dso_api/dynamic_api/middleware.py
@@ -32,14 +32,14 @@ class TemporalDatasetMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         request.versioned = False
+        request.dataset_version = None
+        request.dataset_temporal_slice = None
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if not hasattr(request, "dataset") or request.dataset.temporal is None:
             return None
 
         request.versioned = True
-        request.dataset_version = None
-        request.dataset_temporal_slice = None
         if request.GET.get(request.dataset.temporal["identifier"]):
             request.dataset_version = request.GET.get(request.dataset.temporal["identifier"])
 

--- a/src/dso_api/dynamic_api/middleware.py
+++ b/src/dso_api/dynamic_api/middleware.py
@@ -32,10 +32,10 @@ class TemporalDatasetMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         request.versioned = False
-        request.dataset_version = None
-        request.dataset_temporal_slice = None
 
     def process_view(self, request, view_func, view_args, view_kwargs):
+        request.dataset_version = None
+        request.dataset_temporal_slice = None
         if not hasattr(request, "dataset") or request.dataset.temporal is None:
             return None
 


### PR DESCRIPTION
# This Pull request contains changes to:

Fixes attribute errors related to `TemporalDatasetMiddleware` not setting `dataset_temporal_slice` as expected.

# In case this PR reverts changes in repo

- [x] Extra details describing reasoning:  
Sentry stack: https://sentry.data.amsterdam.nl/sentry/datapunt-apis-acc/issues/2679358/?environment=dso-api&referrer=alert_email