### PR TITLE
Massive performance fix of serializer.fields access.

### DIFF
--- a/src/dso_api/dynamic_api/middleware.py
+++ b/src/dso_api/dynamic_api/middleware.py
@@ -3,6 +3,7 @@ import logging
 
 from django.http import UnreadablePostError
 from django.utils.deprecation import MiddlewareMixin
+from schematools.contrib.django.auth_backend import RequestProfile
 
 audit_log = logging.getLogger("dso_api.audit")
 
@@ -16,6 +17,8 @@ class DatasetMiddleware(MiddlewareMixin):
         """
         Make current dataset available across whole application.
         """
+        request.auth_profile = RequestProfile(request)  # for OAS views
+
         if not hasattr(request, "dataset"):
             try:
                 request.dataset = view_func.cls.model._dataset_schema

--- a/src/dso_api/dynamic_api/oas3.py
+++ b/src/dso_api/dynamic_api/oas3.py
@@ -68,7 +68,6 @@ These are located at:
 
 def _get_openapi_view(renderer_classes=None):
     return get_schema_view(
-        public=True,
         renderer_classes=renderer_classes,
         generator_class=ExtendedSchemaGenerator,
         permission_classes=(permissions.AllowAny,),

--- a/src/dso_api/dynamic_api/remote/views.py
+++ b/src/dso_api/dynamic_api/remote/views.py
@@ -11,7 +11,6 @@ from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, NotFound, ParseError
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from schematools.contrib.django.auth_backend import RequestProfile
 from urllib3 import HTTPResponse
 
 from dso_api.lib.exceptions import (
@@ -61,10 +60,6 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
 
     #: Custom permission that checks amsterdam schema auth settings
     permission_classes = [permissions.HasOAuth2Scopes]
-
-    def initial(self, request, *args, **kwargs):
-        request.auth_profile = RequestProfile(request)
-        super().initial(request, *args, **kwargs)
 
     def get_serializer(self, *args, **kwargs) -> serializers.RemoteSerializer:
         """Instantiate the serializer that validates the remote data."""

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -149,23 +149,21 @@ class DynamicSerializer(DSOModelSerializer):
         """
         return self.context["request"]
 
-    @property
-    def fields(self):
-        fields = super().fields
+    def get_fields(self):
+        fields = super().get_fields()
         request = self.get_request()
 
         # Adjust the serializer based on the request.
         # request can be None for get_schema_view(public=True)
-        if request is not None:
-            unauthorized_fields = get_unauthorized_fields(request, self.Meta.model)
-            if unauthorized_fields:
-                fields = OrderedDict(
-                    [
-                        (field_name, field)
-                        for field_name, field in fields.items()
-                        if field_name not in unauthorized_fields
-                    ]
-                )
+        unauthorized_fields = get_unauthorized_fields(request, self.Meta.model)
+        if unauthorized_fields:
+            fields = OrderedDict(
+                [
+                    (field_name, field)
+                    for field_name, field in fields.items()
+                    if field_name not in unauthorized_fields
+                ]
+            )
         return fields
 
     def get_auth_checker(self):
@@ -293,9 +291,8 @@ class DynamicBodySerializer(DynamicSerializer):
     parameters
     """
 
-    @property
-    def fields(self):
-        fields = super().fields
+    def get_fields(self):
+        fields = super().get_fields()
         output_fields = OrderedDict(
             [
                 (field_name, field)
@@ -321,9 +318,8 @@ class DynamicLinksSerializer(DynamicSerializer):
 
     serializer_related_field = HALTemporalHyperlinkedRelatedField
 
-    @property
-    def fields(self):
-        fields = super().fields
+    def get_fields(self):
+        fields = super().get_fields()
         embedded_fields = self.get_fields_to_expand()
         link_fields = ["self", "schema"]
         relation_fields = [

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -8,7 +8,6 @@ from rest_framework.exceptions import ErrorDetail, NotAcceptable, ValidationErro
 from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
 from rest_framework.views import exception_handler as drf_exception_handler
-from schematools.contrib.django.auth_backend import RequestProfile
 from schematools.types import DatasetTableSchema
 
 from dso_api.lib.exceptions import RemoteAPIException
@@ -184,7 +183,6 @@ class DSOViewMixin:
     pagination_class = AutoSelectPaginationClass(default=DSOPageNumberPagination)
 
     def initial(self, request, *args, **kwargs):
-        request.auth_profile = RequestProfile(request)
         request.accept_crs = None
         request.response_content_crs = None
         super().initial(request, *args, **kwargs)


### PR DESCRIPTION
The original DRF `Serializer.fields` is a cached_property that reads get_fields() once.
Thus overriding `get_fields()` instead of `fields` preserves this caching.

Currently the fields were read multiple times per object, while doing massive unauthorized-fields checks.
This change fixes that.

To address any concerns about information-leakage serializers *must* receive an request object so the unauthorized field checks are performed. This only conflicted with the OAS schema view, which is fixed by `public=False`. Assigning request.auth_profile had to be moved because of this.

The CSV export can not also avoid reading all fields (including M2M), while not returning these.