### PR TITLE
Fixes to API docs (docs/ dir)

### DIFF
--- a/docs/source/generic/rest.rst
+++ b/docs/source/generic/rest.rst
@@ -42,9 +42,8 @@ altijd een JSON response geforceerd.
 Paginering
 ----------
 
-De resultaten hebben een standaard paginagrootte van 1000 records.
-
-De paginagrootte kan aangepast worden door een :samp:`&page_size={n}` query parameter toe te voegen aan de request URL.
+De resultaten worden gepagineerd teruggegeven.
+De paginagrootte kan aangepast worden door een :samp:`?page_size={n}` query parameter toe te voegen aan de request URL.
 
 In de response zijn de volgende elementen te vinden:
 
@@ -158,6 +157,9 @@ Tekstvelden ondersteunen wildcards. Maak daarvoor gebruik van de :samp:`?{veld}[
     curl 'https://api.data.amsterdam.nl/v1/bag/stadsdeel/?naam[like]=West*'
 
     curl 'https://api.data.amsterdam.nl/v1/bag/stadsdeel/?naam[like]=Westp??rt'
+
+``*`` staat voor nul of meer willekeurige tekens. ``?`` staat voor precies
+één willekeurig teken. Er is geen *escaping* van deze symbolen mogelijk.
 
 De namen van de velden en mogelijke operatoren zijn te vinden op
 de :doc:`datasets <../datasets/index>` pagina.

--- a/docs/source/generic/temporele_datasets.rst
+++ b/docs/source/generic/temporele_datasets.rst
@@ -1,103 +1,79 @@
 Temporele Datasets
 ==================
 
-Sommige datasets (BAGH) presenteren historische data en dus bieden eeen "tijd reizen" mogelijkheid aan.
+Sommige datasets bevatten historische data en dus bieden de mogelijkheid van "tijdreizen" aan.
+We noemen deze datasets "temporeel". Elk object binnen een temporele dataset heeft een of meer versies, geïdentificeerd door een "volgnummer".
 
 
-Filtering op versie nummer
---------------------------
+Filtering op versienummer
+-------------------------
 
-Elk object binnen temporele dataset heeft  een of meer versies per ID.
-
-Bijvoorbeeld: `BAGH Riekerpolder Buurt`_ :code:`/v1/bagh/buurt/03630000000477/`
+Bijvoorbeeld: de buurt `Riekerpolder <https://api.data.amsterdam.nl/v1/gebieden/buurten/03630000000477/>`_ in gebieden/buurten heeft op het moment van schrijven de volgende attributen:
 
 .. code-block::
 
    {
        ...
-       "id": "03630000000477_002",
        "code": "F88a",
        "naam": "Riekerpolder",
-       "identificatie": "03630000000477",
+       ...
        "volgnummer": 2,
+       ...
+       "identificatie": "03630000000477",
+       ...
        "eindGeldigheid": null,
        "beginGeldigheid": "2010-05-01",
-       "registratiedatum": "2018-10-25T05:17:48"
-       ...
+       "registratiedatum": "2010-05-01T00:00:00",
+       "id": "03630000000477.2"
    }
 
-Dezelfde link met `volgnummer`_ :code:`/v1/bagh/buurt/03630000000477/?volgnummer=1` geeft de eerste versie van `Riekerpolder` buurt.
+Dezelfde link met `volgnummer=1 <https://api.data.amsterdam.nl/v1/gebieden/buurten/03630000000477/?volgnummer=1>`_ geeft de eerste versie van deze buurt:
 
 .. code-block::
 
    {
        ...
-       "id": "03630000000477_002",
        "code": "F88a",
        "naam": "Riekerpolder",
-       "identificatie": "03630000000477",
+       ...
        "volgnummer": 1,
+       ...
+       "identificatie": "03630000000477",
+       ...
        "eindGeldigheid": "2010-05-01",
        "beginGeldigheid": "2006-06-16",
-       "registratiedatum": "2010-04-30T17:00:00"
-       ...
+       "registratiedatum": "2010-05-01T00:00:00",
+       "id": "03630000000477.1"
    }
 
-   
-
-Filtering op basis van geldigheids datum
-----------------------------------------
-
-Objecten binnen een temporele dataset mogen gefilterd worden op basis van geldigheids datum.
-
-Dit kan gedaan worden op basis van :code:`additionalFilters`, gedefinieerd in de Amsterdam Schema definitie van datasets.
-
-BAGH heeft een temporele filter: :code:`geldigOp`. Dit is een filter die zorgt dat:
- - alle objecten waar `geldigOp` valt binnen `beginGeldigheid` en `eindGeldigheids` datums worden getoond,
- - alle links tussen objecten krijgen `geldigOp` referenties
 
 
-Bijvoorbeeld:
+Filtering op basis van geldigheidsdatum
+---------------------------------------
 
-`BAGH Riekerpolder Buurt`_ :code:`/v1/bagh/buurt/03630000000477/`
+Objecten binnen een temporele dataset mogen gefilterd worden op basis van geldigheidsdatum.
+Dit kan gedaan worden met :code:`additionalFilters`, gedefinieerd in de Amsterdam Schema definitie van datasets.
+
+Gebieden heeft een temporeel filter :code:`geldigOp`. Dit is een filter dat ervoor zorgt dat:
+ - alle objecten waar `geldigOp` valt tussen de datums `beginGeldigheid` en `eindGeldigheid` worden getoond,
+ - alle links tussen objecten referenties `geldigOp` krijgen.
+
+
+Bijvoorbeeld, opnieuw Riekerpolder, maar nu met `geldigOp=2010-04-30 <https://api.data.amsterdam.nl/v1/gebieden/buurt/03630000000477/?geldigOp=2010-04-30>`_, geeft versie 1 van die buurt:
 
 .. code-block::
 
    {
        ...
-       "id": "03630000000477_002",
        "code": "F88a",
        "naam": "Riekerpolder",
-       "identificatie": "03630000000477",
-       "volgnummer": 2,
-       "eindGeldigheid": null,
-       "beginGeldigheid": "2010-05-01",
-       "registratiedatum": "2018-10-25T05:17:48"
        ...
-   }
-
-
-Toevoegen van `geldigOp`_ in URI :code:`/v1/bagh/buurt/03630000000477/?geldigOp=2010-04-30` geeft buurt informatie die geldig is op 30 April 2010.
-
-
-.. code-block::
-
-   {
-       ...
-       "id": "03630000000477_001",
-       "code": "F88a",
-       "naam": "Riekerpolder",
-       "identificatie": "03630000000477",
        "volgnummer": 1,
+       ...
+       "identificatie": "03630000000477",
+       ...
        "eindGeldigheid": "2010-05-01",
        "beginGeldigheid": "2006-06-16",
-       "registratiedatum": "2010-04-30T17:00:00"
-       ...
+       "registratiedatum": "2010-05-01T17:00:00"
+       "id": "03630000000477.1",
    }
-
-
-
-
-.. _BAGH Riekerpolder Buurt: /v1/bagh/buurt/03630000000477/
-.. _volgnummer: /v1/bagh/buurt/03630000000477/?volgnummer=1
-.. _geldigOp: /v1/bagh/buurt/03630000000477/?geldigOp=2010-04-30

--- a/docs/source/generic/wfs.rst
+++ b/docs/source/generic/wfs.rst
@@ -2,25 +2,25 @@ WFS Kaartlagen uitlezen
 =======================
 
 Alle "DSO API" diensten zijn ook als WFS feature beschikbaar.
-Hiermee kunnen GIS-pakketten (zoals QGis) de ruimtelijke data direct visualiseren,
+Hiermee kunnen GIS-pakketten (zoals QGIS) de ruimtelijke data direct visualiseren,
 en queries op uitvoeren.
 
-Werken met QGis
+Werken met QGIS
 ---------------
 
 De WFS lagen zijn beschikbaar onder de volgende URL's:
 
 :samp:`https://api.data.amsterdam.nl/v1/wfs/{<dataset naam>}/`
 
-Gebruik zo'n URL in QGis:
+Gebruik zo'n URL in QGIS:
 
 .. figure:: images/qgis-add-wfs.png
    :width: 1340
    :height: 1582
    :scale: 25%
-   :alt: (voorbeeldafbeelding van QGis)
+   :alt: (voorbeeldafbeelding van QGIS)
 
-   In de bovenstaande afbeelding wordt QGis gekoppeld met de BAG dataset:
+   In de bovenstaande afbeelding wordt QGIS gekoppeld met de BAG dataset:
    https://api.data.amsterdam.nl/v1/wfs/bag/
 
 Hierna zijn de gegevens te raadplegen, te filteren en te combineren:
@@ -29,11 +29,16 @@ Hierna zijn de gegevens te raadplegen, te filteren en te combineren:
    :width: 2438
    :height: 1614
    :scale: 25%
-   :alt: (stadsdelen weergegeven in QGis)
+   :alt: (stadsdelen weergegeven in QGIS)
 
 .. tip::
-    De parameters ``?SERVICE=WFS&VERSION=2.0.0&REQUEST=..`` worden door QGis zelf achter de URL gezet.
+    De parameters ``?SERVICE=WFS&VERSION=2.0.0&REQUEST=..`` worden door QGIS zelf achter de URL gezet.
     Het is niet nodig deze zelf toe te voegen.
+
+.. tip::
+    De schuine streep aan het einde van de URL is belangrijk.
+    QGIS werkt niet als deze ontbreekt. Dit is een beperking
+    in QGIS.
 
 Queries op relaties
 ~~~~~~~~~~~~~~~~~~~
@@ -44,7 +49,7 @@ kan je de volgende optie toevoegen aan de URL:
 * :samp:`?embed={relatienaam},{...}` zal een veld platgeslagen invoegen.
 * :samp:`?expand={relatienaam},{...}` zal een veld als "complex feature" invoegen.
 
-Gebruik deze URL in QGis, of een ander GIS-pakket.
+Gebruik deze URL in QGIS, of een ander GIS-pakket.
 
 Als voorbeeld: de BAG feature type *buurt* een relatie met een *stadsdeel*.
 Deze kan op beide manieren geconfigureerd worden in een GIS-pakket:
@@ -57,8 +62,8 @@ zodat het export formaat ook geneste relaties bevat.
 
 .. admonition:: Embed of expand gebruiken?
 
-   QGis 3 heeft geen ondersteuning voor complex features, en verwerkt deze als tekst.
-   Gebruikt in QGis daarom alleen de platgeslagen versie met :samp:`?embed={...}`.
+   QGIS 3 heeft geen ondersteuning voor complex features, en verwerkt deze als tekst.
+   Gebruikt in QGIS daarom alleen de platgeslagen versie met :samp:`?embed={...}`.
    De :samp:`?expand={...}` versie is daarentegen ideaal voor GeoJSON exports,
    die wel goed kan omgaan met geneste structuren.
 
@@ -531,7 +536,7 @@ Diverse bestaande filters gebruiken nog andere WFS 1 elementen, zoals ``<Propert
 van ``<ValueReference>``. Voor compatibiliteit wordt deze tag ook ondersteund.
 
 De WFS 1 expressies ``<Add>``, ``<Sub>``, ``<Mul>`` en ``<Div>`` zijn tevens geïmplementeerd
-om rekenkundige operaties te ondersteunen vanuit QGis (optellen, aftrekken, vermenigvuldigen en delen).
+om rekenkundige operaties te ondersteunen vanuit QGIS (optellen, aftrekken, vermenigvuldigen en delen).
 
 Technische achtergrond
 ----------------------


### PR DESCRIPTION
* Omit default page size

Doesn't match the implementation, and is prone to change anyway.

* Explain wildcard syntax

* Warn about trailing slash when using QGIS

Omitting the trailing slash causes QGIS to not work, only emitting
cryptic warning messages in its OAFIP log (whatever that may be).

* Fixed links in temporele datasets

bagh/buurt become gebieden/buurten.