### PR TITLE
Add string filterset to URLs

### DIFF
--- a/src/dso_api/dynamic_api/filterset.py
+++ b/src/dso_api/dynamic_api/filterset.py
@@ -38,6 +38,7 @@ DEFAULT_LOOKUPS_BY_TYPE = {
     models.ForeignKey: _identifier_lookups,
     models.OneToOneField: _identifier_lookups,
     models.OneToOneRel: _identifier_lookups,
+    models.URLField: _string_lookups,
     ArrayField: ["contains"],
     PolygonField: _polygon_lookups,
     MultiPolygonField: _polygon_lookups,

--- a/src/tests/test_rest_framework_dso/models.py
+++ b/src/tests/test_rest_framework_dso/models.py
@@ -21,6 +21,7 @@ class Movie(models.Model, NonTemporalMixin):
     name = models.CharField(max_length=100)
     category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True)
     date_added = models.DateTimeField(null=True)
+    url = models.URLField(null=True)
 
     class Meta:
         app_label = "test_rest_framework_dso"


### PR DESCRIPTION
This patch adds the isnull, not, isempty and like filters to URL fields.

Fixes DS-501, which asks for these fields, except like. I could have dropped like, but it comes for free with the string filterset and it can be useful for finding, e.g., non-HTTPS URLs (`?url[like]=http:*`).

Has a unit test and works with a local copy of the bekendmakingen dataset.