### PR TITLE
Run WFS auth tests on custom schemas

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -349,6 +349,9 @@ def brp_dataset(brp_schema_json, brp_endpoint_url) -> Dataset:
     )
 
 
+# Dataset with auth scopes on fields.
+
+
 @pytest.fixture()
 def geometry_auth_schema_json() -> dict:
     return json.loads((HERE / "files" / "geometry_auth.json").read_text())
@@ -372,6 +375,38 @@ def geometry_auth_model(geometry_auth_dataset, dynamic_models):
 @pytest.fixture()
 def geometry_auth_thing(geometry_auth_model):
     return geometry_auth_model.objects.create(
+        id=1,
+        metadata="secret",
+        geometry=Point(10, 10),
+    )
+
+
+# Dataset with auth scopes on the entire dataset.
+
+
+@pytest.fixture()
+def geometry_authdataset_schema_json() -> dict:
+    return json.loads((HERE / "files" / "geometry_authdataset.json").read_text())
+
+
+@pytest.fixture()
+def geometry_authdataset_schema(geometry_authdataset_schema_json) -> DatasetSchema:
+    return DatasetSchema.from_dict(geometry_authdataset_schema_json)
+
+
+@pytest.fixture()
+def geometry_authdataset_dataset(geometry_authdataset_schema):
+    return Dataset.create_for_schema(schema=geometry_authdataset_schema)
+
+
+@pytest.fixture()
+def geometry_authdataset_model(geometry_authdataset_dataset, dynamic_models):
+    return dynamic_models["geometry_authdataset"]["things"]
+
+
+@pytest.fixture()
+def geometry_authdataset_thing(geometry_authdataset_model):
+    return geometry_authdataset_model.objects.create(
         id=1,
         metadata="secret",
         geometry=Point(10, 10),

--- a/src/tests/files/geometry_authdataset.json
+++ b/src/tests/files/geometry_authdataset.json
@@ -1,0 +1,36 @@
+{
+  "id": "geometry_authdataset",
+  "type": "dataset",
+  "title": "Geometry authorization test with dataset scopes",
+  "version": "0.0.1",
+  "auth": "TEST/TOP1,TEST/TOP2",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "things",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["id", "schema"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Identifier"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
+          },
+          "metadata": {
+            "type": "string",
+            "description": ""
+          },
+          "geometry": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Geometrie"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -1,5 +1,6 @@
+from typing import List
+
 import pytest
-from schematools.contrib.django import models
 from schematools.contrib.django.db import create_tables
 
 from dso_api.dynamic_api.permissions import fetch_scopes_for_dataset_table, fetch_scopes_for_model
@@ -52,61 +53,6 @@ class TestDatasetWFSView:
             "id": "1",
             "type": "Langs",
             "e_type": "E666",
-            "soort": "NIET FISCA",
-            "aantal": "1.0",
-            "buurtcode": None,
-            "geometry": None,
-            "straatnaam": None,
-        }
-
-    def test_wfs_model_auth(
-        self, api_client, parkeervakken_schema, parkeervakken_parkeervak_model
-    ):
-        models.DatasetTable.objects.filter(name="parkeervakken").update(auth="TEST/SCOPE")
-        parkeervakken_parkeervak_model.objects.create(
-            id=1,
-            type="Langs",
-            soort="NIET FISCA",
-            aantal="1.0",
-            e_type="E666",
-        )
-
-        wfs_url = (
-            "/v1/wfs/parkeervakken/"
-            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=parkeervakken"
-            "&OUTPUTFORMAT=application/gml+xml"
-        )
-        response = api_client.get(wfs_url)
-        assert response.status_code == 403
-
-    def test_wfs_field_auth(
-        self, api_client, parkeervakken_schema, parkeervakken_parkeervak_model
-    ):
-        models.DatasetField.objects.filter(table__name="parkeervakken", name="e_type").update(
-            auth="TEST/SCOPE"
-        )
-        parkeervakken_parkeervak_model.objects.create(
-            id=1,
-            type="Langs",
-            soort="NIET FISCA",
-            aantal="1.0",
-            e_type="E666",
-        )
-
-        wfs_url = (
-            "/v1/wfs/parkeervakken/"
-            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=parkeervakken"
-            "&OUTPUTFORMAT=application/gml+xml"
-        )
-        response = api_client.get(wfs_url)
-        assert response.status_code == 200
-        xml_root = read_response_xml(response)
-        data = xml_element_to_dict(xml_root[0][0])
-
-        assert "e_type" not in data.keys()
-        assert data == {
-            "id": "1",
-            "type": "Langs",
             "soort": "NIET FISCA",
             "aantal": "1.0",
             "buurtcode": None,
@@ -180,3 +126,74 @@ class TestDatasetWFSView:
         )
         response = api_client.get(wfs_url)
         assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestDatasetWFSViewAuth:
+    @staticmethod
+    def request(client, fetch_auth_token, dataset: str, scopes: List[str]) -> str:
+        url = (
+            f"/v1/wfs/{dataset}/"
+            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=things"
+            "&OUTPUTFORMAT=application/gml+xml"
+        )
+        token = fetch_auth_token(scopes)
+        return client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    @staticmethod
+    def parse_response(response) -> dict:
+        xml_root = read_response_xml(response)
+        return xml_element_to_dict(xml_root[0][0])
+
+    def test_wfs_model_unauthorized(
+        self, api_client, geometry_authdataset_thing, fetch_auth_token, filled_router
+    ):
+        # We need both scopes TEST/TOP[12].
+        response = self.request(
+            api_client, fetch_auth_token, "geometry_authdataset", ["TEST/TOP1"]
+        )
+        assert response.status_code == 403
+
+    def test_wfs_model_authorized(
+        self, api_client, geometry_authdataset_thing, fetch_auth_token, filled_router
+    ):
+        response = self.request(
+            api_client, fetch_auth_token, "geometry_authdataset", ["TEST/TOP1", "TEST/TOP2"]
+        )
+        assert response.status_code == 200
+
+        # We should get a full result, regardless of "auth" on properties,
+        # if we have access to the dataset.
+        data = self.parse_response(response)
+        assert data == {
+            "boundedBy": None,
+            "geometry": None,
+            "id": "1",
+            "metadata": "secret",
+        }
+
+    @pytest.mark.parametrize(
+        "scopes,expect",
+        [
+            # With no scopes, we should not get the "metadata" or "geometry" fields.
+            ([], {"boundedBy": None, "id": "1"}),
+            # Geometry field, but no metadata.
+            (["TEST/GEO1", "TEST/GEO2"], {"boundedBy": None, "id": "1", "geometry": None}),
+            # Metadata, but not all scopes for the geometry field present.
+            (
+                ["TEST/GEO1", "TEST/META"],
+                {
+                    "boundedBy": None,
+                    "id": "1",
+                    "metadata": "secret",
+                },
+            ),
+        ],
+    )
+    def test_wfs_field_auth(
+        self, api_client, geometry_auth_thing, fetch_auth_token, filled_router, scopes, expect
+    ):
+        response = self.request(api_client, fetch_auth_token, "geometry_auth", scopes)
+        assert response.status_code == 200
+        data = self.parse_response(response)
+        assert data == expect


### PR DESCRIPTION
# This Pull request contains changes to:

WFS authorization tests now use schemas instead of a model that is modified on the fly. Follow-up to #255.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
