### PR TITLE
Fix empty generator content in the browsable API preview.

### DIFF
--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -143,7 +143,7 @@ class HALJSONRenderer(RendererMixin, renderers.JSONRenderer):
             # Using orjson.dumps(data, default) here doesn't work, as the dict ordering
             # isn't honored by orjson.
             for key, value in embedded.copy().items():
-                if inspect.isgenerator(value) or isinstance(value, itertools.chain):
+                if isinstance(value, (ReturnGenerator, GeneratorType, itertools.chain)):
                     embedded[key] = list(value)
 
         return orjson.dumps(data, option=orjson.OPT_INDENT_2)


### PR DESCRIPTION
Fixes the browsable API to show the expand field contents.