### PR TITLE
[DS-317] Allow negative field specifiers

### DIFF
--- a/docs/source/generic/rest.rst
+++ b/docs/source/generic/rest.rst
@@ -119,7 +119,15 @@ Gebruik de :samp:`?_fields={veld1},{veld2},{...}` parameter om alleen specifieke
 
 .. code-block:: bash
 
-    curl 'https://api.data.amsterdam.nl/v1/bag/stadsdeel/?_fields=id,code,naam'
+    curl 'https://api.data.amsterdam.nl/v1/fietspaaltjes/fietspaaltjes/?fields=geometry,soortPaaltje'
+
+Als de veldnamen voorafgegaan worden door een minteken, dan worden alle velden behalve de genoemde
+opgestuurd:
+
+.. code-block:: bash
+
+    curl 'https://api.data.amsterdam.nl/v1/fietspaaltjes/fietspaaltjes/?fields=-area,-noodzaak'
+
 
 
 Filtering

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -157,7 +157,10 @@ def _get_viewset_api_docs(
         lines.extend(f"* {name}" for name in embedded_fields)
         lines.append("\nExpand everything using `_expand=true`.")
 
-    lines.append("\nUse `?_fields=field,field2` to limit which fields to receive")
+    lines.append(
+        "\nUse `?_fields=field1,field2` to limit which fields to receive,"
+        "\nor `?_fields=-field3,-field4` to exclude specific fields from the response"
+    )
 
     if ordering_fields:
         lines.append("\nUse `?_sort=field,field2,-field3` to sort on fields")

--- a/src/rest_framework_dso/filters.py
+++ b/src/rest_framework_dso/filters.py
@@ -571,10 +571,12 @@ class DSOFilterSetBackend(DjangoFilterBackend):
         """
         return ""
 
+    _NON_FIELDS = {"_fields", "_format", "_sort", "_pageSize", "_page_size"}
+
     def is_unfiltered(self, request):
         # If there are request parameters (except for this hard-coded exclude list),
         # they are assumed to be filters.
-        return {"_format", "_sort", "_pageSize", "_page_size"}.issuperset(request.GET.keys())
+        return request.GET.keys() <= self._NON_FIELDS
 
     def get_filterset(self, request, queryset, view):  # noqa: C901
         # Optimization: avoid creating the whole filterset, when nothing will be filtered.

--- a/src/tests/test_rest_framework_dso/test_filters.py
+++ b/src/tests/test_rest_framework_dso/test_filters.py
@@ -114,7 +114,7 @@ class TestDSOFilterSetBackend:
     def test_is_unfiltered(self, api_rf):
         """Prove that is_unfiltered() correctly detects non-standard fields"""
         backend = DSOFilterSetBackend()
-        assert backend.is_unfiltered(api_rf.get("/", data={"_format": "csv"}))
+        assert backend.is_unfiltered(api_rf.get("/", data={"_format": "csv", "_fields": "foo"}))
         assert backend.is_unfiltered(api_rf.get("/", data={"_pageSize": "100", "_format": "csv"}))
 
         assert not backend.is_unfiltered(api_rf.get("/", data={"field[in]": "foo"}))


### PR DESCRIPTION
# This Pull request contains changes to:

`_field=-foo,-bar` now causes all fields to be returned except for foo and bar.

Combining positive and negative mentions in the fields list is not allowed.

# In case changes new features added

- [x] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
