### PR TITLE
Get auth scopes from schema in MVT tests

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -349,6 +349,35 @@ def brp_dataset(brp_schema_json, brp_endpoint_url) -> Dataset:
     )
 
 
+@pytest.fixture()
+def geometry_auth_schema_json() -> dict:
+    return json.loads((HERE / "files" / "geometry_auth.json").read_text())
+
+
+@pytest.fixture()
+def geometry_auth_schema(geometry_auth_schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(geometry_auth_schema_json)
+
+
+@pytest.fixture()
+def geometry_auth_dataset(geometry_auth_schema):
+    return Dataset.create_for_schema(schema=geometry_auth_schema)
+
+
+@pytest.fixture()
+def geometry_auth_model(geometry_auth_dataset, dynamic_models):
+    return dynamic_models["geometry_auth"]["things"]
+
+
+@pytest.fixture()
+def geometry_auth_thing(geometry_auth_model):
+    return geometry_auth_model.objects.create(
+        id=1,
+        metadata="secret",
+        geometry=Point(10, 10),
+    )
+
+
 @pytest.fixture
 def category() -> Category:
     """A dummy model to test our API with"""

--- a/src/tests/files/geometry_auth.json
+++ b/src/tests/files/geometry_auth.json
@@ -1,0 +1,37 @@
+{
+  "id": "geometry_auth",
+  "type": "dataset",
+  "title": "Geometry authorization test",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "things",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["id", "schema"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Identifier"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
+          },
+          "metadata": {
+            "type": "string",
+            "auth": "TEST/META",
+            "description": ""
+          },
+          "geometry": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "auth": "TEST/GEO",
+            "description": "Geometrie"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_views_mvt.py
+++ b/src/tests/test_dynamic_api/test_views_mvt.py
@@ -1,6 +1,5 @@
 import mapbox_vector_tile
 import pytest
-from schematools.contrib.django import models
 
 from dso_api.dynamic_api.permissions import fetch_scopes_for_dataset_table, fetch_scopes_for_model
 
@@ -12,83 +11,86 @@ def clear_caches():
     fetch_scopes_for_model.cache_clear()
 
 
+CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
+
+
 @pytest.mark.django_db
-class TestDatasetMVTView:
+def test_mvt_index(api_client, afval_container, filled_router):
+    """Prove that the MVT index view works."""
+    response = api_client.get("/v1/mvt/")
+    assert response.status_code == 200
+    assert b"/v1/mvt/afvalwegingen/containers/{z}/{x}/{y}.pbf" in response.content
+
+
+@pytest.mark.django_db
+def test_mvt_content(api_client, afval_container, filled_router):
     """Prove that the MVT view produces vector tiles."""
+    url = "/v1/mvt/afvalwegingen/containers/1/0/0.pbf"
+    response = api_client.get(url)
+    # MVT view returns 204 when the tile is empty.
+    assert response.status_code == 200
+    assert response["Content-Type"] == CONTENT_TYPE
 
-    CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
-    URL = "/v1/mvt/afvalwegingen/containers/1/0/0.pbf"
+    vt = mapbox_vector_tile.decode(response.content)
 
-    def test_mvt_index(self, api_client, afval_container, filled_router):
-        response = api_client.get("/v1/mvt/")
-        assert response.status_code == 200
-        assert b"/v1/mvt/afvalwegingen/containers/{z}/{x}/{y}.pbf" in response.content
-
-    def test_mvt_content(self, api_client, afval_container, filled_router):
-        response = api_client.get(self.URL)
-        assert response["Content-Type"] == self.CONTENT_TYPE
-        # MVT view returns 204 when the tile is empty.
-        assert response.status_code == 200
-
-        vt = mapbox_vector_tile.decode(response.content)
-
-        assert vt == {
-            "default": {
-                "extent": 4096,
-                "version": 2,
-                "features": [
-                    {
-                        "geometry": {"type": "Point", "coordinates": [4171, 1247]},
-                        "properties": {
-                            "id": 1,
-                            "cluster_id": "c1",
-                            "serienummer": "foobar-123",
-                            "datum_creatie": "2021-01-03",
-                            "eigenaar_naam": "Dataservices",
-                            "datum_leegmaken": "2021-01-03 12:13:14+01",
-                        },
-                        "id": 0,
-                        "type": 1,
-                    }
-                ],
-            }
+    assert vt == {
+        "default": {
+            "extent": 4096,
+            "version": 2,
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [4171, 1247]},
+                    "properties": {
+                        "id": 1,
+                        "cluster_id": "c1",
+                        "serienummer": "foobar-123",
+                        "datum_creatie": "2021-01-03",
+                        "eigenaar_naam": "Dataservices",
+                        "datum_leegmaken": "2021-01-03 12:13:14+01",
+                    },
+                    "id": 0,
+                    "type": 1,
+                }
+            ],
         }
+    }
 
-    def test_mvt_forbidden(self, api_client, afval_container, filled_router):
-        """Prove that an unauthorized geometry field gives 403 Forbidden"""
 
-        models.DatasetField.objects.filter(table__name="containers", name="geometry").update(
-            auth="TEST/SCOPE"
-        )
-        response = api_client.get(self.URL)
-        assert response.status_code == 403
+@pytest.mark.django_db
+def test_mvt_forbidden(api_client, geometry_auth_thing, fetch_auth_token, filled_router):
+    """Prove that an unauthorized geometry field gives 403 Forbidden"""
 
-    def test_mvt_model_auth(self, api_client, afval_container, filled_router):
-        """Prove that unauthorized fields are excluded from vector tiles"""
+    # Get authorization for the meta field, but not the geometry field.
+    token = fetch_auth_token(["TEST/META"])
 
-        for name in ("datum_leegmaken", "eigenaar_naam", "serienummer"):
-            models.DatasetField.objects.filter(table__name="containers", name=name).update(
-                auth="TEST/SCOPE"
-            )
+    url = "/v1/mvt/geometry_auth/things/1/0/0.pbf"
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+    assert response.status_code == 403
 
-        response = api_client.get(self.URL)
-        assert response.status_code == 200
 
-        assert mapbox_vector_tile.decode(response.content) == {
-            "default": {
-                "extent": 4096,
-                "version": 2,
-                "features": [
-                    {
-                        "geometry": {"type": "Point", "coordinates": [4171, 1247]},
-                        "properties": {
-                            "id": 1,
-                            "cluster_id": "c1",
-                            "datum_creatie": "2021-01-03",
-                        },
-                        "id": 0,
-                        "type": 1,
-                    }
-                ],
-            }
+@pytest.mark.django_db
+def test_mvt_model_auth(api_client, geometry_auth_thing, fetch_auth_token, filled_router):
+    """Prove that unauthorized fields are excluded from vector tiles"""
+
+    # Get authorization for the geometry field, but not the meta field.
+    token = fetch_auth_token(["TEST/GEO"])
+
+    url = "/v1/mvt/geometry_auth/things/1/0/0.pbf"
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+    assert response.status_code == 200
+    assert response["Content-Type"] == CONTENT_TYPE
+
+    assert mapbox_vector_tile.decode(response.content) == {
+        "default": {
+            "extent": 4096,
+            "version": 2,
+            "features": [
+                {
+                    "geometry": {"type": "Point", "coordinates": [4171, 1247]},
+                    "id": 0,
+                    "properties": {"id": 1},
+                    "type": 1,
+                }
+            ],
         }
+    }


### PR DESCRIPTION
# This Pull request contains changes to:

MVT tests. This is the first step toward getting authorization scopes from the schema instead of the models.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
