### PR TITLE
remove also relational temporal identifiers and fk relation field fro…

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -100,6 +100,7 @@ def filled_router(
     meldingen_dataset,
     gebieden_dataset,
     woningbouwplannen_dataset,
+    bag_dataset,
 ):
     # Prove that the router URLs are extended on adding a model
     router.reload()
@@ -122,6 +123,7 @@ def filled_router(
         meldingen_dataset: "meldingen_statistieken",
         gebieden_dataset: "gebieden_buurten",
         woningbouwplannen_dataset: "woningbouwplannen_woningbouwplan",
+        bag_dataset: "bag_panden",
     }
 
     # Based on datasets, create test table if not exists
@@ -636,6 +638,23 @@ def gebieden_dataset(gebieden_schema_json) -> Dataset:
 
 
 @pytest.fixture()
+def bag_schema_json() -> dict:
+    """ Fixture to return the schema json """
+    path = HERE / "files/bag.json"
+    return json.loads(path.read_text())
+
+
+@pytest.fixture()
+def bag_schema(bag_schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(bag_schema_json)
+
+
+@pytest.fixture()
+def bag_dataset(bag_schema_json) -> Dataset:
+    return Dataset.objects.create(name="bag", schema_data=bag_schema_json)
+
+
+@pytest.fixture()
 def woningbouwplannen_schema_json() -> dict:
     """ Fixture to return the schema json """
     path = HERE / "files/woningbouwplannen.json"
@@ -657,6 +676,16 @@ def woningbouwplannen_dataset(woningbouwplannen_schema_json) -> Dataset:
 @pytest.fixture()
 def statistieken_model(filled_router):
     return filled_router.all_models["meldingen"]["statistieken"]
+
+
+@pytest.fixture()
+def panden_model(filled_router):
+    return filled_router.all_models["bag"]["panden"]
+
+
+@pytest.fixture()
+def dossiers_model(filled_router):
+    return filled_router.all_models["bag"]["dossiers"]
 
 
 @pytest.fixture()
@@ -698,6 +727,17 @@ def buurten_data(buurten_model):
     buurten_model.objects.create(
         id="03630000000078.2", identificatie="03630000000078", volgnummer=2
     )
+
+
+@pytest.fixture()
+def panden_data(panden_model, dossiers_model):
+    panden_model.objects.create(
+        id="0363100012061164.3",
+        volgnummer=3,
+        identificatie="0363100012061164",
+        heeft_dossier_id="GV00000406",
+    )
+    dossiers_model.objects.create(dossier="GV00000406")
 
 
 @pytest.fixture()

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -1,0 +1,90 @@
+{
+  "type": "dataset",
+  "id": "bag",
+  "title": "bag",
+  "status": "niet_beschikbaar",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "identifier": "identificatie",
+  "temporal": {
+    "identifier": "volgnummer",
+    "dimensions": {
+      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+    }
+  },
+  "tables": [
+    {
+      "id": "panden",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bag/panden.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "id", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Landelijke identificerende sleutel."
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date-time",
+            "description": "De ingangsdatum van de geldigheid van een bepaalde combinatie van gegevens over een PAND."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date-time",
+            "description": "De einddatum van de geldigheid van een bepaalde combinatie van gegevens over een PAND."
+          },
+          "naam": {
+            "type": "string",
+            "description": "Naamgeving van een pand (bv. naam van metrostation of bijzonder gebouw)."
+          },
+          "heeftDossier": {
+            "type": "object",
+            "properties": {
+              "dossier": {
+                "type": "string"
+              }
+            },
+            "relation": "bag:dossiers",
+            "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
+          }
+        }
+      }
+    },
+    {
+      "id": "dossiers",
+      "type": "table",
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/bag/dossiers.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": "dossier",
+        "required": ["schema", "dossier"],
+        "display": "dossier",
+        "isTemporal": false,
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "dossier": {
+            "type": "string",
+            "description": "Verwijzing vanuit de overige objectklassen."
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -768,6 +768,86 @@ class TestEmbedTemporalTables:
             "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",
         }
 
+    def test_detail_no_expand_for_temporal_fk_relation(
+        self,
+        api_client,
+        reloadrouter,
+        buurten_model,
+        buurten_data,
+        wijken_data,
+    ):
+        """Prove that temporal identifier fields have been removed from the body
+        and only appear in the respective HAL envelopes"""
+
+        url = reverse("dynamic_api:gebieden-buurten-detail", args=["03630000000078.1"])
+        response = api_client.get(url)
+        data = read_response_json(response)
+        assert response.status_code == 200, data
+        assert data == {
+            "_links": {
+                "bestaatUitBuurtenGgwgebieden": [],
+                "buurtenWoningbouwplan": [],
+                "ligtInWijk": {
+                    "href": "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1",
+                    "identificatie": "03630012052035",
+                    "title": "03630012052035.1",
+                    "volgnummer": 1,
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#buurten",
+                "self": {
+                    "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=1",
+                    "identificatie": "03630000000078",
+                    "title": "03630000000078.1",
+                    "volgnummer": 1,
+                },
+            },
+            "beginGeldigheid": None,
+            "code": None,
+            "eindGeldigheid": None,
+            "geometrie": None,
+            "id": "03630000000078.1",
+            "ligtInWijkId": "03630012052035",
+            "naam": None,
+        }
+
+    def test_detail_no_expand_for_fk_relation(
+        self,
+        api_client,
+        reloadrouter,
+        buurten_model,
+        buurten_data,
+        wijken_data,
+        panden_model,
+        panden_data,
+    ):
+        """Prove that the FK identifier field (heeftDossierDossier) has been removed
+        from the body"""
+
+        url = reverse("dynamic_api:bag-panden-detail", args=["0363100012061164.3"])
+        response = api_client.get(url)
+        data = read_response_json(response)
+        assert response.status_code == 200, data
+        assert data == {
+            "_links": {
+                "heeftDossier": {
+                    "href": "http://testserver/v1/bag/dossiers/GV00000406/",
+                    "title": "GV00000406",
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/bag/bag#panden",
+                "self": {
+                    "href": "http://testserver/v1/bag/panden/0363100012061164/?volgnummer=3",
+                    "identificatie": "0363100012061164",
+                    "title": "0363100012061164.3",
+                    "volgnummer": 3,
+                },
+            },
+            "beginGeldigheid": None,
+            "eindGeldigheid": None,
+            "heeftDossierId": "GV00000406",
+            "id": "0363100012061164.3",
+            "naam": None,
+        }
+
     def test_list_expand_true_for_fk_relation(
         self,
         api_client,
@@ -852,8 +932,6 @@ class TestEmbedTemporalTables:
                 },
             },
             "geometrie": None,
-            "ligtInWijkVolgnummer": None,
-            "ligtInWijkIdentificatie": None,
             "naam": None,
             "code": None,
             "eindGeldigheid": None,
@@ -966,8 +1044,6 @@ class TestEmbedTemporalTables:
                     "code": None,
                     "naam": None,
                     "geometrie": None,
-                    "ligtInWijkVolgnummer": None,
-                    "ligtInWijkIdentificatie": None,
                     "eindGeldigheid": None,
                     "beginGeldigheid": None,
                     "id": "03630000000078.2",


### PR DESCRIPTION
Additional tweaks for the DSO/HAL output:
- relational temporal identifiers removed from the body; only in HAL envelope
- added test model for bag/panden and bag/dossiers for testing foreign key relations from temporal to non-temporal data.
- foreign key relation fields removed from the body; only in HAL envelope
