### PR TITLE
Separate MVT+WFS permissions checks from DRF checks

### DIFF
--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -135,7 +135,7 @@ class DatasetMVTView(MVTView):
 
     def check_permissions(self, request) -> None:
         for permission in self.permission_classes:
-            if not permission().has_permission(request, self, [self.model]):
+            if not permission().has_permission_for_models(request, self, [self.model]):
                 raise PermissionDenied()
         if self.vector_tile_geom_name in self._unauthorized:
             raise PermissionDenied()

--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -340,7 +340,7 @@ class DatasetWFSView(WFSView):
         Check if the request should be permitted.
         """
         for permission in self.get_permissions():
-            if not permission.has_permission(request, self, models):
+            if not permission.has_permission_for_models(request, self, models):
                 self.permission_denied(request, message=getattr(permission, "message", None))
 
     def get_permissions(self):


### PR DESCRIPTION
MVT and WFS used an overloaded `has_permission` method to do auth checks. They now call a custom method so the code paths are more clearly separated.