### PR TITLE
Optimize querysets, allow prefetch-related on large sets

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,6 +13,7 @@ amsterdam-schema-tools[django] == 0.17.8
 datapunt-authorization-django==1.0.0
 drf-spectacular == 0.8.5
 jsonschema == 3.2.0
+lru_dict == 1.1.7
 more-ds == 0.0.3
 psycopg2-binary == 2.8.4
 python-string-utils == 1.0.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -125,6 +125,8 @@ jwcrypto==0.7
     # via datapunt-authorization-django
 lark-parser==0.7.8
     # via mappyfile
+lru_dict==1.1.7
+    # via -r requirements.in
 mappyfile==0.8.4
     # via amsterdam-schema-tools
 markdown==3.2.1

--- a/src/rest_framework_dso/embedding.py
+++ b/src/rest_framework_dso/embedding.py
@@ -6,8 +6,12 @@ the main objects are inspected while they are consumed by the output stream.
 """
 from __future__ import annotations
 
+from collections import defaultdict
+from itertools import islice
 from typing import Callable, Dict, Iterable, Iterator, List, Optional, TypeVar, Union
 
+from django.db import models
+from lru import LRU
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError, PermissionDenied
 
@@ -17,6 +21,8 @@ from rest_framework_dso.serializer_helpers import ReturnGenerator, peek_iterable
 
 EmbeddedFieldDict = Dict[str, AbstractEmbeddedField]
 T = TypeVar("T")
+M = TypeVar("M", bound=models.Model)
+DEFAULT_SQL_CHUNK_SIZE = 2000  # allow unit tests to alter this.
 
 
 def get_expanded_fields(  # noqa: C901
@@ -75,6 +81,95 @@ def _expand_parse_error(allowed_names, field_name):
             f"Eager loading is not supported for field '{field_name}', "
             f"available options are: {available}"
         )
+
+
+class ChunkedQuerySetIterator(Iterable[M]):
+    """An optimal strategy to perform ``prefetch_related()`` on large datasets.
+
+    It fetches data from the queryset in chunks,
+    and performs ``prefetch_related()`` behavior on each chunk.
+
+    Django's ``QuerySet.prefetch_related()`` works by loading the whole queryset into memory,
+    and performing an analysis of the related objects to fetch. When working on large datasets,
+    this is very inefficient as more memory is consumed. Instead, ``QuerySet.iterator()``
+    is preferred here as it returns instances while reading them. Nothing is stored in memory.
+    Hence, both approaches are fundamentally incompatible. This class performs a
+    mixed strategy: load a chunk, and perform prefetches for that particular batch.
+
+    As extra performance benefit, a local cache avoids prefetching the same records
+    again when the next chunk is analysed. It has a "least recently used" cache to avoid
+    flooding the caches when foreign keys constantly point to different unique objects.
+    """
+
+    def __init__(self, queryset: models.QuerySet, chunk_size=None, sql_chunk_size=None):
+        """
+        :param queryset: The queryset to iterate over, that has ``prefetch_related()`` data.
+        :param chunk_size: The size of each segment to analyse in-memory for related objects.
+        :param sql_chunk_size: The size of each segment to fetch from the database,
+            used when server-side cursors are not available. The default follows Django behavior.
+        """
+        self.queryset = queryset
+        self.sql_chunk_size = sql_chunk_size or DEFAULT_SQL_CHUNK_SIZE
+        self.chunk_size = chunk_size or self.sql_chunk_size
+        self._fk_caches = defaultdict(lambda: LRU(self.chunk_size // 2))
+
+    def __iter__(self):
+        # Using iter() ensures the ModelIterable is resumed with the next chunk.
+        qs_iter = iter(self.queryset.iterator(chunk_size=self.sql_chunk_size))
+
+        # Keep fetching chunks
+        while instances := list(islice(qs_iter, self.chunk_size)):
+            # Perform prefetches on this chunk:
+            if self.queryset._prefetch_related_lookups:
+                self._add_prefetches(instances)
+            yield from instances
+
+    def _add_prefetches(self, instances: List[M]):
+        """Merge the prefetched objects for this batch with the model instances."""
+        if self._fk_caches:
+            # Make sure prefetch_related_objects() doesn't have to fetch items again
+            # that infrequently changes (e.g. a "wijk" or "stadsdeel").
+            all_restored = self._restore_caches(instances)
+            if all_restored:
+                return
+
+        # Reuse the Django machinery for retrieving missing sub objects.
+        # and analyse the ForeignKey caches to allow faster prefetches next time
+        models.prefetch_related_objects(instances, *self.queryset._prefetch_related_lookups)
+        self._persist_prefetch_cache(instances)
+
+    def _persist_prefetch_cache(self, instances):
+        """Store the prefetched data so it can be applied to the next batch"""
+        for instance in instances:
+            for lookup, obj in instance._state.fields_cache.items():
+                if obj is not None:
+                    cache = self._fk_caches[lookup]
+                    cache[obj.pk] = obj
+
+    def _restore_caches(self, instances) -> bool:
+        """Restore prefetched data to the new set of instances.
+        This avoids unneeded prefetching of the same ForeignKey relation.
+        """
+        if not instances:
+            return True
+        if not self._fk_caches:
+            return False
+
+        all_restored = True
+
+        for lookup, cache in self._fk_caches.items():
+            field = instances[0]._meta.get_field(lookup)
+            for instance in instances:
+                id_value = getattr(instance, field.attname)
+                if id_value is None:
+                    continue
+
+                if (obj := cache.get(id_value, None)) is not None:
+                    instance._state.fields_cache[lookup] = obj
+                else:
+                    all_restored = False
+
+        return all_restored
 
 
 class ObservableIterator(Iterator[T]):


### PR DESCRIPTION
This performs prefetches in batches, leveraging Django's prefetch_related_objects() while using QuerySet.iterator() for performance.

As extra feature, the previously prefetched objects are reused so the next batch doens't have to refetch identical related objects.