### PR TITLE
Pass title/description/version/license from Amsterdam Schema to the OpenAPI docs

### DIFF
--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -236,7 +236,7 @@ class DynamicRouter(routers.DefaultRouter):
             results.append(
                 path(
                     self.make_url(dataset.url_prefix, dataset_id) + "/",
-                    get_openapi_json_view(dataset_id),
+                    get_openapi_json_view(dataset),
                     name=f"openapi-{dataset_id}",
                 )
             )

--- a/src/tests/files/afval.json
+++ b/src/tests/files/afval.json
@@ -2,6 +2,8 @@
   "id": "afvalwegingen",
   "type": "dataset",
   "title": "Afvalwegingen",
+  "description": "unit testing version of afvalwegingen",
+  "license": "CC0 1.0",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -35,6 +35,16 @@ def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_r
     assert response["content-type"] == "application/vnd.oai.openapi+json"
     schema = response.data
 
+    # Prove that the main info block is correctly rendered
+    assert schema["info"] == {
+        "title": "Afvalwegingen",
+        "description": "unit testing version of afvalwegingen",
+        "version": "0.0.1",
+        "license": "CC0 1.0",
+        "contact": {"email": "datapunt@amsterdam.nl"},
+        "termsOfService": "https://data.amsterdam.nl/",
+    }
+
     # Prove that only afvalwegingen are part of this OpenAPI page:
     paths = sorted(schema["paths"].keys())
     assert paths == [


### PR DESCRIPTION
Changed *dataset_ids to actual 'dataset' object as this is already known at construction and avoids fetching the object again during rendering.