### PR TITLE
Include a GeoJSON id in the output, similar to what the WFS server does.

### DIFF
--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -212,3 +212,21 @@ class HALHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
     def to_representation(self, value):
         href = super().to_representation(value)
         return {"href": href, "title": str(value.pk)}
+
+
+class GeoJSONIdentifierField(serializers.Field):
+    """A field that renders the "id" field for a GeoJSON feature."""
+
+    def __init__(self, model=None, **kwargs):
+        kwargs["source"] = "*"
+        kwargs["read_only"] = True
+        super().__init__(**kwargs)
+        self.model = model
+
+    def bind(self, field_name, parent):
+        super().bind(field_name, parent)
+        if self.model is None:
+            self.model = parent.Meta.model
+
+    def to_representation(self, value):
+        return f"{self.model._meta.object_name}.{value.pk}"

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1221,6 +1221,7 @@ class TestExportFormats:
                 "features": [
                     {
                         "type": "Feature",
+                        "id": "containers.1",
                         "geometry": {
                             "type": "Point",
                             "coordinates": GEOJSON_POINT,
@@ -1294,6 +1295,7 @@ class TestExportFormats:
                 "features": [
                     {
                         "type": "Feature",
+                        "id": f"containers.{i}",
                         "geometry": {
                             "type": "Point",
                             "coordinates": GEOJSON_POINT,
@@ -1458,6 +1460,7 @@ class TestExportFormats:
             "application/geo+json; charset=utf-8",
             {
                 "type": "Feature",
+                "id": "containers.1",
                 "geometry": {
                     "coordinates": GEOJSON_POINT,
                     "type": "Point",


### PR DESCRIPTION
This PR is to solve some differences between the WFS and DSO API output.
It also allows to distinguish between normal and additionally returned objects when `?_embed=true` or `?_embedScope=..` is used.