### PR TITLE
Yrob/ab4388 temporaliteit naar tabel niveau

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ ENV/
 # vim
 *.swp
 
+# VSCode
+.vscode/
+
 # Project specific
 .DS_Store
 

--- a/src/dso_api/dynamic_api/fields.py
+++ b/src/dso_api/dynamic_api/fields.py
@@ -34,7 +34,7 @@ class TemporalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
 
             base_url = self.reverse(view_name, kwargs=kwargs, request=request, format=format)
             if request.table_temporal_slice is None:
-                key = obj.table_schema().temporal.get("identifier")
+                key = obj.table_schema().temporal.identifier
                 value = version
             else:
                 key = request.table_temporal_slice["key"]
@@ -59,7 +59,7 @@ class HALTemporalHyperlinkedRelatedField(TemporalHyperlinkedRelatedField):
         if href and value.is_temporal():
             table_schema = value.table_schema()
             dataset_schema = value.get_dataset_schema()
-            temporal_fieldname = table_schema.temporal["identifier"]
+            temporal_fieldname = table_schema.temporal.identifier
             id_fieldname = dataset_schema["identifier"]
             output.update(
                 {
@@ -106,7 +106,7 @@ class TemporalLinksField(LinksField):
         base_url = self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
         table_schema = obj.table_schema()
-        temporal_identifier = table_schema.temporal["identifier"]
+        temporal_identifier = table_schema.temporal.identifier
         version = getattr(obj, temporal_identifier)
         return URL(base_url) // {temporal_identifier: version}
 

--- a/src/dso_api/dynamic_api/fields.py
+++ b/src/dso_api/dynamic_api/fields.py
@@ -33,13 +33,12 @@ class TemporalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
             kwargs = {self.lookup_field: lookup_value}
 
             base_url = self.reverse(view_name, kwargs=kwargs, request=request, format=format)
-
-            if request.dataset_temporal_slice is None:
-                key = obj.get_dataset_schema().temporal.get("identifier")
+            if request.table_temporal_slice is None:
+                key = obj.table_schema().temporal.get("identifier")
                 value = version
             else:
-                key = request.dataset_temporal_slice["key"]
-                value = request.dataset_temporal_slice["value"]
+                key = request.table_temporal_slice["key"]
+                value = request.table_temporal_slice["value"]
 
             base_url = URL(base_url) // {key: value}
         else:
@@ -58,8 +57,9 @@ class HALTemporalHyperlinkedRelatedField(TemporalHyperlinkedRelatedField):
             output["title"] = str(value)
 
         if href and value.is_temporal():
+            table_schema = value.table_schema()
             dataset_schema = value.get_dataset_schema()
-            temporal_fieldname = dataset_schema.temporal["identifier"]
+            temporal_fieldname = table_schema.temporal["identifier"]
             id_fieldname = dataset_schema["identifier"]
             output.update(
                 {
@@ -105,7 +105,8 @@ class TemporalLinksField(LinksField):
         kwargs = {self.lookup_field: lookup_value}
         base_url = self.reverse(view_name, kwargs=kwargs, request=request, format=format)
 
-        temporal_identifier = dataset_schema.temporal["identifier"]
+        table_schema = obj.table_schema()
+        temporal_identifier = table_schema.temporal["identifier"]
         version = getattr(obj, temporal_identifier)
         return URL(base_url) // {temporal_identifier: version}
 

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -82,7 +82,7 @@ def filter_latest_temporal(queryset: models.QuerySet) -> models.QuerySet:
         return queryset
 
     identifier = dataset_schema.identifier
-    sequence_name = table_schema.temporal["identifier"]
+    sequence_name = table_schema.temporal.identifier
 
     # does SELECT DISTINCT ON(identifier) ... ORDER BY identifier, sequence DESC
     return queryset.distinct(identifier).order_by(identifier, f"-{sequence_name}")
@@ -395,8 +395,8 @@ class DynamicBodySerializer(DynamicSerializer):
         table = self.Meta.model.table_schema()
         hal_fields = [ds.identifier]
         temporal = table.temporal
-        if temporal is not None and "identifier" in temporal:
-            hal_fields.append(temporal["identifier"])
+        if temporal is not None:
+            hal_fields.append(temporal.identifier)
         capitalized_identifier_fields = [
             identifier_field.capitalize() for identifier_field in hal_fields
         ]

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -54,9 +54,9 @@ class TemporalRetrieveModelMixin:
         queryset = super().get_queryset()
 
         if self.request.versioned and self.model.is_temporal():
-            if self.request.dataset_temporal_slice is not None:
-                temporal_value = self.request.dataset_temporal_slice["value"]
-                start_field, end_field = self.request.dataset_temporal_slice["fields"]
+            if self.request.table_temporal_slice is not None:
+                temporal_value = self.request.table_temporal_slice["value"]
+                start_field, end_field = self.request.table_temporal_slice["fields"]
                 queryset = queryset.filter(**{f"{start_field}__lte": temporal_value}).filter(
                     models.Q(**{f"{end_field}__gte": temporal_value})
                     | models.Q(**{f"{end_field}__isnull": True})
@@ -81,8 +81,7 @@ class TemporalRetrieveModelMixin:
             )  # fallback to full id search.
         else:
             queryset = queryset.filter(pk=pk)
-
-        identifier = self.request.dataset.temporal.get("identifier", None)
+        identifier = queryset.model._table_schema.temporal.get("identifier", None)
 
         # Filter queryset using GET parameters, if any.
         for field in queryset.model._table_schema.fields:

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -81,10 +81,10 @@ class TemporalRetrieveModelMixin:
             )  # fallback to full id search.
         else:
             queryset = queryset.filter(pk=pk)
-        identifier = queryset.model._table_schema.temporal.get("identifier", None)
+        identifier = queryset.model.table_schema().temporal.identifier
 
         # Filter queryset using GET parameters, if any.
-        for field in queryset.model._table_schema.fields:
+        for field in queryset.model.table_schema().fields:
             if field.name != pk_field and field.name in self.request.GET:
                 queryset = queryset.filter(**{field.name: self.request.GET[field.name]})
 
@@ -228,7 +228,7 @@ def viewset_factory(model: Type[DynamicModel]) -> Type[DynamicApiViewSet]:
         "filterset_class": filterset_class,
         "ordering_fields": ordering_fields,
         "dataset_id": model._dataset_schema["id"],
-        "table_id": model._table_schema["id"],
+        "table_id": model.table_schema()["id"],
     }
     return type(f"{model.__name__}ViewSet", (DynamicApiViewSet,), attrs)
 

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -82,7 +82,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authorization_django.authorization_middleware",
     "dso_api.dynamic_api.middleware.DatasetMiddleware",
-    "dso_api.dynamic_api.middleware.TemporalDatasetMiddleware",
+    "dso_api.dynamic_api.middleware.TemporalTableMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -10,7 +10,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 0.21.3
+amsterdam-schema-tools[django] == 0.21.4
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.17.1
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.21.3
+amsterdam-schema-tools[django]==0.21.4
     # via -r requirements.in
 asgiref==3.3.4
     # via django
@@ -163,7 +163,9 @@ mercantile==1.1.6
 methodtools==0.4.2
     # via amsterdam-schema-tools
 more-ds==0.0.4
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   amsterdam-schema-tools
 msrest==0.6.21
     # via azure-storage-blob
 ndjson==0.3.1

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -182,7 +182,7 @@ class LinksField(serializers.HyperlinkedIdentityField):
             output.update({"title": str(value)})
 
         if value.is_temporal():
-            temporal_fieldname = value.table_schema().temporal.get("identifier")
+            temporal_fieldname = value.table_schema().temporal.identifier
             temporal_value = getattr(value, temporal_fieldname)
             id_fieldname = value.get_dataset_schema().get("identifier")
             id_value = getattr(value, id_fieldname)

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -182,7 +182,7 @@ class LinksField(serializers.HyperlinkedIdentityField):
             output.update({"title": str(value)})
 
         if value.is_temporal():
-            temporal_fieldname = value.get_dataset_schema().temporal.get("identifier")
+            temporal_fieldname = value.table_schema().temporal.get("identifier")
             temporal_value = getattr(value, temporal_fieldname)
             id_fieldname = value.get_dataset_schema().get("identifier")
             id_value = getattr(value, id_fieldname)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -47,7 +47,7 @@ def api_request(api_rf) -> WSGIRequest:
     request.auth_profile = RequestProfile(request)
     request.is_authorized_for = lambda *scopes: True
 
-    # Temporal modifications. Usually done via TemporalDatasetMiddleware
+    # Temporal modifications. Usually done via TemporalTableMiddleware
     request.versioned = False
     return request
 

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -10,6 +10,12 @@
     {
       "id": "panden",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/panden.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -18,12 +24,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -6,12 +6,6 @@
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "tables": [
     {
       "id": "panden",
@@ -24,6 +18,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "id", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -70,7 +70,6 @@
         "identifier": "dossier",
         "required": ["schema", "dossier"],
         "display": "dossier",
-        "isTemporal": false,
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -10,6 +10,12 @@
     {
       "id": "buurten",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -19,12 +25,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -78,6 +78,12 @@
     {
       "id": "wijken",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/wijken.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -87,12 +93,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "additionalRelations": {
           "buurt": {
             "table": "buurten",
@@ -149,6 +149,12 @@
     {
       "id": "ggwgebieden",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/ggwgebieden.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -158,12 +164,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -221,6 +221,12 @@
     {
       "id": "stadsdelen",
       "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/stadsdelen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -230,12 +236,6 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
-        "temporal": {
-          "identifier": "volgnummer",
-          "dimensions": {
-            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-          }
-        },
         "additionalRelations": {
           "wijk": {
             "table": "wijken",

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -5,12 +5,6 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "identifier": "identificatie",
-  "temporal": {
-    "identifier": "volgnummer",
-    "dimensions": {
-      "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
-    }
-  },
   "crs": "EPSG:28992",
   "tables": [
     {
@@ -25,6 +19,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -87,6 +87,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "additionalRelations": {
           "buurt": {
             "table": "buurten",
@@ -152,6 +158,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -218,6 +230,12 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "temporal": {
+          "identifier": "volgnummer",
+          "dimensions": {
+            "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+          }
+        },
         "additionalRelations": {
           "wijk": {
             "table": "wijken",

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -302,7 +302,7 @@ class TestDynamicSerializer:
     ):
         """Show backwards"""
         drf_request.dataset = gebieden_schema
-        drf_request.dataset_temporal_slice = None
+        drf_request.table_temporal_slice = None
         stadsdelen_model = gebieden_models["stadsdelen"]
         wijken_model = gebieden_models["wijken"]
         stadsdeel = stadsdelen_model.objects.create(


### PR DESCRIPTION
Temporaliteit in amsterdam-schema wordt verplaatst van Dataset naar Tabel niveau. Een PR aan schema-tools die dat bewerkstelligd staat hier: (https://github.com/Amsterdam/schema-tools/pull/158) Deze aanpassingen maken dso-api compatibel met die update aan schema-tools.