### PR TITLE
FIX using camelCase table names vs feature names in WFS

### DIFF
--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -46,7 +46,7 @@ from rest_framework_dso import crs
 
 FieldDef = Union[str, FeatureField]
 RE_SIMPLE_NAME = re.compile(
-    r"^(?P<ns>[a-z0-9]+:)?(?P<name>[a-z0-9]+)(?P<variant>-[a-z0-9]+)?$", re.I
+    r"^(?P<ns>[a-z0-9_]+:)?(?P<name>[a-z0-9_]+)(?P<variant>-[a-z0-9_]+)?$", re.I
 )
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -221,16 +221,10 @@ def afval_container(afval_container_model, afval_cluster):
 
 
 @pytest.fixture()
-def afval_adresloopafstand(afval_adresloopafstand_model, afval_cluster):
+def afval_adresloopafstand(afval_adresloopafstand_model):
     return afval_adresloopafstand_model.objects.create(
-        id=1,
-        serienummer="foobar-123",
-        eigenaar_naam="Dataservices",
-        # set to fixed dates to the CSV export can also check for desired formatting
-        datum_creatie=date(2021, 1, 3),
-        datum_leegmaken=get_current_timezone().localize(datetime(2021, 1, 3, 12, 13, 14)),
-        cluster=afval_cluster,
-        geometry=Point(10, 10),  # no SRID on purpose, should use django model field.
+        id=999,
+        serienummer="foobar-456",
     )
 
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -110,7 +110,7 @@ def filled_router(
     table_names = connection.introspection.table_names()
 
     datasets = {
-        afval_dataset: "afval_containers",
+        afval_dataset: "afval_clusters",
         bommen_dataset: "bommen_bommen",
         parkeervakken_dataset: "parkeervakken_parkeervakken",
         vestiging_dataset: "vestiging_vestiging",
@@ -201,8 +201,28 @@ def afval_container_model(filled_router):
 
 
 @pytest.fixture()
+def afval_adresloopafstand_model(filled_router):
+    # Using filled_router so all urls can be generated too.
+    return filled_router.all_models["afvalwegingen"]["adres_loopafstand"]
+
+
+@pytest.fixture()
 def afval_container(afval_container_model, afval_cluster):
     return afval_container_model.objects.create(
+        id=1,
+        serienummer="foobar-123",
+        eigenaar_naam="Dataservices",
+        # set to fixed dates to the CSV export can also check for desired formatting
+        datum_creatie=date(2021, 1, 3),
+        datum_leegmaken=get_current_timezone().localize(datetime(2021, 1, 3, 12, 13, 14)),
+        cluster=afval_cluster,
+        geometry=Point(10, 10),  # no SRID on purpose, should use django model field.
+    )
+
+
+@pytest.fixture()
+def afval_adresloopafstand(afval_adresloopafstand_model, afval_cluster):
+    return afval_adresloopafstand_model.objects.create(
         id=1,
         serienummer="foobar-123",
         eigenaar_naam="Dataservices",

--- a/src/tests/files/afval.json
+++ b/src/tests/files/afval.json
@@ -88,33 +88,14 @@
         "properties": {
           "id": {
             "type": "integer",
-            "description": "Container-ID"
+            "description": "row identifier"
           },
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
           },
-          "cluster": {
-            "type": "string",
-            "relation": "afvalwegingen:clusters",
-            "description": "Cluster-ID"
-          },
           "serienummer": {
             "type": "string",
-            "description": "Serienummer van container"
-          },
-          "eigenaar naam": {
-            "type": "string",
-            "description": "Naam van eigenaar"
-          },
-          "datum creatie": {
-            "type": "string",
-            "format": "date",
-            "description": "Datum aangemaakt"
-          },
-          "datum leegmaken": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Datum leeggemaakt"
+            "description": "some serienumber"
           },
           "geometry": {
             "$ref": "https://geojson.org/schema/Point.json",

--- a/src/tests/files/afval.json
+++ b/src/tests/files/afval.json
@@ -75,6 +75,53 @@
           }
         }
       }
+    },
+    {
+      "id": "adresLoopafstand",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "schema"],
+        "display": "id",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Container-ID"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
+          },
+          "cluster": {
+            "type": "string",
+            "relation": "afvalwegingen:clusters",
+            "description": "Cluster-ID"
+          },
+          "serienummer": {
+            "type": "string",
+            "description": "Serienummer van container"
+          },
+          "eigenaar naam": {
+            "type": "string",
+            "description": "Naam van eigenaar"
+          },
+          "datum creatie": {
+            "type": "string",
+            "format": "date",
+            "description": "Datum aangemaakt"
+          },
+          "datum leegmaken": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Datum leeggemaakt"
+          },
+          "geometry": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Geometrie"
+          }
+        }
+      }
     }
   ]
 }

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -19,7 +19,7 @@ class TestDatasetWFSView:
     def test_wfs_view(self, api_client, filled_router, afval_dataset, afval_container):
         wfs_url = (
             "/v1/wfs/afvalwegingen/"
-            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=containers"
+            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=app:containers"
             "&OUTPUTFORMAT=application/gml+xml"
         )
         response = api_client.get(wfs_url)
@@ -92,3 +92,18 @@ class TestDatasetWFSView:
             "geometry": None,
             "straatnaam": None,
         }
+
+    def test_wfs_feature_name(
+        self, api_client, filled_router, afval_dataset, afval_adresloopafstand
+    ):
+        """Prove that if feature name contains non-letters like underscore,
+        it can be useds find the correct table name and data
+        """
+        print("******", afval_adresloopafstand.__dict__)
+        wfs_url = (
+            "/v1/wfs/afvalwegingen/"
+            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=app:adres_loopafstand"
+            "&OUTPUTFORMAT=application/gml+xml"
+        )
+        response = api_client.get(wfs_url)
+        assert response.status_code == 200

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -108,7 +108,6 @@ class TestDatasetWFSView:
         assert response.status_code == 200
         xml_root = read_response_xml(response)
         data = xml_element_to_dict(xml_root[0][0])
-        print("****", data)
         assert data == {
             "name": "999",
             "id": "999",

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -99,7 +99,6 @@ class TestDatasetWFSView:
         """Prove that if feature name contains non-letters like underscore,
         it can be useds find the correct table name and data
         """
-        print("******", afval_adresloopafstand.__dict__)
         wfs_url = (
             "/v1/wfs/afvalwegingen/"
             "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=app:adres_loopafstand"
@@ -107,3 +106,12 @@ class TestDatasetWFSView:
         )
         response = api_client.get(wfs_url)
         assert response.status_code == 200
+        xml_root = read_response_xml(response)
+        data = xml_element_to_dict(xml_root[0][0])
+        print("****", data)
+        assert data == {
+            "name": "999",
+            "id": "999",
+            "geometry": None,
+            "serienummer": "foobar-456",
+        }


### PR DESCRIPTION
The use of underscore - as a result of camelCase table names - was not taken into account when building the WFS viewset.

This led to a 400 Bad Request error. Which was a result of not finding the table in the internal models due to the ignore of table names with underscores.

# This Pull request contains changes to:

DSO-API WFS view

# In case changes new features added
N.A.

# In case breaking changes introduced into API
N.A.

# In case this PR reverts changes in repo
N.A.
