### PR TITLE
Fix problem with multiple ? in urls

### DIFF
--- a/src/dso_api/dynamic_api/fields.py
+++ b/src/dso_api/dynamic_api/fields.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 import azure.storage.blob
 from django.conf import settings
+from more_ds.network.url import URL
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from schematools.utils import to_snake_case
@@ -38,7 +39,8 @@ class TemporalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
             else:
                 key = request.dataset_temporal_slice["key"]
                 value = request.dataset_temporal_slice["value"]
-            base_url = "{}?{}={}".format(base_url, key, value)
+
+            base_url = URL(base_url) // {key: value}
         else:
             kwargs = {self.lookup_field: obj.pk}
             base_url = self.reverse(view_name, kwargs=kwargs, request=request, format=format)
@@ -87,7 +89,7 @@ class TemporalLinksField(LinksField):
 
         temporal_identifier = dataset.temporal["identifier"]
         version = getattr(obj, temporal_identifier)
-        return "{}?{}={}".format(base_url, temporal_identifier, version)
+        return URL(base_url) // {temporal_identifier: version}
 
 
 class AzureBlobFileField(serializers.ReadOnlyField):

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,6 +13,7 @@ amsterdam-schema-tools[django] == 0.17.4
 datapunt-authorization-django==1.0.0
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0
+more-ds == 0.0.3
 psycopg2-binary == 2.8.4
 python-string-utils == 1.0.0
 readerwriterlock == 1.0.6

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -133,6 +133,8 @@ markupsafe==1.1.1
     # via jinja2
 mccabe==0.6.1
     # via flake8
+more-ds==0.0.3
+    # via -r requirements.in
 more-itertools==8.2.0
     # via pytest
 msrest==0.6.19

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -191,5 +191,11 @@ class TestViews:
         data = read_response_json(response)
 
         # Check if there is only one '?' in the temporal urls
-        assert len(data["_embedded"]["stadsdelen"][1]["_links"]["self"]["href"].split("?")) == 2
-        assert len(data["_embedded"]["stadsdelen"][1]["_links"]["wijk"][0]["href"].split("?")) == 2
+        fetch_query_keys = lambda url: set(parse.parse_qs(parse.urlparse(url).query).keys())
+        assert fetch_query_keys(data["_embedded"]["stadsdelen"][1]["_links"]["self"]["href"]) == {
+            "_format",
+            "volgnummer",
+        }
+        assert fetch_query_keys(
+            data["_embedded"]["stadsdelen"][1]["_links"]["wijk"][0]["href"]
+        ) == {"_format", "volgnummer"}

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -180,3 +180,16 @@ class TestViews:
         assert data["_links"]["bestaatUitBuurten"][0]["href"].endswith(expected_url), data[
             "bestaatUitBuurten"
         ]
+
+    def test_correct_handling_of_extra_url_params(
+        self, api_client, reloadrouter, stadsdelen, buurt
+    ):
+        """Prove that extra url parameters do not interfere with the existing
+        url parameters for temporality."""
+        url = reverse("dynamic_api:gebieden-stadsdelen-list")
+        response = api_client.get(f"{url}?_format=json")
+        data = read_response_json(response)
+
+        # Check if there is only one '?' in the temporal urls
+        assert len(data["_embedded"]["stadsdelen"][1]["_links"]["self"]["href"].split("?")) == 2
+        assert len(data["_embedded"]["stadsdelen"][1]["_links"]["wijk"][0]["href"].split("?")) == 2


### PR DESCRIPTION
When using url params like _format=json, the embedded
temporal urls were having  more than one '?' in the url, leading to invalid url.

# This Pull request contains changes to:

Fix invalid temporal url in the "_links" section of the HAL output.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extraq details describing reasoning: ...
