### PR TITLE
CSV expand support

### DIFF
--- a/src/dso_api/dynamic_api/remote/serializers.py
+++ b/src/dso_api/dynamic_api/remote/serializers.py
@@ -34,7 +34,8 @@ JSON_TYPE_TO_DRF = {
 class RemoteListSerializer(DSOListSerializer):
     """ListSerializer that takes remote data"""
 
-    def get_expanded_fields(self):
+    @property
+    def expanded_fields(self):
         return {}
 
 

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -52,7 +52,7 @@ class AbstractEmbeddedField:
         """
         raise NotImplementedError()
 
-    def get_serializer(self, parent: serializers.Serializer) -> serializers.Serializer:
+    def get_serializer(self, parent: serializers.Serializer, **kwargs) -> serializers.Serializer:
         """Build the EmbeddedField serializer object that can generate an embedded result.
 
         Since this virtual-field object persists between all sessions,
@@ -61,7 +61,7 @@ class AbstractEmbeddedField:
         if not isinstance(parent, self.parent_serializer_class):
             raise TypeError(f"Invalid parent for {self.__class__.__name__}.get_serializer()")
 
-        embedded_serializer = self.serializer_class(context=parent.context)
+        embedded_serializer = self.serializer_class(context=parent.context, **kwargs)
         embedded_serializer.bind(field_name=self.field_name, parent=parent)
         return embedded_serializer
 
@@ -117,6 +117,10 @@ class EmbeddedField(AbstractEmbeddedField):
 
 class EmbeddedManyToManyField(AbstractEmbeddedField):
     """An embedded field for a n-m relation."""
+
+    def get_serializer(self, parent: serializers.Serializer, **kwargs) -> serializers.Serializer:
+        kwargs.setdefault("many", True)
+        return super().get_serializer(parent, **kwargs)
 
     def get_related_ids(self, instance):
         """Find the _id field value(s)"""

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -27,6 +27,9 @@ class AbstractEmbeddedField:
         self.field_name = None
         self.parent_serializer_class = None
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {self.field_name}>"
+
     def __set_name__(self, owner, name):
         from .serializers import _SideloadMixin
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -735,6 +735,7 @@ def panden_data(panden_model, dossiers_model):
         id="0363100012061164.3",
         volgnummer=3,
         identificatie="0363100012061164",
+        naam="Voorbeeldpand",
         heeft_dossier_id="GV00000406",
     )
     dossiers_model.objects.create(dossier="GV00000406")

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -51,13 +51,9 @@
             "description": "Naamgeving van een pand (bv. naam van metrostation of bijzonder gebouw)."
           },
           "heeftDossier": {
-            "type": "object",
-            "properties": {
-              "dossier": {
-                "type": "string"
-              }
-            },
+            "type": "string",
             "relation": "bag:dossiers",
+            "provenance": "$.heeftDossier.dossier",
             "description": "Het dossier op basis waarvan het object is toegevoegd aan de registratie."
           }
         }

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1241,7 +1241,7 @@ class TestExportFormats:
     }
 
     @pytest.mark.parametrize("format", sorted(UNPAGINATED_FORMATS.keys()))
-    def test_unpaginated_list(self, format, api_client, api_rf, afval_container, filled_router):
+    def test_unpaginated_list(self, format, api_client, afval_container, filled_router):
         """Prove that the export formats generate proper data."""
         decoder, expected_type, expected_data = self.UNPAGINATED_FORMATS[format]
         url = reverse("dynamic_api:afvalwegingen-containers-list")
@@ -1325,7 +1325,7 @@ class TestExportFormats:
     }
 
     @pytest.mark.parametrize("format", sorted(PAGINATED_FORMATS.keys()))
-    def test_paginated_list(self, format, api_client, api_rf, afval_container, filled_router):
+    def test_paginated_list(self, format, api_client, afval_container, filled_router):
         """Prove that the pagination still works if explicitly requested."""
         decoder, expected_type, expected_data = self.PAGINATED_FORMATS[format]
         url = reverse("dynamic_api:afvalwegingen-containers-list")
@@ -1378,7 +1378,7 @@ class TestExportFormats:
     }
 
     @pytest.mark.parametrize("format", sorted(EMPTY_FORMATS.keys()))
-    def test_empty_list(self, format, api_client, api_rf, filled_router):
+    def test_empty_list(self, format, api_client, filled_router):
         """Prove that empty list pages are properly serialized."""
         decoder, expected_type, expected_data = self.EMPTY_FORMATS[format]
         url = reverse("dynamic_api:afvalwegingen-containers-list")
@@ -1426,7 +1426,7 @@ class TestExportFormats:
     }
 
     @pytest.mark.parametrize("format", sorted(DETAIL_FORMATS.keys()))
-    def test_detail(self, format, api_client, api_rf, afval_container, filled_router):
+    def test_detail(self, format, api_client, afval_container, filled_router):
         """Prove that the detail view also returns an export of a single feature."""
         decoder, expected_type, expected_data = self.DETAIL_FORMATS[format]
         url = reverse(
@@ -1447,7 +1447,7 @@ class TestExportFormats:
         assert "X-Pagination-Page" not in response
 
     @pytest.mark.parametrize("format", sorted(DETAIL_FORMATS.keys()))
-    def test_detail_404(self, format, api_client, api_rf, filled_router):
+    def test_detail_404(self, format, api_client, filled_router):
         """Prove that error pages are also properly rendered.
         These are not rendered in the output format, but get a generic exception.
         """


### PR DESCRIPTION
The `DSOSerializer` incorporates the embedded-field serializers as regular fields when the output format needs to use inline embedding (e.g. for CSV). To make this performant, the prefetch was optimized in #216 (5e4b9f18f567f3ffddd2a2ccedeb86e6e5ee0515).

The serializer construction is improved to handle sub-resources well, and to avoid expanding their parameters. The many=True is needed to properly initialize inline M2M fields for an output renderer.

All output renderers can declare whether they support "inline" embeds, and whether the support M2M relations.