### PR TITLE
Test multiple required scopes in MVT auth test

### DIFF
--- a/src/tests/files/geometry_auth.json
+++ b/src/tests/files/geometry_auth.json
@@ -27,7 +27,7 @@
           },
           "geometry": {
             "$ref": "https://geojson.org/schema/Point.json",
-            "auth": "TEST/GEO",
+            "auth": "TEST/GEO1,TEST/GEO2",
             "description": "Geometrie"
           }
         }


### PR DESCRIPTION
# This Pull request contains changes to:

Authorization tests. The MVT test now requires two scopes to access the geometry field.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
