### PR TITLE
Remove comma-separated "auth" list support

### DIFF
--- a/src/tests/files/geometry_auth.json
+++ b/src/tests/files/geometry_auth.json
@@ -27,7 +27,7 @@
           },
           "geometry": {
             "$ref": "https://geojson.org/schema/Point.json",
-            "auth": "TEST/GEO1,TEST/GEO2",
+            "auth": "TEST/GEO",
             "description": "Geometrie"
           }
         }

--- a/src/tests/files/geometry_authdataset.json
+++ b/src/tests/files/geometry_authdataset.json
@@ -3,7 +3,7 @@
   "type": "dataset",
   "title": "Geometry authorization test with dataset scopes",
   "version": "0.0.1",
-  "auth": "TEST/TOP1,TEST/TOP2",
+  "auth": "TEST/TOP",
   "crs": "EPSG:28992",
   "tables": [
     {

--- a/src/tests/test_dynamic_api/test_views_mvt.py
+++ b/src/tests/test_dynamic_api/test_views_mvt.py
@@ -88,22 +88,17 @@ def test_mvt_model_auth(api_client, geometry_auth_thing, fetch_auth_token, fille
         }
     }
 
-    # With all required scopes, we get a full response.
-    token = fetch_auth_token(["TEST/GEO1", "TEST/GEO2", "TEST/META"])
+    # With both required scopes, we get a full response.
+    token = fetch_auth_token(["TEST/GEO", "TEST/META"])
     response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
     assert response.status_code == 200
     assert mapbox_vector_tile.decode(response.content) == content
 
-    # With only the GEO[12] scopes, we still get a 200 response
+    # With only the GEO scope, we still get a 200 response
     # but we lose access to the metadata field.
-    token = fetch_auth_token(["TEST/GEO1", "TEST/GEO2"])
+    token = fetch_auth_token(["TEST/GEO"])
     response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
     assert response.status_code == 200
 
     del content["default"]["features"][0]["properties"]["metadata"]
     assert mapbox_vector_tile.decode(response.content) == content
-
-    # The geometry field requires two scopes. Giving it only one should give 403.
-    token = fetch_auth_token(["TEST/GEO1"])
-    response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
-    assert response.status_code == 403

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -148,18 +148,14 @@ class TestDatasetWFSViewAuth:
     def test_wfs_model_unauthorized(
         self, api_client, geometry_authdataset_thing, fetch_auth_token, filled_router
     ):
-        # We need both scopes TEST/TOP[12].
-        response = self.request(
-            api_client, fetch_auth_token, "geometry_authdataset", ["TEST/TOP1"]
-        )
+        # We need TEST/TOP.
+        response = self.request(api_client, fetch_auth_token, "geometry_authdataset", [])
         assert response.status_code == 403
 
     def test_wfs_model_authorized(
         self, api_client, geometry_authdataset_thing, fetch_auth_token, filled_router
     ):
-        response = self.request(
-            api_client, fetch_auth_token, "geometry_authdataset", ["TEST/TOP1", "TEST/TOP2"]
-        )
+        response = self.request(api_client, fetch_auth_token, "geometry_authdataset", ["TEST/TOP"])
         assert response.status_code == 200
 
         # We should get a full result, regardless of "auth" on properties,
@@ -175,19 +171,9 @@ class TestDatasetWFSViewAuth:
     @pytest.mark.parametrize(
         "scopes,expect",
         [
-            # With no scopes, we should not get the "metadata" or "geometry" fields.
             ([], {"boundedBy": None, "id": "1"}),
-            # Geometry field, but no metadata.
-            (["TEST/GEO1", "TEST/GEO2"], {"boundedBy": None, "id": "1", "geometry": None}),
-            # Metadata, but not all scopes for the geometry field present.
-            (
-                ["TEST/GEO1", "TEST/META"],
-                {
-                    "boundedBy": None,
-                    "id": "1",
-                    "metadata": "secret",
-                },
-            ),
+            (["TEST/GEO"], {"boundedBy": None, "id": "1", "geometry": None}),
+            (["TEST/META"], {"boundedBy": None, "id": "1", "metadata": "secret"}),
         ],
     )
     def test_wfs_field_auth(


### PR DESCRIPTION
"auth" fields on datasets, tables and fields could previously be comma-separated lists stored in JSON strings (`"FOO/BAR,FOO/BAZ"`). This feature was never used and is now removed.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
