### PR TITLE
OpenAPI fixes + Swagger op root

### DIFF
--- a/dev-docs/source/api/rest_framework_dso.filters.rst
+++ b/dev-docs/source/api/rest_framework_dso.filters.rst
@@ -6,7 +6,7 @@ rest\_framework\_dso.filters module
 Filter Backends
 ---------------
 
-.. autoclass:: rest_framework_dso.filters.DSOFilterSetBackend
+.. autoclass:: rest_framework_dso.filters.DSOFilterBackend
 
 .. autoclass:: rest_framework_dso.filters.DSOOrderingFilter
 

--- a/docs/source/_templates/datasets/dataset.rst.j2
+++ b/docs/source/_templates/datasets/dataset.rst.j2
@@ -1,3 +1,6 @@
+.. seealso::
+    Bekijk ook de :ref:`algemene uitleg <rest_api_generic>` voor REST API's voor het gebruik van de parameters.
+
 {{ main_title|underline("=") }}
 
 {{ schema.description or '' }}

--- a/docs/source/_templates/datasets/dataset.rst.j2
+++ b/docs/source/_templates/datasets/dataset.rst.j2
@@ -9,9 +9,9 @@
    .. raw:: html
 
       <ul>
-          <li>Swagger UI:<a href="{{ swagger_url }}">{{ swagger_url|strip_base_url }}</a></li>
+          <li>Swagger UI: <a href="{{ swagger_url }}">{{ swagger_url|strip_base_url }}</a></li>
         {% for table in tables %}
-          <li>REST URI:<a href="{{ table.uri }}">{{ table.uri|strip_base_url }}</a></li>
+          <li>REST URI: <a href="{{ table.uri }}">{{ table.uri|strip_base_url }}</a></li>
         {% endfor %}
       </ul>
 

--- a/docs/source/datasets.py
+++ b/docs/source/datasets.py
@@ -55,6 +55,8 @@ def render_dataset_docs(dataset: DatasetSchema):
     else:
         wfs_url = None
 
+    path = f"{dataset.url_prefix}/{snake_name}" if dataset.url_prefix else snake_name
+
     render_template(
         "datasets/dataset.rst.j2",
         f"datasets/{snake_name}.rst",
@@ -64,7 +66,7 @@ def render_dataset_docs(dataset: DatasetSchema):
             "main_title": main_title,
             "tables": tables,
             "wfs_url": wfs_url,
-            "swagger_url": f"{BASE_URL}/v1/swagger/{snake_name}",
+            "swagger_url": f"{BASE_URL}/v1/{path}/",
         },
     )
 

--- a/docs/source/generic/rest.rst
+++ b/docs/source/generic/rest.rst
@@ -1,3 +1,5 @@
+.. _rest_api_generic:
+
 REST API gebruiken
 ==================
 

--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -18,7 +18,6 @@ from rest_framework_dso.openapi import DSOSchemaGenerator
 
 __all__ = (
     "get_openapi_json_view",
-    "get_openapi_yaml_view",
     "DynamicApiSchemaGenerator",
 )
 
@@ -84,16 +83,6 @@ class DynamicApiSchemaGenerator(DSOSchemaGenerator):
 
 
 def get_openapi_json_view(dataset: Dataset):
-    """Provide the OpenAPI view, which renders as JSON."""
-    return _get_openapi_view(dataset, renderer_classes=[renderers.JSONOpenAPIRenderer])
-
-
-def get_openapi_yaml_view(dataset: Dataset):
-    """Provide the OpenAPI view, which renders as YAML."""
-    return _get_openapi_view(dataset, renderer_classes=[renderers.OpenAPIRenderer])
-
-
-def _get_openapi_view(dataset: Dataset, renderer_classes=None):
     # To reduce the OpenAPI endpoints in the view there are 2 possible stategies:
     # 1. Override the generator_class.get_schema() and set .endpoints manually.
     #    This requires overriding the inner workings for the generator,
@@ -107,7 +96,7 @@ def _get_openapi_view(dataset: Dataset, renderer_classes=None):
     view = get_schema_view(
         title=dataset_schema.title,
         description=dataset_schema.description or "",
-        renderer_classes=renderer_classes,
+        renderer_classes=[renderers.JSONOpenAPIRenderer],
         patterns=_lazy_get_dataset_patterns(dataset_schema.id),
         generator_class=DynamicApiSchemaGenerator,
         permission_classes=(permissions.AllowAny,),

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -66,6 +66,7 @@ class DynamicAPIRootView(APIView):
         result = {"datasets": {}}
 
         for ds in datasets:
+            dataset_id = ds.schema.id
             result["datasets"][ds.schema.id] = {
                 "id": ds.schema.id,
                 "name": ds.name,
@@ -73,10 +74,9 @@ class DynamicAPIRootView(APIView):
                 "status": ds.schema.get("status", "Beschikbaar"),
                 "description": ds.schema.description or "",
                 "api_type": "rest_json",
-                "api_url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
-                "documentation_url": f"{base}/v1/docs/datasets/{ds.schema.id}.html",
-                "specification_url": base
-                + reverse("dynamic_api:swagger-ui", kwargs={"dataset_name": ds.name}),
+                "api_url": base + reverse(f"dynamic_api:openapi-{dataset_id}"),
+                "documentation_url": f"{base}/v1/docs/datasets/{dataset_id}.html",
+                "specification_url": base + reverse(f"dynamic_api:openapi-{dataset_id}"),
                 "terms_of_use": {
                     "government_only": "auth" in ds.schema,
                     "pay_per_use": False,

--- a/src/dso_api/dynamic_api/urls.py
+++ b/src/dso_api/dynamic_api/urls.py
@@ -26,11 +26,6 @@ def get_patterns(router_urls):
         path("wfs/<dataset_name>/", views.DatasetWFSView.as_view(), name="wfs"),
         path("", include(router_urls)),
         # Swagger, OpenAPI and OAuth2 login logic.
-        path(
-            "swagger/<dataset_name>/",
-            views.DSOSwaggerView.as_view(),
-            name="swagger-ui",
-        ),
         path("oauth2-redirect.html", views.oauth2_redirect, name="oauth2-redirect"),
     ]
 

--- a/src/dso_api/dynamic_api/views/__init__.py
+++ b/src/dso_api/dynamic_api/views/__init__.py
@@ -1,7 +1,7 @@
 """All views for the dynamically generated API, split by protocol type."""
 from .api import DynamicApiViewSet, reload_patterns, viewset_factory
 from .mvt import DatasetMVTIndexView, DatasetMVTSingleView, DatasetMVTView
-from .oauth import DSOSwaggerView, oauth2_redirect
+from .oauth import oauth2_redirect
 from .wfs import DatasetWFSIndexView, DatasetWFSView
 
 __all__ = (
@@ -11,7 +11,6 @@ __all__ = (
     "DatasetMVTSingleView",
     "DatasetWFSView",
     "DatasetWFSIndexView",
-    "DSOSwaggerView",
     "viewset_factory",
     "reload_patterns",
     "oauth2_redirect",

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -141,14 +141,16 @@ class DynamicApiViewSet(
 
 
 def _get_viewset_api_docs(
+    model: Type[DynamicModel],
     serializer_class: Type[serializers.DynamicSerializer],
     filterset_class: Type[filterset.DynamicFilterSet],
     ordering_fields: list,
 ) -> str:
-    """Generate the API documentation header for the viewset.
-    This documentation is also shown in the Swagger / DRF HTML browser.
-    """
+    """Generate the API documentation header for the viewset."""
     lines = []
+    if description := model.table_schema().description:
+        lines.append(f"{description}\n\n")
+
     if filterset_class and filterset_class.base_filters:
         lines.append("The following fields can be used as filter with `?FIELDNAME=...`:\n")
         for name, filter_field in filterset_class.base_filters.items():
@@ -214,7 +216,9 @@ def viewset_factory(model: Type[DynamicModel]) -> Type[DynamicApiViewSet]:
     ordering_fields = _get_ordering_fields(serializer_class)
 
     attrs = {
-        "__doc__": _get_viewset_api_docs(serializer_class, filterset_class, ordering_fields),
+        "__doc__": _get_viewset_api_docs(
+            model, serializer_class, filterset_class, ordering_fields
+        ),
         "model": model,
         "queryset": model.objects.all(),  # also for OpenAPI schema parsing.
         "serializer_class": serializer_class,

--- a/src/dso_api/dynamic_api/views/oauth.py
+++ b/src/dso_api/dynamic_api/views/oauth.py
@@ -1,15 +1,4 @@
 from django.shortcuts import render
-from drf_spectacular.utils import extend_schema
-from drf_spectacular.views import SpectacularSwaggerView
-
-
-class DSOSwaggerView(SpectacularSwaggerView):
-    template_name_js = "dso_api/dynamic_api/swagger_ui.js"
-
-    @extend_schema(exclude=True)
-    def get(self, request, dataset_name, *args, **kwargs):
-        self.url = f"/v1/{dataset_name}"
-        return super().get(request, *args, **kwargs)
 
 
 def oauth2_redirect(request):

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -320,7 +320,7 @@ These are located at:
     "CONTACT": {"email": "datapunt@amsterdam.nl"},
     "LICENSE": {"name": "CC0 1.0 Universal"},
     "EXTERNAL_DOCS": {
-        "description": "API usage Documentation",
+        "description": "API Usage Documentation",
         "url": "https://api.data.amsterdam.nl/v1/docs/",
     },
     "SCHEMA_PATH_PREFIX": r"^/v?\d+(\.\d+)?/",  # strip /v1/ from tags.

--- a/src/rest_framework_dso/embedding.py
+++ b/src/rest_framework_dso/embedding.py
@@ -100,9 +100,10 @@ class EmbeddedFieldMatch:
         """Provide the serializer for the embedded relation."""
         # The nested 'fields_to_expand' data is provided to the child serializer,
         # so it can expand the next nesting if needed.
+        from .serializers import ExpandMixin
+
         kwargs = {}
-        if hasattr(self.field.serializer_class, "fields_to_expand"):
-            # _SideLoadMixin subclass.
+        if issubclass(self.field.serializer_class, ExpandMixin):
             kwargs["fields_to_expand"] = list(self.nested_fields_to_expand.keys())
 
         serializer = self.field.get_serializer(parent=self.serializer, **kwargs)

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -32,9 +32,9 @@ class AbstractEmbeddedField:
         return f"<{self.__class__.__name__}: {self.field_name}, {self.serializer_class.__name__}>"
 
     def __set_name__(self, owner, name):
-        from .serializers import _SideloadMixin
+        from .serializers import ExpandMixin
 
-        if not issubclass(owner, _SideloadMixin):
+        if not issubclass(owner, ExpandMixin):
             raise TypeError(f"{owner} does not extend from DSO serializer classes") from None
 
         self.parent_serializer_class = owner

--- a/src/rest_framework_dso/filters/__init__.py
+++ b/src/rest_framework_dso/filters/__init__.py
@@ -4,7 +4,7 @@ which does the heavy lifting of argument parsing and processing.
 
 There are 2 distinct object types: a "filter set backend" and "filter set".
 
-**Backends**, like the  :class:`~rest_framework_dso.filters.DSOFilterSetBackend`
+**Backends**, like the  :class:`~rest_framework_dso.filters.DSOFilterBackend`
 and :class:`~rest_framework_dso.filters.DSOOrderingFilter` are linked
 into the standard Django REST Framework logic for "filter backends".
 Those classes receive the Django :class:`~django.models.db.QuerySet` and
@@ -23,9 +23,9 @@ In code, this works as following:
 
     class View(GenericAPIView):
         # Standard Django REST Framework logic:
-        filter_backends = [DSOFilterSetBackend, DSOOrderingFilter]
+        filter_backends = [DSOFilterBackend, DSOOrderingFilter]
 
-        # Additional attribute for the filterset backend.
+        # Additional attribute for the filter backend.
         filterset_class = [...]  # list of DSOFilterSet subclasses
 
 Filterset internals
@@ -83,13 +83,13 @@ additional lookup classes are implemented that provide this functionality within
 .. _django-filter: https://django-filter.readthedocs.io/
 """
 from . import lookups  # noqa (import is needed for registration)
-from .backends import DSOFilterSetBackend, DSOOrderingFilter
+from .backends import DSOFilterBackend, DSOOrderingFilter
 from .filters import MultipleValueFilter, RangeFilter
 from .filtersets import DSOFilterSet
 
 __all__ = [
     "DSOFilterSet",
-    "DSOFilterSetBackend",
+    "DSOFilterBackend",
     "DSOOrderingFilter",
     "RangeFilter",
     "MultipleValueFilter",

--- a/src/rest_framework_dso/filters/backends.py
+++ b/src/rest_framework_dso/filters/backends.py
@@ -9,7 +9,7 @@ from schematools.utils import to_snake_case
 from .filtersets import DSOFilterSet
 
 
-class DSOFilterSetBackend(DjangoFilterBackend):
+class DSOFilterBackend(DjangoFilterBackend):
     """DSF fields filter.
 
     This loads the filterset logic of django-filter into the
@@ -20,7 +20,7 @@ class DSOFilterSetBackend(DjangoFilterBackend):
     Usage in views::
 
         class View(GenericAPIView):
-            filter_backends = [filters.DSOFilterSetBackend]
+            filter_backends = [filters.DSOFilterBackend]
             filterset_class = ... # subclass of DSOFilterSet
 
     The ``filterset_class`` defines how each querystring field is parsed and processed.

--- a/src/rest_framework_dso/filters/filtersets.py
+++ b/src/rest_framework_dso/filters/filtersets.py
@@ -24,7 +24,7 @@ class DSOFilterSet(FilterSet):
     it translates the Django model fields to proper filter class.
     Usage in views::
 
-        class MyFilterSet(DSOFilterSetBackend):
+        class MyFilterSet(DSOFilterBackend):
             class Meta:
                 model = MyModel
                 fields = {
@@ -34,7 +34,7 @@ class DSOFilterSet(FilterSet):
 
 
         class View(GenericAPIView):
-            filter_backends = [filters.DSOFilterSetBackend]
+            filter_backends = [filters.DSOFilterBackend]
             filterset_class = MyFilterSet
     """
 

--- a/src/rest_framework_dso/openapi.py
+++ b/src/rest_framework_dso/openapi.py
@@ -231,6 +231,14 @@ class DSOSchemaGenerator(generators.SchemaGenerator):
 class DSOAutoSchema(openapi.AutoSchema):
     """Default schema for API views that don't define a ``schema`` attribute."""
 
+    def get_description(self):
+        """Override what _get_viewset_api_docs() does."""
+        action = getattr(self.view, "action", self.method.lower())
+        if action == "retrieve":
+            return ""  # detail view.
+
+        return self.view.table_schema.description or ""
+
     def get_tags(self) -> List[str]:
         """Auto-generate tags based on the path, take last bit of path."""
         tokenized_path = self._tokenize_path()

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -45,7 +45,7 @@ from rest_framework_dso.fields import DSOGeometryField, LinksField
 from rest_framework_dso.serializer_helpers import ReturnGenerator, peek_iterable
 
 
-class _SideloadMixin:
+class ExpandMixin:
     """Handling ?_expand / ?_expandScope parameter.
 
     This is only a separate mixin because the parameter needs to be handled
@@ -101,7 +101,7 @@ class _SideloadMixin:
         raise NotImplementedError("child serializer should implement this")
 
 
-class DSOListSerializer(_SideloadMixin, serializers.ListSerializer):
+class DSOListSerializer(ExpandMixin, serializers.ListSerializer):
     """Fix pagination for lists.
 
     This should be used together with the DSO...Pagination class when results are paginated.
@@ -251,7 +251,7 @@ class DSOModelListSerializer(DSOListSerializer):
             return {self.results_field: items, **embedded_fields}
 
 
-class DSOSerializer(_SideloadMixin, serializers.Serializer):
+class DSOSerializer(ExpandMixin, serializers.Serializer):
     """Basic non-model serializer logic.
 
     This class implements all logic that can be used by all serializers,

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -339,5 +339,5 @@ class DSOViewMixin:
 
     def get_view_description(self, **kwargs):
         if self.action == "retrieve":
-            return ""
+            return ""  # hide description for detail view
         return super().get_view_description(**kwargs)

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -241,7 +241,7 @@ class DSOViewMixin:
     accept_crs_required = False
 
     # Using standard fields
-    filter_backends = [filters.DSOFilterSetBackend, filters.DSOOrderingFilter]
+    filter_backends = [filters.DSOFilterBackend, filters.DSOOrderingFilter]
 
     #: Class to configure the filterset
     #: (auto-generated when filterset_fields is defined, but this is slower).

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -116,20 +116,48 @@ def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_r
     assert container_properties["id"]["type"] == "integer"
     assert container_properties["datumLeegmaken"]["format"] == "date-time"
 
-    # Prove that the filter help text is exposed as description
+    # Prove that various filters are properly exposed.
     afval_parameters = {
         param["name"]: param
         for param in schema["paths"]["/v1/afvalwegingen/containers/"]["get"]["parameters"]
     }
     all_keys = ", ".join(afval_parameters.keys())
     assert "datumCreatie" in afval_parameters, all_keys
-    assert afval_parameters["datumCreatie"]["description"] == "yyyy-mm-dd"
+    assert afval_parameters["datumCreatie"] == {
+        "name": "datumCreatie",
+        "in": "query",
+        "description": "yyyy-mm-dd",
+        "schema": {"format": "date", "type": "string"},
+    }
 
     # Prove that DSOOrderingFilter exposes parameters
+    assert "_format" in afval_parameters, all_keys
+    assert afval_parameters["_format"] == {
+        "name": "_format",
+        "in": "query",
+        "schema": {
+            "type": "string",
+            "enum": ["csv", "geojson", "json"],
+        },
+    }
     assert "_sort" in afval_parameters, all_keys
+    assert afval_parameters["_sort"] == {
+        "name": "_sort",
+        "in": "query",
+        "required": False,
+        "description": "Which field to use when ordering the results.",
+        "schema": {"type": "string"},
+    }
 
     # Prove that general page parameters are exposed
     assert "_pageSize" in afval_parameters, all_keys
+    assert afval_parameters["_pageSize"] == {
+        "name": "_pageSize",
+        "in": "query",
+        "required": False,
+        "description": "Number of results to return per page.",
+        "schema": {"type": "integer"},
+    }
 
     # Prove that expansion is documented
     assert "_expand" in afval_parameters, all_keys
@@ -157,6 +185,23 @@ def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_r
     # ([lt] for dates, [in] for keys)
     assert "datumCreatie[lt]" in afval_parameters, all_keys
     assert "clusterId[in]" in afval_parameters, all_keys
+    assert afval_parameters["clusterId[in]"] == {
+        "name": "clusterId[in]",
+        "in": "query",
+        "description": "Multiple values may be separated by commas.",
+        "explode": False,
+        "schema": {
+            "type": "array",
+            "items": {"nullable": True, "type": "string"},
+        },
+        "style": "form",
+    }
+    assert afval_parameters["clusterId[isnull]"] == {
+        "name": "clusterId[isnull]",
+        "in": "query",
+        "description": "true | false",
+        "schema": {"type": "boolean"},
+    }
 
     # Prove that the extra headers are included
     assert "Accept-Crs" in afval_parameters, all_keys

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -3,6 +3,8 @@ import logging
 import pytest
 from django.urls import reverse
 
+from tests.utils import read_response
+
 
 @pytest.mark.django_db
 def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_router, drf_request):
@@ -55,6 +57,19 @@ def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_rout
             },
         }
     }
+
+
+@pytest.mark.django_db
+def test_openapi_swagger(api_client, afval_dataset, filled_router):
+    """Prove that the OpenAPI page can be rendered."""
+    url = reverse("dynamic_api:openapi-afvalwegingen")
+    assert url == "/v1/afvalwegingen/"
+
+    response = api_client.get(url, HTTP_ACCEPT="text/html")
+    assert response.status_code == 200
+    assert response["content-type"] == "text/html; charset=utf-8"
+    content = read_response(response)
+    assert "ui.initOAuth(" in content
 
 
 @pytest.mark.django_db

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -106,22 +106,45 @@ def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_r
         param["name"]: param
         for param in schema["paths"]["/v1/afvalwegingen/containers/"]["get"]["parameters"]
     }
-    assert "datumCreatie" in afval_parameters, ", ".join(afval_parameters.keys())
+    all_keys = ", ".join(afval_parameters.keys())
+    assert "datumCreatie" in afval_parameters, all_keys
     assert afval_parameters["datumCreatie"]["description"] == "yyyy-mm-dd"
 
     # Prove that DSOOrderingFilter exposes parameters
-    assert "_sort" in afval_parameters, ", ".join(afval_parameters.keys())
+    assert "_sort" in afval_parameters, all_keys
 
     # Prove that general page parameters are exposed
-    assert "_pageSize" in afval_parameters, ", ".join(afval_parameters.keys())
+    assert "_pageSize" in afval_parameters, all_keys
+
+    # Prove that expansion is documented
+    assert "_expand" in afval_parameters, all_keys
+    assert "_expandScope" in afval_parameters, all_keys
+    assert afval_parameters["_expandScope"] == {
+        "name": "_expandScope",
+        "description": "Comma separated list of named relations to expand.",
+        "in": "query",
+        "schema": {"type": "string"},
+        "examples": {
+            "AllValues": {
+                "summary": "All Values",
+                "value": "cluster",
+                "description": "Expand all fields, identical to only using _expand=true.",
+            },
+            "Cluster": {
+                "summary": "cluster",
+                "value": "cluster",
+                "description": "Cluster-ID",
+            },
+        },
+    }
 
     # Prove that the lookups of LOOKUPS_BY_TYPE are parsed
     # ([lt] for dates, [in] for keys)
-    assert "datumCreatie[lt]" in afval_parameters, ", ".join(afval_parameters.keys())
-    assert "clusterId[in]" in afval_parameters, ", ".join(afval_parameters.keys())
+    assert "datumCreatie[lt]" in afval_parameters, all_keys
+    assert "clusterId[in]" in afval_parameters, all_keys
 
     # Prove that the extra headers are included
-    assert "Accept-Crs" in afval_parameters, ", ".join(afval_parameters.keys())
+    assert "Accept-Crs" in afval_parameters, all_keys
     assert afval_parameters["Accept-Crs"]["in"] == "header"
 
     log_messages = [m for m in caplog.messages if "DisableMigrations" not in m]

--- a/src/tests/test_rest_framework_dso/test_filters.py
+++ b/src/tests/test_rest_framework_dso/test_filters.py
@@ -4,7 +4,7 @@ import pytest
 from django.db.models import Value
 from django.http import QueryDict
 
-from rest_framework_dso.filters import DSOFilterSet, DSOFilterSetBackend
+from rest_framework_dso.filters import DSOFilterBackend, DSOFilterSet
 from rest_framework_dso.filters.lookups import Wildcard
 
 from .models import Category, Movie
@@ -111,10 +111,10 @@ class TestDSOFilterSet:
         assert set(obj.name for obj in qs) == expect, str(qs.query)
 
 
-class TestDSOFilterSetBackend:
+class TestDSOFilterBackend:
     def test_is_unfiltered(self, api_rf):
         """Prove that is_unfiltered() correctly detects non-standard fields"""
-        backend = DSOFilterSetBackend()
+        backend = DSOFilterBackend()
         assert backend.is_unfiltered(api_rf.get("/", data={"_format": "csv", "_fields": "foo"}))
         assert backend.is_unfiltered(api_rf.get("/", data={"_pageSize": "100", "_format": "csv"}))
 


### PR DESCRIPTION
Veel fixes in de OpenAPI weergave.

Als je de root van een dataset opent (bijv.`/v1/bag/`) krijg je in de browser nu een swagger UI te zien. Hiermee is de browser ervaring voor `/v1/`, `/v1/dataset/` en `/v1/dataset/tabel/` allemaal een HTML weergave.

Daarnaast worden veel descriptions nu overgenomen, en krijgen filter-parameters weer het juiste data type.