### PR TITLE
[AB#8346] Fix combining _fields with _expand parameters.

### DIFF
--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Optional, Type
 
 from django.db import models
 from django.db.models.fields.related import RelatedField
@@ -6,6 +6,14 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.utils.functional import cached_property
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
+
+
+def parse_request_fields(fields: Optional[str]):
+    if not fields:
+        return None
+
+    # TODO: support nesting, perform validation
+    return fields.split(",")
 
 
 class AbstractEmbeddedField:

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -41,7 +41,7 @@ from rest_framework_dso.embedding import (
     get_serializer_lookups,
     parse_expand_scope,
 )
-from rest_framework_dso.fields import DSOGeometryField, LinksField
+from rest_framework_dso.fields import DSOGeometryField, LinksField, parse_request_fields
 from rest_framework_dso.serializer_helpers import ReturnGenerator, peek_iterable
 
 
@@ -64,6 +64,17 @@ class ExpandMixin:
         """Tell whether the 'fields_to_expand' is set by the code instead of request."""
         return self._fields_to_expand is not empty
 
+    @cached_property
+    def is_toplevel(self):
+        """Tell whether the current serializer is the top-level serializer.
+        Nested serializers shouldn't handle request-parsing logic.
+        """
+        # The extra parent check tests for serializers that are initialized with many=True
+        root = self.root
+        return (self is root) or (
+            isinstance(self.parent, serializers.ListSerializer) and self.parent is root
+        )
+
     @property
     def fields_to_expand(self) -> Union[List[str], bool]:
         """Retrieve the requested expand, 2 possible values:
@@ -75,10 +86,7 @@ class ExpandMixin:
             # Instead of retrieving this from request,
             # the expand can be defined using the serializer __init__.
             return False if self._fields_to_expand is False else cast(list, self._fields_to_expand)
-        elif (self.root is self) or (
-            isinstance(self.parent, serializers.ListSerializer)
-            and self.parent is self.parent.root  # serializer initialized with many=True
-        ):
+        elif self.is_toplevel:
             # This is the top-level serializer. Parse from request
             request = self.context["request"]
             return parse_expand_scope(
@@ -284,6 +292,10 @@ class DSOSerializer(ExpandMixin, serializers.Serializer):
     fields_param = "_fields"  # so ?_fields=.. gives a result
     _default_list_serializer_class = DSOListSerializer
 
+    def __init__(self, *args, fields_to_display=empty, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._fields_to_display = fields_to_display
+
     @classmethod
     def many_init(cls, *args, **kwargs):
         """The initialization for many=True.
@@ -320,6 +332,30 @@ class DSOSerializer(ExpandMixin, serializers.Serializer):
 
         return list_serializer_class(*args, **list_kwargs)
 
+    @property
+    def fields_to_display(self) -> Optional[List[str]]:
+        """Define which fields should be included only."""
+        if self._fields_to_display is not empty:
+            # Instead of retrieving this from request,
+            # the expand can be defined using the serializer __init__.
+            return cast(List[str], self._fields_to_display)
+        elif self.is_toplevel:
+            # This is the top-level serializer. Parse from request
+            request = self.context["request"]
+            request_fields = request.GET.get(self.fields_param)
+            if not request_fields and "fields" in request.GET:
+                request_fields = request.GET["fields"]  # DSO 1.0
+
+            return parse_request_fields(request_fields)
+        else:
+            # Sub field should have received it's fields_to_display override via __init__().
+            return None
+
+    @fields_to_display.setter
+    def fields_to_display(self, fields: List[str]):
+        """Allow serializers to assign 'fields_to_expand' later (e.g. in bind())."""
+        self._fields_to_display = fields
+
     def get_fields(self):
         # .get() is needed to print serializer fields during debugging
         request = self.context.get("request")
@@ -334,11 +370,7 @@ class DSOSerializer(ExpandMixin, serializers.Serializer):
 
         # Adjust the serializer based on the request,
         # remove fields if a subset is requested.
-        request_fields = request.GET.get(self.fields_param)
-        if not request_fields and "fields" in request.GET:
-            request_fields = request.GET["fields"]  # DSO 1.0
-
-        if request_fields:
+        if request_fields := self.fields_to_display:
             display_fields = self.get_fields_to_display(fields, request_fields)
             fields = OrderedDict(
                 [
@@ -367,7 +399,7 @@ class DSOSerializer(ExpandMixin, serializers.Serializer):
 
         # Split into fields to include and fields to omit (-fieldname).
         display_fields, omit_fields = set(), set()
-        for field in request_fields.split(","):
+        for field in request_fields:
             if field.startswith("-"):
                 omit_fields.add(field[1:])
             else:


### PR DESCRIPTION
This fixes combining `_fields=..` with `_expandScope`.
This is a bit of a stop-gap to quickly fix errors for dataportaal devs.

This doesn't handle the second part yet (relation.field), but at least fixes the unwanted error message. The field parsing is already written in the same style as the expand logic so it can be revised to support nested field limiting too.
