### PR TITLE
Use the identifier from the table_schema for temporality

### DIFF
--- a/src/dso_api/dynamic_api/fields.py
+++ b/src/dso_api/dynamic_api/fields.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import azure.storage.blob
 from django.conf import settings
 from more_ds.network.url import URL
+from more_itertools import first
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from schematools.contrib.django.models import DynamicModel
@@ -59,7 +60,7 @@ class HALTemporalHyperlinkedRelatedField(TemporalHyperlinkedRelatedField):
         if href and value.is_temporal():
             table_schema = value.table_schema()
             temporal_fieldname = table_schema.temporal.identifier
-            id_fieldname = table_schema.identifier[0]
+            id_fieldname = first(table_schema.identifier)
             output.update(
                 {
                     temporal_fieldname: getattr(value, temporal_fieldname),
@@ -100,7 +101,7 @@ class TemporalLinksField(LinksField):
             return super().get_url(obj, view_name, request, format)
 
         table_schema = obj.table_schema()
-        lookup_value = getattr(obj, table_schema.identifier[0])
+        lookup_value = getattr(obj, first(table_schema.identifier))
 
         kwargs = {self.lookup_field: lookup_value}
         base_url = self.reverse(view_name, kwargs=kwargs, request=request, format=format)
@@ -175,7 +176,7 @@ class HALLooseRelationUrlField(LooseRelationUrlField):
         if view.model.has_display_field():
             result["title"] = str(value)
 
-        related_identifier = field.related_model.table_schema().identifier[0]
+        related_identifier = first(field.related_model.table_schema().identifier)
         result[related_identifier] = value
         return result
 

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -73,15 +73,16 @@ class TemporalRetrieveModelMixin:
         if not self.request.versioned or not self.model.is_temporal():
             return super().get_object()
 
+        table_schema = self.model.table_schema()
         pk = self.kwargs.get("pk")
-        pk_field = self.request.dataset.identifier
+        pk_field = table_schema.identifier[0]
         if pk_field != "pk":
             queryset = queryset.filter(
                 models.Q(**{pk_field: pk}) | models.Q(pk=pk)
             )  # fallback to full id search.
         else:
             queryset = queryset.filter(pk=pk)
-        identifier = queryset.model.table_schema().temporal.identifier
+        identifier = table_schema.temporal.identifier
 
         # Filter queryset using GET parameters, if any.
         for field in queryset.model.table_schema().fields:

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -18,6 +18,7 @@ from django.db import models
 from django.http import Http404, JsonResponse
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from more_itertools import first
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -75,7 +76,7 @@ class TemporalRetrieveModelMixin:
 
         table_schema = self.model.table_schema()
         pk = self.kwargs.get("pk")
-        pk_field = table_schema.identifier[0]
+        pk_field = first(table_schema.identifier)
         if pk_field != "pk":
             queryset = queryset.filter(
                 models.Q(**{pk_field: pk}) | models.Q(pk=pk)

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -184,7 +184,8 @@ class LinksField(serializers.HyperlinkedIdentityField):
         if value.is_temporal():
             temporal_fieldname = value.table_schema().temporal.identifier
             temporal_value = getattr(value, temporal_fieldname)
-            id_fieldname = value.get_dataset_schema().get("identifier")
+            id_fieldname = value.table_schema().identifier[0]
+
             id_value = getattr(value, id_fieldname)
             output.update({temporal_fieldname: temporal_value, id_fieldname: id_value})
 

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.utils.functional import cached_property
+from more_itertools import first
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 
@@ -184,7 +185,7 @@ class LinksField(serializers.HyperlinkedIdentityField):
         if value.is_temporal():
             temporal_fieldname = value.table_schema().temporal.identifier
             temporal_value = getattr(value, temporal_fieldname)
-            id_fieldname = value.table_schema().identifier[0]
+            id_fieldname = first(value.table_schema().identifier)
 
             id_value = getattr(value, id_fieldname)
             output.update({temporal_fieldname: temporal_value, id_fieldname: id_value})


### PR DESCRIPTION
The temporal info has been move down from dataset to table.
The main temporal identifier, was still obtained from the dataset
that has now been corrected.