### PR TITLE
Use str.format for remote endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Meaning, that requests for it are proxied to another API;
 an API that we apparently cannot access at this moment.
 To address the error we need to point requests for that dataset to another valid URL:
 
-    ./manage.py change_dataset hcbrk --endpoint-url=http://google.com
+    ./manage.py change_dataset hcbrk --endpoint-url='http://example.com/{table_id}/'
 
 # Run the server
 

--- a/src/dso_api/dynamic_api/remote/views.py
+++ b/src/dso_api/dynamic_api/remote/views.py
@@ -153,7 +153,7 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
         if query_params:
             url = urljoin(self.endpoint_url, "?" + urlencode(query_params))
 
-        url = url.replace("{table_id}", self.table_id)
+        url = url.format(table_id=self.table_id)
 
         # Using urllib directly instead of requests for performance
         logger.debug("Forwarding call to %s", url)


### PR DESCRIPTION
# This Pull request contains changes to:

Remote views. Their URLs were constructed by str.replace, instead of the more strict str.format.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [x] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
