### PR TITLE
Guido/ab6678 split audit logging

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -172,10 +172,13 @@ opencensus-ext-azure==1.0.7
     # via -r requirements.in
 opencensus-ext-django==0.7.4
     # via -r requirements.in
+opencensus-ext-logging==0.1.0
+    # via -r requirements.in
 opencensus==0.7.12
     # via
     #   opencensus-ext-azure
     #   opencensus-ext-django
+    #   opencensus-ext-logging
 ordered-set==4.0.2
     # via deepdiff
 orjson==3.5.1


### PR DESCRIPTION
This PR changes:
- all logging formats to be JSON 
- tags the audit logs with the key-value pair `"audit": true`. 

This should allow filtering of audit specific logs in whatever environment/system we sent our logs to.