### PR TITLE
DS-597. Limit datasets with DATASETS_LIST and DATASETS_EXCLUDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ In some cases it might be required to isolate datasets from others on infrastruc
 for example sensitive information should not be published via Public APIs, but public information should be available in private API.
 
 This can be achieved by using `DATASETS_LIST` and `DATASETS_EXCLUDE` environment variables.
+Both variables accept comma separated list of dataset ids e.g. `bommen,gebieden,meldingen` etc.
 
 In case API should expose only limited set of datasets - use `DATASETS_LIST` to load only provided datasets into memory.
 In case API should expose all datasets with exception to limited subset - use `DATASETS_EXCLUDE` to loxad all datasets except provided into memory.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ This can be achieved by using `DATASETS_LIST` and `DATASETS_EXCLUDE` environment
 Both variables accept comma separated list of dataset ids e.g. `bommen,gebieden,meldingen` etc.
 
 In case API should expose only limited set of datasets - use `DATASETS_LIST` to load only provided datasets into memory.
-In case API should expose all datasets with exception to limited subset - use `DATASETS_EXCLUDE` to loxad all datasets except provided into memory.
+In case API should expose all datasets with exception to limited subset - use `DATASETS_EXCLUDE` to load all datasets except provided into memory.
 
 Both `DATASETS_LIST` and `DATASETS_EXCLUDE` variables should be used with great care, 
 as any relation to dataset outside of those loaded into memory will break API.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Then it will import the schemafiles in **_schemas/data/datasets_** with :
 
     python manage.py import_schemas
     
-#FreeBSD Installation Instructions
+# FreeBSD Installation Instructions
 
 Installing the DSO API under FreeBSD should be largely similar to installing it under Linux or MacOS.
 However, some extra work will be required to build packages that rely on code written in other languages
@@ -197,3 +197,17 @@ OpenAPI schema can be verified on localhost using following command:
     OPENAPI_HOST=http://localhost:8000 ./.jenkins/openapi_validator/run_validator.sh
 
 Do not forget to replace `OPENAPI_HOST` with address of running DSO api, if it differs from `http://localhost:8000`.
+
+
+# Limiting number of Datasets available via API
+
+In some cases it might be required to isolate datasets from others on infrastructure level, 
+for example sensitive information should not be published via Public APIs, but public information should be available in private API.
+
+This can be achieved by using `DATASETS_LIST` and `DATASETS_EXCLUDE` environment variables.
+
+In case API should expose only limited set of datasets - use `DATASETS_LIST` to load only provided datasets into memory.
+In case API should expose all datasets with exception to limited subset - use `DATASETS_EXCLUDE` to loxad all datasets except provided into memory.
+
+Both `DATASETS_LIST` and `DATASETS_EXCLUDE` variables should be used with great care, 
+as any relation to dataset outside of those loaded into memory will break API.

--- a/README.md
+++ b/README.md
@@ -118,10 +118,7 @@ To change from e.g. Django 3.0 to 3.1, update the version in `requirements.in` y
 
 # Development details
 
-Extra information on how to develop DSO-API locally can be found in [DEVELOPMENT.md](DEVELOPMENT)
-
-To import the latest database from acceptance (replace `<username>` with your
-username, assumes your public SSH key is known and you have appropriate level of access.
+Extra information on how to develop DSO-API locally can be found in [DEVELOPMENT](DEVELOPMENT.md)
 
 This command expects the private SSH key to be found in the ~/.ssh folder,
 in a file with the name datapunt.key (chmod 600):

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ for example sensitive information should not be published via Public APIs, but p
 This can be achieved by using `DATASETS_LIST` and `DATASETS_EXCLUDE` environment variables.
 Both variables accept comma separated list of dataset ids e.g. `bommen,gebieden,meldingen` etc.
 
-In case API should expose only limited set of datasets - use `DATASETS_LIST` to load only provided datasets into memory.
-In case API should expose all datasets with exception to limited subset - use `DATASETS_EXCLUDE` to load all datasets except provided into memory.
+* To expose only a subset of the datasets, use `DATASETS_LIST`.
+* To expose all datasets with some exceptions, use `DATASETS_EXCLUDE`.
 
 Both `DATASETS_LIST` and `DATASETS_EXCLUDE` variables should be used with great care, 
 as any relation to dataset outside of those loaded into memory will break API.

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -41,6 +41,17 @@ INITIALIZE_DYNAMIC_VIEWSETS = env.bool(
     default={"migrate", "makemigrations", "showmigrations"}.isdisjoint(sys.argv[1:]),
 )
 
+# -- Datasets
+
+# WARNING: use with care, dangerous settings.
+# Both DATASETS_LIST and DATASETS_EXCLUDE will limit list of datasets loaded into memory.
+#  Relations to datasets outside list are not loaded automatically,
+#  this means dso-api will break on pages where related datasets are missing.
+# DATASETS_LIST: will load only provided datasets into memory.
+# DATASETS_EXCLUDE: will load all datasets except provided in list.
+DATASETS_LIST = env.list("DATASETS_LIST", default=None)
+DATASETS_EXCLUDE = env.list("DATASETS_EXCLUDE", default=None)
+
 INTERNAL_IPS = ("127.0.0.1", "0.0.0.0")
 
 TIME_ZONE = "Europe/Amsterdam"

--- a/src/tests/test_dynamic_api/test_router.py
+++ b/src/tests/test_dynamic_api/test_router.py
@@ -29,3 +29,66 @@ def test_reload_delete(router, bommen_dataset):
 
     with pytest.raises(NoReverseMatch):
         assert reverse("dynamic_api:bommen-bommen-list")
+
+
+@pytest.mark.django_db
+def test_only_selected_datasets_loaded(
+    settings, router, bommen_dataset, gebieden_dataset, meldingen_dataset
+):
+    router.reload()
+    assert reverse(
+        "dynamic_api:bommen-bommen-list"
+    )  # Bommen dataset reverse works, as dataset is registered
+    assert reverse("dynamic_api:gebieden-buurten-list")
+    assert reverse("dynamic_api:meldingen-statistieken-list")
+
+    settings.DATASETS_LIST = ["gebieden", "meldingen"]
+
+    router.reload()
+    with pytest.raises(NoReverseMatch):
+        assert reverse("dynamic_api:bommen-bommen-list")
+    assert reverse("dynamic_api:gebieden-buurten-list")
+    assert reverse("dynamic_api:meldingen-statistieken-list")
+
+
+@pytest.mark.django_db
+def test_router_excludes_datasets(
+    settings, router, bommen_dataset, gebieden_dataset, meldingen_dataset
+):
+    router.reload()
+    assert reverse(
+        "dynamic_api:bommen-bommen-list"
+    )  # Bommen dataset reverse works, as dataset is registered
+    assert reverse("dynamic_api:gebieden-buurten-list")
+    assert reverse("dynamic_api:meldingen-statistieken-list")
+
+    settings.DATASETS_EXCLUDE = ["bommen"]
+
+    router.reload()
+    with pytest.raises(NoReverseMatch):
+        assert reverse("dynamic_api:bommen-bommen-list")
+    assert reverse("dynamic_api:gebieden-buurten-list")
+    assert reverse("dynamic_api:meldingen-statistieken-list")
+
+
+@pytest.mark.django_db
+def test_router_excludes_datasets_combined_with_list(
+    settings, router, bommen_dataset, gebieden_dataset, meldingen_dataset
+):
+    router.reload()
+    assert reverse(
+        "dynamic_api:bommen-bommen-list"
+    )  # Bommen dataset reverse works, as dataset is registered
+    assert reverse("dynamic_api:gebieden-buurten-list")
+    assert reverse("dynamic_api:meldingen-statistieken-list")
+
+    settings.DATASETS_LIST = ["gebieden"]
+    settings.DATASETS_EXCLUDE = ["bommen"]
+
+    router.reload()
+
+    assert reverse("dynamic_api:gebieden-buurten-list")
+    with pytest.raises(NoReverseMatch):
+        assert reverse("dynamic_api:bommen-bommen-list")
+    with pytest.raises(NoReverseMatch):
+        assert reverse("dynamic_api:meldingen-statistieken-list")

--- a/src/tests/test_dynamic_api/test_router.py
+++ b/src/tests/test_dynamic_api/test_router.py
@@ -82,7 +82,7 @@ def test_router_excludes_datasets_combined_with_list(
     assert reverse("dynamic_api:gebieden-buurten-list")
     assert reverse("dynamic_api:meldingen-statistieken-list")
 
-    settings.DATASETS_LIST = ["gebieden"]
+    settings.DATASETS_LIST = ["gebieden", "bommen"]
     settings.DATASETS_EXCLUDE = ["bommen"]
 
     router.reload()

--- a/src/tests/test_dynamic_api/test_router.py
+++ b/src/tests/test_dynamic_api/test_router.py
@@ -36,9 +36,9 @@ def test_only_selected_datasets_loaded(
     settings, router, bommen_dataset, gebieden_dataset, meldingen_dataset
 ):
     router.reload()
-    assert reverse(
-        "dynamic_api:bommen-bommen-list"
-    )  # Bommen dataset reverse works, as dataset is registered
+
+    # Bommen dataset reverse works, as dataset is registered
+    assert reverse("dynamic_api:bommen-bommen-list")
     assert reverse("dynamic_api:gebieden-buurten-list")
     assert reverse("dynamic_api:meldingen-statistieken-list")
 
@@ -56,9 +56,9 @@ def test_router_excludes_datasets(
     settings, router, bommen_dataset, gebieden_dataset, meldingen_dataset
 ):
     router.reload()
-    assert reverse(
-        "dynamic_api:bommen-bommen-list"
-    )  # Bommen dataset reverse works, as dataset is registered
+
+    # Bommen dataset reverse works, as dataset is registered
+    assert reverse("dynamic_api:bommen-bommen-list")
     assert reverse("dynamic_api:gebieden-buurten-list")
     assert reverse("dynamic_api:meldingen-statistieken-list")
 
@@ -76,9 +76,9 @@ def test_router_excludes_datasets_combined_with_list(
     settings, router, bommen_dataset, gebieden_dataset, meldingen_dataset
 ):
     router.reload()
-    assert reverse(
-        "dynamic_api:bommen-bommen-list"
-    )  # Bommen dataset reverse works, as dataset is registered
+
+    # Bommen dataset reverse works, as dataset is registered
+    assert reverse("dynamic_api:bommen-bommen-list")
     assert reverse("dynamic_api:gebieden-buurten-list")
     assert reverse("dynamic_api:meldingen-statistieken-list")
 


### PR DESCRIPTION
# This Pull request contains changes to:

Router loading mechanics, allowing limitation of datasets loaded into memory using `DATASETS_LIST` and/or `DATASETS_EXCLUDE` environment variables.

Can be used to split APIs with sensitive information from generic APIs on infrastructure level.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [x] Developer friendly documentation added into `DEVELOPMENT|README.md`

