### PR TITLE
AB#4402 Fix error handling in geo contains filter

### DIFF
--- a/src/rest_framework_dso/filters/backends.py
+++ b/src/rest_framework_dso/filters/backends.py
@@ -1,6 +1,7 @@
 import re
 
 from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos.error import GEOSException
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter
@@ -74,7 +75,10 @@ class DSOFilterBackend(DjangoFilterBackend):
                         if srid in (4326, 28992) and (x_lon is None or y_lat is None):
                             raise ValueError(f"Invalid x,y values : {x},{y}")
                         # longitude, latitude for 4326 x,y otherwise
-                        value = GEOSGeometry(f"POINT({x_lon} {y_lat})", srid)
+                        try:
+                            value = GEOSGeometry(f"POINT({x_lon} {y_lat})", srid)
+                        except GEOSException as e:
+                            raise ValidationError(f"Invalid x,y values : {x},{y}") from e
                         new_data = filterset.data.copy()
                         new_data[name] = value
                         filterset.data = new_data

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -382,6 +382,13 @@ class TestDynamicFilterSet:
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 1
 
+        response = APIClient().get(
+            "/v1/parkeervakken/parkeervakken/",
+            data={"geometry[contains]": "52.388231,48897865"},
+            headers={"Accept-CRS": 4326},
+        )
+        assert response.status_code == 400
+
     @staticmethod
     def test_filter_isempty(parkeervakken_parkeervak_model, filled_router):
         parkeervakken_parkeervak_model.objects.create(


### PR DESCRIPTION
Wanneer je als gebruiker een incorrect punt opgeeft in de contains filter krijg je momenteel een non-descript error 500 melding terug. Deze pr zorgt dat een 400 error wordt terug gegeven, die aangeeft dat de geometrie niet klopt. ex: https://api.data.amsterdam.nl/v1/beschermdestadsdorpsgezichten/beschermdestadsdorpsgezichten/?geometry[contains]=121876,48774&_fields=status  (DS-520) 