### PR TITLE
Build dev docs and run them locally in docker.

### DIFF
--- a/Dockerfile-dev-docs
+++ b/Dockerfile-dev-docs
@@ -12,7 +12,6 @@ WORKDIR /docs
 COPY dev-docs/requirements.txt /docs
 RUN pip install -r requirements.txt
 
-COPY dev-docs/.gitconfig /root/
 COPY dev-docs/ /docs/
 COPY src/ /sources/
 RUN pip install -e /sources/

--- a/Dockerfile-dev-docs
+++ b/Dockerfile-dev-docs
@@ -25,4 +25,4 @@ RUN mkdir -p /docs/_static \
 # Static serving runtime
 FROM nginx
 RUN mkdir -p /usr/share/nginx/html/v1/docs/
-COPY --from=builder /docs/build/html/ /usr/share/nginx/html/v1/docs/
+COPY --from=builder /docs/build/html/ /usr/share/nginx/html/

--- a/DockerfileDevDocs
+++ b/DockerfileDevDocs
@@ -1,0 +1,29 @@
+FROM amsterdam/python:3.8-buster AS builder
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      graphviz \
+      fonts-liberation \
+      make \
+      git \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /docs
+COPY dev-docs/requirements.txt /docs
+RUN pip install -r requirements.txt
+
+COPY dev-docs/.gitconfig /root/
+COPY dev-docs/ /docs/
+COPY src/ /sources/
+RUN pip install -e /sources/
+RUN pip install -r /sources/requirements_dev.txt
+
+# Added arg here, so build step is invalidated each time
+ARG BUILD_NUMBER=unknown
+RUN mkdir -p /docs/_static \
+ && make html
+
+# Static serving runtime
+FROM nginx
+RUN mkdir -p /usr/share/nginx/html/v1/docs/
+COPY --from=builder /docs/build/html/ /usr/share/nginx/html/v1/docs/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node {
         tryStep "build dev docs", {
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                 docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
-                    def image = docker.build("datapunt/dataservices/dso-api-dev-docs:${env.BUILD_NUMBER}", "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} -f DockerfileDevDocs")
+                    def image = docker.build("datapunt/dataservices/dso-api-dev-docs:${env.BUILD_NUMBER}", "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} -f Dockerfile-dev-docs")
                     image.push()
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,17 @@ node {
             }
         }
     }
+
+    stage("Build Dev-Docs image") {
+        tryStep "build dev docs", {
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
+                    def image = docker.build("datapunt/dataservices/dso-api-dev-docs:${env.BUILD_NUMBER}", "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} -f DockerfileDevDocs")
+                    image.push()
+                }
+            }
+        }
+    }
 }
 
 
@@ -68,6 +79,13 @@ if (BRANCH == "master") {
             tryStep "docs image tagging", {
                 docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
                     def image = docker.image("datapunt/dataservices/dso-api-docs:${env.BUILD_NUMBER}")
+                    image.pull()
+                    image.push("acceptance")
+                }
+            }
+            tryStep "dev-docs image tagging", {
+                docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
+                    def image = docker.image("datapunt/dataservices/dso-api-dev-docs:${env.BUILD_NUMBER}")
                     image.pull()
                     image.push("acceptance")
                 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
   dev-docs:
     build:
       context:  .
-      dockerfile: DockerfileDevDocs
+      dockerfile: Dockerfile-dev-docs
     environment:
       PYTHONPATH: "/dev-docs/"
       DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,3 +64,16 @@ services:
       - "./docs/build/html:/usr/share/nginx/html"
     ports:
       - "8081:80"
+
+  dev-docs:
+    build:
+      context:  .
+      dockerfile: DockerfileDevDocs
+    environment:
+      PYTHONPATH: "/dev-docs/"
+      DATABASE_URL: "postgres://dataservices:insecure@database/dataservices"
+    volumes:
+      - "./dev-docs:/docs"
+      - "./dev-docs/build/html:/usr/share/nginx/html"
+    ports:
+      - "8082:80"


### PR DESCRIPTION
# This Pull request contains changes to:

Automated build of dev docs.

It also includes building of image using jenkins, making it ready to deploy docs to publicly accessible location.

What needs to be done in the future:
 - Deployment should be done via OpenStack.

However if starting `docker-compose up dev-docs` you will be able to see docs, which makes me wonder: do we need these docs served somewhere on amsterdam.nl?