### PR TITLE
AB#8005 Fix remote client error handling and logging

### DIFF
--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -15,7 +15,7 @@ import urllib3
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from more_ds.network.url import URL
-from rest_framework.exceptions import NotAuthenticated, NotFound, ParseError, PermissionDenied
+from rest_framework.exceptions import NotFound, ParseError, PermissionDenied
 from schematools.types import DatasetTableSchema
 from urllib3 import HTTPResponse
 
@@ -211,7 +211,7 @@ class AuthForwardingClient(RemoteClient):
         if 300 <= response.status <= 399 and (
             "/oauth/authorize" in response.headers.get("Location", "")
         ):
-            raise NotAuthenticated("Invalid token")
+            raise PermissionDenied("Invalid token")
 
 
 class HCBRKClient(RemoteClient):

--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from more_ds.network.url import URL
 from rest_framework.exceptions import NotFound, ParseError, PermissionDenied
+from rest_framework.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from schematools.types import DatasetTableSchema
 from urllib3 import HTTPResponse
 
@@ -161,7 +162,7 @@ class RemoteClient:
                 )
             else:
                 raise BadGateway(detail_message)
-        elif response.status in (401, 403):  # "unauthorized", "forbidden"
+        elif response.status in (HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN):
             # We translate 401 to 403 because 401 must always have a
             # WWW-Authenticate header in the response and we can't easily
             # set that from here.

--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -15,7 +15,7 @@ import urllib3
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from more_ds.network.url import URL
-from rest_framework.exceptions import NotAuthenticated, NotFound, ParseError
+from rest_framework.exceptions import NotAuthenticated, NotFound, ParseError, PermissionDenied
 from schematools.types import DatasetTableSchema
 from urllib3 import HTTPResponse
 
@@ -68,7 +68,7 @@ class RemoteClient:
             logger.error("Proxy call to %s failed, error when connecting to server: %s", url, e)
             raise ServiceUnavailable(str(e)) from e
 
-        level = logging.ERROR if response.status >= 500 else logging.INFO
+        level = logging.ERROR if response.status >= 400 else logging.INFO
         logger.log(level, "Proxy call to %s, status %s: %s", url, response.status, response.reason)
 
         if response.status == 200:
@@ -151,11 +151,7 @@ class RemoteClient:
             detail_message = response.data.decode()
 
         if response.status == 400:  # "bad request"
-            if response.data == b"Missing required MKS headers":
-                # Didn't pass the MKS_APPLICATIE / MKS_GEBRUIKER headers.
-                # Shouldn't occur anymore since it's JWT-token based now.
-                raise NotAuthenticated("Internal credentials are missing")
-            elif content_type == "application/problem+json":
+            if content_type == "application/problem+json":
                 # Translate proper "Bad Request" to REST response
                 raise RemoteAPIException(
                     title=ParseError.default_detail,
@@ -165,9 +161,11 @@ class RemoteClient:
                 )
             else:
                 raise BadGateway(detail_message)
-        elif response.status == 403:  # "forbidden"
-            # Return 403 to client as well
-            raise NotAuthenticated(detail_message)
+        elif response.status in (401, 403):  # "unauthorized", "forbidden"
+            # We translate 401 to 403 because 401 must always have a
+            # WWW-Authenticate header in the response and we can't easily
+            # set that from here.
+            raise PermissionDenied(detail_message)
         elif response.status == 404:  # "not found"
             # Return 404 to client (in DRF format)
             if content_type == "application/problem+json":

--- a/src/tests/test_dynamic_api/remote/test_views.py
+++ b/src/tests/test_dynamic_api/remote/test_views.py
@@ -309,6 +309,25 @@ def test_remote_404_problem_json(api_client, router, brp_dataset, urllib3_mocker
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("remote_status", [401, 403])
+def test_brp_not_authenticated(
+    api_client, filled_router, brp_dataset, urllib3_mocker, remote_status
+):
+    """Test auth error handling: 401 and 403 should both become 403."""
+
+    urllib3_mocker.add_callback(
+        "GET",
+        "/unittest/brp/ingeschrevenpersonen/999990901",
+        callback=lambda request: (remote_status, {}, None),
+        content_type="application/json",
+    )
+
+    url = reverse("dynamic_api:brp-ingeschrevenpersonen-detail", kwargs={"pk": "999990901"})
+    response = api_client.get(url)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_remote_timeout(api_client, router, brp_dataset, urllib3_mocker):
     """Prove that the remote router can proxy the other service."""
 


### PR DESCRIPTION
Log client errors at error level.

Remove MKS header handling, it's not longer in use.

Return 401 or 403 from remote as 403. We previously returned 403 as 401 (by mistake) and returned 401 as 502 Bad Gateway.