### PR TITLE
flake8: use extend-ignore instead of ignore.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore=
+extend-ignore=
   # Black may add spaces in slice[func(v) : end] syntax
   E203,
   # Black leaves commas after combining lines
@@ -9,8 +9,6 @@ ignore=
   F405,
   # Allow lambdas:
   E731,
-  # line break before binary operator (incompatible with black):
-  W503,
   # Allow raise Exception()
   R102,
 exclude=.git,


### PR DESCRIPTION
`flake8` has a default ignore list. Reason being that, according to its
maintainer on the podcast https://testandcode.com/156?t=230, PEP8 has
flip flopped on certain style recommendations over the years. So
`flake8` simply adds those to the default ignore list. In addition there
are number of style checks that are each other's opposite. These are
added to the default ignore list as well.

So when specifying your own `ignore` list these default values are
overwritten. Hence it's better to extend the ignore list by means of the
`extend-ignore` option. And that's what I'm doing in this commit.

BTW I'm removing the W503 rule. It's already part of the default ignore
list.