### PR TITLE
Make URL creation in RemoteViewSet more robust

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -334,7 +334,7 @@ def brp_schema(brp_schema_json) -> DatasetSchema:
 
 @pytest.fixture()
 def brp_endpoint_url() -> str:
-    return "http://remote-server/unittest/brp/ingeschrevenpersonen/"
+    return "http://remote-server/unittest/brp/{table_id}"
 
 
 @pytest.fixture()

--- a/src/tests/test_dynamic_api/remote/test_views.py
+++ b/src/tests/test_dynamic_api/remote/test_views.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from schematools.contrib.django import models
 from urllib3_mock import Responses
 
+from dso_api.dynamic_api.remote import remote_viewset_factory
 from tests.utils import read_response_json
 
 DEFAULT_RESPONSE = {
@@ -333,3 +334,18 @@ def test_remote_timeout(api_client, router, brp_dataset, urllib3_mocker):
         "detail": "Connection failed (server timeout)",
         "status": 504,
     }
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        ("http://remote", "http://remote/foo?bar=baz"),
+        ("http://remote/", "http://remote/foo?bar=baz"),
+        ("http://remote/quux/{table_id}", "http://remote/quux/mytable/foo?bar=baz"),
+        ("http://remote/quux/{table_id}/", "http://remote/quux/mytable/foo?bar=baz"),
+    ],
+)
+def test_make_url(case):
+    base, expect = case
+    viewset = remote_viewset_factory(base, type(None), None, "mytable", None)()
+    assert viewset._make_url("foo", {"bar": "baz"}) == expect


### PR DESCRIPTION
# This Pull request contains changes to:

URL creation in `RemoteViewSet`. It now works with or without trailing slash and is properly tested.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
