### PR TITLE
Add content-disposition header for csv and geojson

### DIFF
--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -77,6 +77,9 @@ class RendererMixin:
         else:
             return f"/* Aborted by {exception.__class__.__name__} during rendering! */\n"
 
+    def get_content_disposition(self, filename):
+        return None
+
 
 class BrowsableAPIRenderer(RendererMixin, renderers.BrowsableAPIRenderer):
     def get_context(self, data, accepted_media_type, renderer_context):
@@ -265,6 +268,9 @@ class CSVRenderer(RendererMixin, CSVStreamingRenderer):
             return f"\n\nAborted by {exception.__class__.__name__}: {exception}\n"
         else:
             return f"\n\nAborted by {exception.__class__.__name__} during rendering!\n"
+
+    def get_content_disposition(self, filename):
+        return f'attachment; filename="{filename}.csv"'
 
 
 class GeoJSONRenderer(RendererMixin, renderers.JSONRenderer):
@@ -457,6 +463,9 @@ class GeoJSONRenderer(RendererMixin, renderers.JSONRenderer):
             (key for key, value in properties.items() if isinstance(value, GeoJsonDict)),
             None,
         )
+
+    def get_content_disposition(self, filename):
+        return f'attachment; filename="{filename}.json"'
 
 
 def _chunked_output(stream, chunk_size=DEFAULT_CHUNK_SIZE, write_exception=None):

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from datetime import datetime
 from inspect import isgeneratorfunction
 from typing import Optional, Type, Union
 
@@ -326,6 +327,17 @@ class DSOViewMixin:
         # check what 'response.rendered_content' returns as that invokes the rendering.
         if isgeneratorfunction(response.accepted_renderer.render):
             response = StreamingResponse.from_response(response)
+
+        if hasattr(response.accepted_renderer, "get_content_disposition"):
+            try:
+                now = datetime.now().isoformat()
+                filename = f"{self.dataset_id}-{self.table_id}-{now}"
+            except AttributeError:
+                filename = "file"
+            content_disposition = response.accepted_renderer.get_content_disposition(filename)
+
+            if content_disposition is not None:
+                response["Content-Disposition"] = content_disposition
 
         return response
 

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from datetime import datetime
 from inspect import isgeneratorfunction
 from typing import Optional, Type, Union
 
@@ -328,16 +327,13 @@ class DSOViewMixin:
         if isgeneratorfunction(response.accepted_renderer.render):
             response = StreamingResponse.from_response(response)
 
-        if hasattr(response.accepted_renderer, "get_content_disposition"):
+        if hasattr(response.accepted_renderer, "finalize_response"):
+            renderer_context = {}
             try:
-                now = datetime.now().isoformat()
-                filename = f"{self.dataset_id}-{self.table_id}-{now}"
+                renderer_context = {"dataset_id": self.dataset_id, "table_id": self.table_id}
             except AttributeError:
-                filename = "file"
-            content_disposition = response.accepted_renderer.get_content_disposition(filename)
-
-            if content_disposition is not None:
-                response["Content-Disposition"] = content_disposition
+                pass
+            response = response.accepted_renderer.finalize_response(response, renderer_context)
 
         return response
 

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1184,6 +1184,8 @@ class TestExportFormats:
         data = decoder(response.getvalue())
         assert data == expected_data
         assert response["Content-Type"] == expected_type  # And test after reading
+        assert "attachment" in response.get("Content-Disposition")
+        assert "afvalwegingen-containers" in response.get("Content-Disposition")
 
         # Paginator was not triggered
         assert "X-Pagination-Page" not in response
@@ -1335,6 +1337,9 @@ class TestExportFormats:
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         assert response["Content-Type"] == "text/csv; charset=utf-8"  # Test before reading stream
+        assert "attachment" in response.get("Content-Disposition")
+        assert "afvalwegingen-containers" in response.get("Content-Disposition")
+
         assert response.status_code == 200, response.getvalue()
         assert isinstance(response, StreamingResponse)
         data = read_response(response)

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1184,8 +1184,9 @@ class TestExportFormats:
         data = decoder(response.getvalue())
         assert data == expected_data
         assert response["Content-Type"] == expected_type  # And test after reading
-        assert "attachment" in response.get("Content-Disposition")
-        assert "afvalwegingen-containers" in response.get("Content-Disposition")
+        assert response["Content-Disposition"].startswith(
+            'attachment; filename="afvalwegingen-containers'
+        )
 
         # Paginator was not triggered
         assert "X-Pagination-Page" not in response
@@ -1337,8 +1338,9 @@ class TestExportFormats:
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         assert response["Content-Type"] == "text/csv; charset=utf-8"  # Test before reading stream
-        assert "attachment" in response.get("Content-Disposition")
-        assert "afvalwegingen-containers" in response.get("Content-Disposition")
+        assert response["Content-Disposition"].startswith(
+            'attachment; filename="afvalwegingen-containers'
+        )
 
         assert response.status_code == 200, response.getvalue()
         assert isinstance(response, StreamingResponse)


### PR DESCRIPTION
# This Pull request contains changes to:

Add content-disposition header for csv and geojson download.
For a more user-friendly behaviour when downloading in the browser

Filename of the download is constructed based on {dataset_id}-{table_id}-{timestamp} if available.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
