### PR TITLE
Do not give key error for missing geofield if is not required.

### DIFF
--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -254,7 +254,7 @@ class DSOSerializer(_SideloadMixin, serializers.Serializer):
         for field in self._geometry_fields:
             if isinstance(instance, dict):
                 # non-model Serializer
-                geo_value = instance[field.source]
+                geo_value = instance.get(field.source)
             else:
                 # ModelSerializer
                 geo_value = getattr(instance, field.source)


### PR DESCRIPTION
In the production version for HaalCentraal brk the begrenzingPerceel is
missing. This now gives the following error:

https://sentry.data.amsterdam.nl/sentry/datapunt-apis-prod/issues/2680654/



