### PR TITLE
extension of hal envelope of relations

### DIFF
--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -164,6 +164,13 @@ class LinksField(serializers.HyperlinkedIdentityField):
         if value._display_field:
             output.update({"title": str(value)})
 
+        if value.is_temporal():
+            temporal_fieldname = value.get_dataset().temporal.get("identifier")
+            temporal_value = getattr(value, temporal_fieldname)
+            id_fieldname = value.get_dataset().get("identifier")
+            id_value = getattr(value, id_fieldname)
+            output.update({temporal_fieldname: temporal_value, id_fieldname: id_value})
+
         return output
 
 

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -4,10 +4,11 @@ import pytest
 from django.core.validators import EmailValidator, URLValidator
 from schematools.contrib.django.auth_backend import RequestProfile
 from schematools.contrib.django.models import Profile
-
 from dso_api.dynamic_api.serializers import serializer_factory
 from rest_framework_dso.fields import EmbeddedField
+from rest_framework_dso.views import DSOViewMixin
 from tests.utils import normalize_data
+
 
 
 @pytest.fixture(autouse=True)
@@ -238,20 +239,22 @@ class TestDynamicSerializer:
                 "self": {
                     "href": "http://testserver/v1/gebieden/stadsdelen/0363/?volgnummer=1",
                     "title": "0363.1",
+                    "volgnummer": 1,
+                    "identificatie": "0363",
                 },
                 "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#stadsdelen",  # NoQA
                 "wijk": [
                     {
                         "href": "http://testserver/v1/gebieden/wijken/03630000000001/?volgnummer=1",  # NoQA
                         "title": "03630000000001.1",
+                        "volgnummer": 1,
+                        "identificatie": "03630000000001",
                     }
                 ],
             },
             "id": "0363.1",
             "naam": "Stadsdeel",
             "code": None,
-            "volgnummer": 1,
-            "identificatie": "0363",
             "eindGeldigheid": None,
             "beginGeldigheid": None,
             "registratiedatum": None,
@@ -743,7 +746,7 @@ class TestDynamicSerializer:
         for a loose relation field
         """
 
-        class DummyView:
+        class DummyView(DSOViewMixin):
             def __init__(self, model):
                 self.model = model
 

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -101,9 +101,9 @@ class TestViews:
 
         assert response.status_code == 200, data
         assert len(data["_embedded"]["stadsdelen"]) == 1, data["_embedded"]["stadsdelen"]
-        assert data["_embedded"]["stadsdelen"][0]["volgnummer"] == 2, data["_embedded"][
-            "stadsdelen"
-        ][0]
+        assert (
+            data["_embedded"]["stadsdelen"][0]["_links"]["self"]["volgnummer"] == 2
+        ), data["_embedded"]["stadsdelen"][0]
 
     def test_additionalrelations_works_and_has_temporary_param(
         self, api_client, stadsdelen, wijk, buurt
@@ -115,10 +115,12 @@ class TestViews:
         response = api_client.get(f"{url}?geldigOp=2015-01-02")
         data = read_response_json(response)
 
+
         assert response.status_code == 200, data
         assert len(data["_embedded"]["wijken"]) == 1, data["_embedded"]["wijken"]
-        assert data["_embedded"]["wijken"][0]["volgnummer"] == 1, data["_embedded"]["wijken"][0]
-
+        assert (
+            data["_embedded"]["wijken"][0]["_links"]["self"]["volgnummer"] == 1
+        ), data["_embedded"]["wijken"][0]
         assert data["_embedded"]["wijken"][0]["buurt"]["count"] == 1
         href = data["_embedded"]["wijken"][0]["buurt"]["href"]
         query_params = parse.parse_qs(parse.urlparse(href).query)
@@ -131,7 +133,9 @@ class TestViews:
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert data["volgnummer"] == stadsdelen[0].volgnummer, data
+        assert (
+            data["_links"]["self"]["volgnummer"] == stadsdelen[0].volgnummer
+        ), data
 
     def test_details_default_returns_latest_record(self, api_client, stadsdelen):
         """Prove that object can be requested by identification
@@ -141,7 +145,7 @@ class TestViews:
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert data["volgnummer"] == 2, data
+        assert data["_links"]["self"]["volgnummer"] == 2, data
 
     def test_details_can_be_requested_with_valid_date(self, api_client, stadsdelen):
         """Prove that object can be requested by identification and date,
@@ -153,7 +157,7 @@ class TestViews:
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert data["volgnummer"] == 1, data
+        assert data["_links"]["self"]["volgnummer"] == 1, data
 
     def test_details_can_be_requested_with_version(self, api_client, stadsdelen):
         """Prove that object can be requested by identification and version,
@@ -163,7 +167,7 @@ class TestViews:
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert data["volgnummer"] == 1, data
+        assert data["_links"]["self"]["volgnummer"] == 1, response.data
 
     def test_serializer_temporal_request_corrects_link_to_temporal(
         self, api_client, reloadrouter, gebied, buurt


### PR DESCRIPTION
Temporal identifier fields (usually named `identificatie` and `volgnummer`) are moved into the HAL envelope.
Specifically, this means:
- Identifier fields are removed from the body (potentially a breaking change)
- Identifier fields are added to `self` in `_links`
- Identifier fields are added to the HAL envelope of temporal relations (besides `href` and `title`)
- In case of loose relations, only `identificatie` (name of identifier fieldname in the related dataset) is added to the relation HAL envelope. (`volgnummer` is only shown in the embedded objects with `_expand=true`. Same as before, but:
- In case of embedding, temporal identifier fields are added to `self` in `_links` for each embedded object.