### PR TITLE
Bump some dependencies

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,25 +1,25 @@
-cachetools == 4.2.1
+cachetools == 4.2.2
 Django == 3.1.8
 django-environ == 0.4.5
 django-cors-headers == 3.7.0
 django-filter == 2.4.0
 django-healthchecks == 1.4.2
 django-postgres-unlimited-varchar == 1.1.0
-django-gisserver == 1.1.2
+django-gisserver == 1.1.3
 django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
-djangorestframework-csv == 2.1.0
+djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
 amsterdam-schema-tools[django] == 0.21.3
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
 jsonschema == 3.2.0
 lru_dict == 1.1.7
-more-ds == 0.0.3
+more-ds == 0.0.4
 psycopg2-binary == 2.8.6
 python-string-utils == 1.0.0
 readerwriterlock == 1.0.8
-orjson == 3.5.1
+orjson == 3.5.3
 requests == 2.25.1
 sentry-sdk == 1.0.0
 urllib3 == 1.26.5
@@ -32,15 +32,15 @@ opencensus-ext-logging == 0.1.0
 markdown == 3.3.4
 
 # Testing
-flake8 == 3.9.0
+flake8 == 3.9.2
 flake8-blind-except == 0.2.0
 flake8-colors == 0.1.9
 flake8-debugger == 4.0.0
 flake8-raise == 0.0.5
-mapbox-vector-tile == 1.2.0
-pytest == 6.2.3
+mapbox-vector-tile == 1.2.1
+pytest == 6.2.4
 pytest-django == 4.1.0
-pytest-cov == 2.11.1
+pytest-cov == 2.12.1
 python-owasp-zap-v2.4 == 0.0.18
 
 azure-storage-blob == 12.8.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -17,7 +17,7 @@ azure-core==1.13.0
     # via azure-storage-blob
 azure-storage-blob==12.8.0
     # via -r requirements.in
-cachetools==4.2.1
+cachetools==4.2.2
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
@@ -58,7 +58,7 @@ django-environ==0.4.5
     #   amsterdam-schema-tools
 django-filter==2.4.0
     # via -r requirements.in
-django-gisserver==1.1.2
+django-gisserver==1.1.3
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
@@ -84,7 +84,7 @@ django==3.1.8
     #   djangorestframework
     #   drf-spectacular
     #   opencensus-ext-django
-djangorestframework-csv==2.1.0
+djangorestframework-csv==2.1.1
     # via -r requirements.in
 djangorestframework-gis==0.17
     # via -r requirements.in
@@ -104,7 +104,7 @@ flake8-debugger==4.0.0
     # via -r requirements.in
 flake8-raise==0.0.5
     # via -r requirements.in
-flake8==3.9.0
+flake8==3.9.2
     # via
     #   -r requirements.in
     #   flake8-colors
@@ -148,7 +148,7 @@ lark-parser==0.11.2
     # via mappyfile
 lru_dict==1.1.7
     # via -r requirements.in
-mapbox-vector-tile==1.2.0
+mapbox-vector-tile==1.2.1
     # via -r requirements.in
 mappyfile==0.9.1
     # via amsterdam-schema-tools
@@ -162,7 +162,7 @@ mercantile==1.1.6
     # via django-vectortiles
 methodtools==0.4.2
     # via amsterdam-schema-tools
-more-ds==0.0.3
+more-ds==0.0.4
     # via -r requirements.in
 msrest==0.6.21
     # via azure-storage-blob
@@ -185,7 +185,7 @@ opencensus==0.7.12
     #   opencensus-ext-logging
 ordered-set==4.0.2
     # via deepdiff
-orjson==3.5.1
+orjson==3.5.3
     # via
     #   -r requirements.in
     #   django-gisserver
@@ -232,11 +232,11 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.17.3
     # via jsonschema
-pytest-cov==2.11.1
+pytest-cov==2.12.1
     # via -r requirements.in
 pytest-django==4.1.0
     # via -r requirements.in
-pytest==6.2.3
+pytest==6.2.4
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -307,7 +307,9 @@ sqlalchemy==1.3.24
 sqlparse==0.4.1
     # via django
 toml==0.10.2
-    # via pytest
+    # via
+    #   pytest
+    #   pytest-cov
 typing-extensions==3.7.4.3
     # via readerwriterlock
 unicodecsv==0.14.1


### PR DESCRIPTION
I scanned the diffs for these and am reasonably sure nothing crazy happens.

pytest-django is not upgraded, since 4.3.0 causes a test failure:

```
――――――――――――――――――― ERROR at teardown of TestDatabaseSchemasRouter.test_db_for_read_returns_schema_name_if_set ――――――――――――――――――――

cls = <class 'pytest_django.fixtures._django_db_fixture_helper.<locals>.PytestDjangoTestCase'>

    @classmethod
    def tearDownClass(cls):
        if cls._databases_support_transactions():
            cls._rollback_atomics(cls.cls_atomics)
            for conn in connections.all():
                conn.close()
>       super().tearDownClass()

../venv/lib/python3.8/site-packages/django/test/testcases.py:1135:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../venv/lib/python3.8/site-packages/django/test/testcases.py:228: in tearDownClass
    cls._remove_databases_failures()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'pytest_django.fixtures._django_db_fixture_helper.<locals>.PytestDjangoTestCase'>

    @classmethod
    def _remove_databases_failures(cls):
        for alias in connections:
            if alias in cls.databases:
                continue
            connection = connections[alias]
            for name, _ in cls._disallowed_connection_methods:
                method = getattr(connection, name)
>               setattr(connection, name, method.wrapped)
E               AttributeError: 'function' object has no attribute 'wrapped'

../venv/lib/python3.8/site-packages/django/test/testcases.py:224: AttributeError
```