### PR TITLE
WFS unauthorized gives 500 -> give 403

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -4,6 +4,7 @@ from typing import Dict, Set
 from cachetools.func import ttl_cache
 from django.contrib.auth.models import AnonymousUser, _user_has_perm
 from rest_framework import permissions
+from rest_framework.viewsets import ViewSetMixin
 from schematools.contrib.django import models
 from schematools.utils import to_snake_case, toCamelCase
 
@@ -84,7 +85,8 @@ class HasOAuth2Scopes(permissions.BasePermission):
         scopes = fetch_scopes_for_dataset_table(dataset_id, table_id)
         if request.is_authorized_for(*scopes.table):
             return True  # authorized by scope
-        else:
+        # Check for DRF classes (not WFS, MVT).
+        elif isinstance(view, ViewSetMixin):
             if view.action_map["get"] == "retrieve":  # is a detailview
                 request.auth_profile.valid_query_params = (
                     request.auth_profile.get_valid_query_params() + view.table_schema.identifier

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -58,6 +58,26 @@ class TestDatasetWFSView:
             "straatnaam": None,
         }
 
+    def test_wfs_model_auth(
+        self, api_client, parkeervakken_schema, parkeervakken_parkeervak_model
+    ):
+        models.DatasetTable.objects.filter(name="parkeervakken").update(auth="TEST/SCOPE")
+        parkeervakken_parkeervak_model.objects.create(
+            id=1,
+            type="Langs",
+            soort="NIET FISCA",
+            aantal="1.0",
+            e_type="E666",
+        )
+
+        wfs_url = (
+            "/v1/wfs/parkeervakken/"
+            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=parkeervakken"
+            "&OUTPUTFORMAT=application/gml+xml"
+        )
+        response = api_client.get(wfs_url)
+        assert response.status_code == 403
+
     def test_wfs_field_auth(
         self, api_client, parkeervakken_schema, parkeervakken_parkeervak_model
     ):


### PR DESCRIPTION
# This Pull request contains changes to:

Permissions checks. HasOAuth2Scopes assumes it deals with DRF classes, but DatasetWFSView isn't one so it crashes with an AttributeError/HTTP 500 instead of 403.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
