### PR TITLE
Revert part of PR #209 - the fields removal logic was too aggressive

### DIFF
--- a/src/dso_api/dynamic_api/fields.py
+++ b/src/dso_api/dynamic_api/fields.py
@@ -73,6 +73,9 @@ class TemporalReadOnlyField(serializers.ReadOnlyField):
     """
 
     def to_representation(self, value):
+        """Remove the version number from the relation value,
+        typically done for RELATION_identificatie, RELATION_volgnummer fields.
+        """
         if "request" in self.parent.context and self.parent.context["request"].versioned:
             value = split_on_separator(value)[0]
         return value

--- a/src/dso_api/dynamic_api/filterset.py
+++ b/src/dso_api/dynamic_api/filterset.py
@@ -79,7 +79,7 @@ def filterset_factory(model: Type[DynamicModel]) -> Type[DynamicFilterSet]:
     fields = {
         f.attname: _get_field_lookups(f)
         for f in model._meta.get_fields()
-        if isinstance(f, (models.fields.Field, models.fields.related.ForeignKey))
+        if isinstance(f, (models.fields.Field, models.ForeignKey))
     }
 
     filters = generate_relation_filters(model)

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -315,26 +315,16 @@ class DynamicBodySerializer(DynamicSerializer):
         capitalized_identifier_fields = [
             identifier_field.capitalize() for identifier_field in hal_fields
         ]
-        fk_identifier_fields = []
         for field_name, field in fields.items():
             if isinstance(field, TemporalHyperlinkedRelatedField):
                 hal_fields.append(field_name)
                 hal_fields += [f"{field_name}{suffix}" for suffix in capitalized_identifier_fields]
-            elif isinstance(field, TemporalReadOnlyField):
-                fk_identifier_fields.append(field_name)
             elif isinstance(
                 field,
                 (HyperlinkedRelatedField, ManyRelatedField, LooseRelationUrlField),
             ):
                 hal_fields.append(field_name)
 
-        for fk_identifier_field in fk_identifier_fields:
-            root_field_name = fk_identifier_field[:-2]  # without "Id"
-            for field_name, field in fields.items():
-                if field_name not in fk_identifier_fields and field_name.startswith(
-                    root_field_name
-                ):
-                    hal_fields.append(field_name)
         return hal_fields
 
 

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -200,7 +200,7 @@ class DynamicSerializer(DSOModelSerializer):
     def build_property_field(self, field_name, model_class):
         field_class, field_kwargs = super().build_property_field(field_name, model_class)
         forward_map = model_class._meta._forward_fields_map.get(field_name)
-        if forward_map and isinstance(forward_map, models.fields.related.ForeignKey):
+        if forward_map and isinstance(forward_map, models.ForeignKey):
             field_class = TemporalReadOnlyField
 
         return field_class, field_kwargs

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -21,6 +21,7 @@ def snake_to_camel_case(key: str) -> str:
     return re.sub(RE_CAMELIZE, _underscore_to_camel, key)
 
 
-def split_on_separator(instr):
+def split_on_separator(value):
+    """Split on the last separator, which can be a dot or underscore."""
     # reversal is king
-    return [part[::-1] for part in PK_SPLIT.split(instr[::-1], 1)][::-1]
+    return [part[::-1] for part in PK_SPLIT.split(value[::-1], 1)][::-1]

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -810,44 +810,6 @@ class TestEmbedTemporalTables:
             "naam": None,
         }
 
-    def test_detail_no_expand_for_fk_relation(
-        self,
-        api_client,
-        reloadrouter,
-        buurten_model,
-        buurten_data,
-        wijken_data,
-        panden_model,
-        panden_data,
-    ):
-        """Prove that the FK identifier field (heeftDossierDossier) has been removed
-        from the body"""
-
-        url = reverse("dynamic_api:bag-panden-detail", args=["0363100012061164.3"])
-        response = api_client.get(url)
-        data = read_response_json(response)
-        assert response.status_code == 200, data
-        assert data == {
-            "_links": {
-                "heeftDossier": {
-                    "href": "http://testserver/v1/bag/dossiers/GV00000406/",
-                    "title": "GV00000406",
-                },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/bag/bag#panden",
-                "self": {
-                    "href": "http://testserver/v1/bag/panden/0363100012061164/?volgnummer=3",
-                    "identificatie": "0363100012061164",
-                    "title": "0363100012061164.3",
-                    "volgnummer": 3,
-                },
-            },
-            "beginGeldigheid": None,
-            "eindGeldigheid": None,
-            "heeftDossierId": "GV00000406",
-            "id": "0363100012061164.3",
-            "naam": None,
-        }
-
     def test_list_expand_true_for_fk_relation(
         self,
         api_client,


### PR DESCRIPTION
This code was obscuring a problem, as the schematools package generated additional "related" fields for objects that aren't temporaral (e.g. bag.panden.heeftDossier_dossier).  That logic should only be triggered for "identificatie" and "volgnummer".

Also, the string matching done here is extremely brittle and could easily remove other fields from the response. Which it did, as it completely broke the CSV inline fields for embedding relations.

Partially reverts 2dfdf75