### PR TITLE
Point out import_schemas first in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,23 +140,22 @@ To import the bag database do the following :
 
     docker-compose exec bag_v11_database update-db.sh  bag_v11
 
-# Using a local version for schema import
+# Using local versions of schemas
 
-For testing it is convenient to have local server for schema importing.
+To import a custom schema for testing/development, use the command
 
-In the docker-compose there is a nginx server **schemas** that will serve this purpose.
-It will read the config from **_schemas/conf/default.conf_** and datasets from **_schemas/data/datasets_**
+    python src/manage.py import_schemas schemafile.json
 
-It can be started with :
+For more complicated cases, there is a nginx server ``schemas`` in ``docker-compose.yml``
+that acts as a replacement for ``schemas.data.amsterdam.nl``.
+It reads its config from ``schemas/conf/default.conf`` and datasets from ``schemas/data/datasets``.
+It can be started with:
 
     docker-compose up -d schemas
 
-Point to this server as schema server with :
+Then point to this server as the schema server and import schemas from it:
 
     export SCHEMA_URL=http://localhost:8080/datasets
-
-Then it will import the schemafiles in **_schemas/data/datasets_** with :
-
     python manage.py import_schemas
     
 # FreeBSD Installation Instructions


### PR DESCRIPTION
The README explains only the complicated way of testing with custom schemas. Mention the simple way first and condense the instructions for the nginx container.