### PR TITLE
[AB#8005] RemoteClient: send Accept header without charset

### DIFF
--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -97,7 +97,7 @@ class RemoteClient:
             forward = client_ip
 
         headers = {
-            "Accept": "application/json; charset=utf-8",
+            "Accept": "application/json",
             "X-Forwarded-For": forward,
         }
 


### PR DESCRIPTION
Looks like the BRP endpoint doesn't understand the Accept header "application/json; charset=utf-8". Drop the charset from the header.

If JSON in any other encoding comes in, we'll have to decode it, but RFC 8259 (8.1) requires JSON to be in UTF8 anyway, except in a "closed ecosystem". I've never witnessed a system that uses any other encoding for JSON.