### PR TITLE
Yrob/ab5522 separate path from id

### DIFF
--- a/docs/source/datasets.py
+++ b/docs/source/datasets.py
@@ -113,8 +113,6 @@ def render_dataset_docs(dataset: DatasetSchema):
     else:
         wfs_url = None
 
-    path = f"{dataset.url_prefix}/{snake_name}" if dataset.url_prefix else snake_name
-
     render_template(
         "datasets/dataset.rst.j2",
         f"datasets/{snake_name}.rst",
@@ -125,7 +123,7 @@ def render_dataset_docs(dataset: DatasetSchema):
             "main_title": main_title,
             "tables": tables,
             "wfs_url": wfs_url,
-            "swagger_url": f"{BASE_URL}/v1/{path}/",
+            "swagger_url": f"{BASE_URL}/v1/{dataset.path}/",
         },
     )
 

--- a/src/dso_api/dynamic_api/remote/serializers.py
+++ b/src/dso_api/dynamic_api/remote/serializers.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+from schematools.contrib.django.models import Dataset
 from schematools.types import DatasetFieldSchema, DatasetTableSchema
 from schematools.utils import to_snake_case, toCamelCase
 
@@ -50,7 +51,6 @@ class RemoteSerializer(DSOSerializer):
     """Serializer that takes remote data"""
 
     table_schema = None  # defined by factory
-
     schema = serializers.SerializerMethodField()
 
     _default_list_serializer_class = RemoteListSerializer
@@ -60,7 +60,8 @@ class RemoteSerializer(DSOSerializer):
         """The schema field is exposed with every record"""
         name = self.table_schema._parent_schema.id
         table = self.table_schema.id
-        return f"https://schemas.data.amsterdam.nl/datasets/{name}/{name}#{table}"
+        dataset_path = Dataset.objects.get(name=name).path
+        return f"https://schemas.data.amsterdam.nl/datasets/{dataset_path}/dataset#{table}"
 
 
 class RemoteObjectSerializer(DSOSerializer):

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -197,10 +197,9 @@ class DynamicRouter(routers.DefaultRouter):
                     continue
 
                 dataset_id = model.get_dataset_id()
-                dataset = db_datasets[dataset_id]
 
                 # Determine the URL prefix for the model
-                url_prefix = self.make_url(dataset.url_prefix, dataset_id, model.get_table_id())
+                url_prefix = self.make_url(model.get_dataset_path(), model.get_table_id())
 
                 logger.debug("Created viewset %s", url_prefix)
                 viewset = viewset_factory(model)
@@ -218,12 +217,11 @@ class DynamicRouter(routers.DefaultRouter):
         tmp_router = routers.SimpleRouter()
 
         for dataset in api_datasets:
-            schema = dataset.schema
-            dataset_id = schema.id
+            dataset_id = dataset.schema.id
 
-            for table in schema.tables:
+            for table in dataset.schema.tables:
                 # Determine the URL prefix for the model
-                url_prefix = self.make_url(dataset.url_prefix, dataset_id, table.id)
+                url_prefix = self.make_url(dataset.path, table.id)
                 serializer_class = remote_serializer_factory(table)
                 viewset = remote_viewset_factory(
                     endpoint_url=dataset.endpoint_url,
@@ -245,7 +243,7 @@ class DynamicRouter(routers.DefaultRouter):
             dataset_id = dataset.schema.id
             results.append(
                 path(
-                    self.make_url(dataset.url_prefix, dataset_id) + "/",
+                    dataset.path + "/",
                     get_openapi_json_view(dataset),
                     name=f"openapi-{dataset_id}",
                 )

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -243,16 +243,9 @@ class DynamicSerializer(DSOModelSerializer):
     @extend_schema_field(OpenApiTypes.URI)
     def get_schema(self, instance):
         """The schema field is exposed with every record"""
-        name = instance.get_dataset_id()
         table = instance.get_table_id()
-        url_parts = [name]
-        url_prefix = instance.get_dataset().url_prefix
-        if url_prefix:
-            url_parts.insert(0, url_prefix.strip("/"))
-        else:
-            url_parts.append(name)
-
-        return f"https://schemas.data.amsterdam.nl/datasets/{'/'.join(url_parts)}#{table}"
+        dataset_path = instance.get_dataset_path()
+        return f"https://schemas.data.amsterdam.nl/datasets/{dataset_path}/dataset#{table}"
 
     def build_url_field(self, field_name, model_class):
         """Make sure the generated URLs point to our dynamic models"""

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -10,7 +10,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 0.21.8
+amsterdam-schema-tools[django] == 0.21.9
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.21.8
+amsterdam-schema-tools[django]==0.21.9
     # via -r requirements.in
 asgiref==3.3.4
     # via django

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -241,7 +241,9 @@ def afval_schema_backwards_summary(
 
 @pytest.fixture()
 def afval_dataset(afval_schema_json) -> Dataset:
-    return Dataset.objects.create(name="afvalwegingen", schema_data=afval_schema_json)
+    return Dataset.objects.create(
+        name="afvalwegingen", path="afvalwegingen", schema_data=afval_schema_json
+    )
 
 
 @pytest.fixture()
@@ -345,7 +347,7 @@ def brp_dataset(brp_schema_json, brp_endpoint_url) -> Dataset:
         schema_data=brp_schema_json,
         enable_db=False,
         endpoint_url=brp_endpoint_url,
-        url_prefix="remote",
+        path="remote/brp",
     )
 
 
@@ -357,7 +359,7 @@ def hcbrk_dataset() -> Dataset:
         enable_db=False,
         # URL netloc needs ".acceptatie." because of HTTP pool selection.
         endpoint_url="http://fake.acceptatie.kadaster/esd/bevragen/v1/{table_id}",
-        url_prefix="remote",
+        path="remote/hcbrk",
     )
 
 
@@ -467,7 +469,9 @@ def parkeervakken_schema(parkeervakken_schema_json) -> DatasetSchema:
 
 @pytest.fixture()
 def parkeervakken_dataset(parkeervakken_schema_json) -> Dataset:
-    return Dataset.objects.create(name="parkeervakken", schema_data=parkeervakken_schema_json)
+    return Dataset.objects.create(
+        name="parkeervakken", path="parkeervakken", schema_data=parkeervakken_schema_json
+    )
 
 
 @pytest.fixture()
@@ -538,7 +542,9 @@ def vestiging2(vestiging_vestiging_model, bezoek_adres2, post_adres1):
 
 @pytest.fixture()
 def vestiging_dataset(vestiging_schema_json) -> Dataset:
-    return Dataset.objects.create(name="vestiging", schema_data=vestiging_schema_json)
+    return Dataset.objects.create(
+        name="vestiging", path="vestiging", schema_data=vestiging_schema_json
+    )
 
 
 @pytest.fixture()
@@ -598,7 +604,9 @@ def fietspaaltjes_schema_json() -> dict:
 
 @pytest.fixture()
 def fietspaaltjes_dataset(fietspaaltjes_schema_json) -> Dataset:
-    return Dataset.objects.create(name="fietspaaltjes", schema_data=fietspaaltjes_schema_json)
+    return Dataset.objects.create(
+        name="fietspaaltjes", path="fietspaaltjes", schema_data=fietspaaltjes_schema_json
+    )
 
 
 @pytest.fixture()
@@ -648,7 +656,9 @@ def fietspaaltjes_schema_json_no_display() -> dict:
 @pytest.fixture()
 def fietspaaltjes_dataset_no_display(fietspaaltjes_schema_json_no_display) -> Dataset:
     return Dataset.objects.create(
-        name="fietspaaltjesnodisplay", schema_data=fietspaaltjes_schema_json_no_display
+        name="fietspaaltjesnodisplay",
+        path="fietspaaltjesnodisplay",
+        schema_data=fietspaaltjes_schema_json_no_display,
     )
 
 
@@ -698,7 +708,9 @@ def explosieven_schema(
 
 @pytest.fixture()
 def explosieven_dataset(explosieven_schema_json) -> Dataset:
-    return Dataset.objects.create(name="explosieven", schema_data=explosieven_schema_json)
+    return Dataset.objects.create(
+        name="explosieven", path="explosieven", schema_data=explosieven_schema_json
+    )
 
 
 @pytest.fixture()
@@ -729,7 +741,9 @@ def indirect_self_ref_schema(indirect_self_ref_schema_json) -> DatasetSchema:
 @pytest.fixture()
 def indirect_self_ref_dataset(indirect_self_ref_schema_json) -> Dataset:
     return Dataset.objects.create(
-        name="indirect_self_ref", schema_data=indirect_self_ref_schema_json
+        name="indirect_self_ref",
+        path="indirect_self_ref",
+        schema_data=indirect_self_ref_schema_json,
     )
 
 
@@ -754,7 +768,9 @@ def download_url_schema(download_url_schema_json) -> DatasetSchema:
 
 @pytest.fixture()
 def download_url_dataset(download_url_schema_json) -> Dataset:
-    return Dataset.objects.create(name="download", schema_data=download_url_schema_json)
+    return Dataset.objects.create(
+        name="download", path="download", schema_data=download_url_schema_json
+    )
 
 
 @pytest.fixture()
@@ -774,7 +790,9 @@ def meldingen_dataset(
     gebieden_dataset,  # dependency in schema
     meldingen_schema_json,
 ) -> Dataset:
-    return Dataset.objects.create(name="meldingen", schema_data=meldingen_schema_json)
+    return Dataset.objects.create(
+        name="meldingen", path="meldingen", schema_data=meldingen_schema_json
+    )
 
 
 @pytest.fixture()
@@ -800,7 +818,9 @@ def gebieden_schema(gebieden_schema_json) -> DatasetSchema:
 @pytest.fixture()
 def _gebieden_dataset(gebieden_schema_json) -> Dataset:
     """Internal"""
-    return Dataset.objects.create(name="gebieden", schema_data=gebieden_schema_json)
+    return Dataset.objects.create(
+        name="gebieden", path="gebieden", schema_data=gebieden_schema_json
+    )
 
 
 @pytest.fixture()
@@ -826,7 +846,7 @@ def bag_schema(bag_schema_json) -> DatasetSchema:
 
 @pytest.fixture()
 def bag_dataset(bag_schema_json) -> Dataset:
-    return Dataset.objects.create(name="bag", schema_data=bag_schema_json)
+    return Dataset.objects.create(name="bag", path="bag", schema_data=bag_schema_json)
 
 
 @pytest.fixture()
@@ -846,7 +866,9 @@ def woningbouwplannen_dataset(woningbouwplannen_schema_json, _gebieden_dataset) 
     # Woningbouwplannen has a dependency on gebieden,
     # so this fixture makes sure it's always loaded.
     return Dataset.objects.create(
-        name="woningbouwplannen", schema_data=woningbouwplannen_schema_json
+        name="woningbouwplannen",
+        path="woningbouwplannen",
+        schema_data=woningbouwplannen_schema_json,
     )
 
 

--- a/src/tests/settings.py
+++ b/src/tests/settings.py
@@ -11,7 +11,7 @@ INSTALLED_APPS += [
 DATABASES = {
     "default": env.db_url(
         "DATABASE_URL",
-        default="postgres://dataservices:insecure@localhost:5415/dataservices",
+        default="postgres://dataservices:insecure@localhost:5416/dataservices",
         engine="django.contrib.gis.db.backends.postgis",
     ),
 }

--- a/src/tests/test_dynamic_api/remote/test_views.py
+++ b/src/tests/test_dynamic_api/remote/test_views.py
@@ -75,7 +75,7 @@ SUCCESS_TESTS = {
     "default": (
         DEFAULT_RESPONSE,
         {
-            "schema": "https://schemas.data.amsterdam.nl/datasets/brp/brp#ingeschrevenpersonen",
+            "schema": "https://schemas.data.amsterdam.nl/datasets/remote/brp/dataset#ingeschrevenpersonen",  # noqa: E501
             "_links": {
                 "self": {"href": "http://testserver/v1/remote/brp/ingeschrevenpersonen/999990901/"}
             },
@@ -85,7 +85,7 @@ SUCCESS_TESTS = {
     "small": (
         SMALL_RESPONSE,
         {
-            "schema": "https://schemas.data.amsterdam.nl/datasets/brp/brp#ingeschrevenpersonen",
+            "schema": "https://schemas.data.amsterdam.nl/datasets/remote/brp/dataset#ingeschrevenpersonen",  # noqa: E501
             "_links": {
                 "self": {"href": "http://testserver/v1/remote/brp/ingeschrevenpersonen/999990901/"}
             },
@@ -403,7 +403,7 @@ HCBRK_NATUURLIJKPERSOON = (
 
 
 DSO_NATUURLIJK_PERSOON = {
-    "schema": "https://schemas.data.amsterdam.nl/datasets/hcbrk/hcbrk#kadasternatuurlijkpersonen",
+    "schema": "https://schemas.data.amsterdam.nl/datasets/remote/hcbrk/dataset#kadasternatuurlijkpersonen",  # noqa: E501
     "naam": {
         "aanhef": "Geachte heer Jansens",
         "voornamen": "Willem",
@@ -469,7 +469,7 @@ HCBRK_ONROERENDE_ZAAK = (
 
 
 DSO_ONROERENDE_ZAAK = {
-    "schema": "https://schemas.data.amsterdam.nl/datasets/hcbrk/hcbrk#kadastraalonroerendezaken",
+    "schema": "https://schemas.data.amsterdam.nl/datasets/remote/hcbrk/dataset#kadastraalonroerendezaken",  # noqa: E501
     "type": "perceel",
     "domein": "NL.IMKAD.KadastraalObject",
     "koopsom": {"koopsom": 185000, "koopjaar": 2015},

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -93,7 +93,7 @@ class TestDynamicSerializer:
                     "href": "http://testserver/v1/afvalwegingen/clusters/123.456/",
                     "title": "123.456",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/2/",
                     "title": "2",
@@ -127,7 +127,7 @@ class TestDynamicSerializer:
         data = normalize_data(container_serializer.data)
         assert data == {
             "_links": {
-                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/2/",
                     "title": "2",
@@ -151,7 +151,7 @@ class TestDynamicSerializer:
                             "href": "http://testserver/v1/afvalwegingen/clusters/123.456/",
                             "title": "123.456",
                         },
-                        "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#clusters",  # noqa: E501
+                        "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#clusters",  # noqa: E501
                     },
                     "id": "123.456",
                     "status": "open",
@@ -179,7 +179,7 @@ class TestDynamicSerializer:
         data = normalize_data(container_serializer.data)
         assert data == {
             "_links": {
-                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/3/",
                     "title": "3",
@@ -220,7 +220,7 @@ class TestDynamicSerializer:
                     "href": "http://testserver/v1/afvalwegingen/containers/4/",
                     "title": "4",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/afvalwegingen#containers",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#containers",  # noqa: E501
             },
             "id": 4,
             "clusterId": 99,
@@ -233,7 +233,7 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_dataset_url_prefix(
+    def test_dataset_path(
         drf_request,
         afval_dataset,
         afval_container_model,
@@ -241,18 +241,19 @@ class TestDynamicSerializer:
         afval_cluster_model,
         filled_router,
     ):
-        """Prove dataset url_prefix works.
+        """Prove dataset url sub paths works.
 
         The schema in _links contains correct URLs.
         """
-        afval_dataset.url_prefix = "test"
-        afval_dataset.save()
+        afval_dataset.path = "test/" + afval_dataset.path
+
         # Update dataset in instance cache
         afval_container_model._dataset = afval_dataset
         afval_cluster_model._dataset = afval_dataset
         drf_request.dataset = afval_dataset.schema
         ContainerSerializer = serializer_factory(afval_container_model, 0)
         afval_container = afval_container_model.objects.create(id=2, cluster=afval_cluster)
+
         # Prove that expands work on object-detail level
         container_serializer = ContainerSerializer(
             afval_container,
@@ -262,7 +263,7 @@ class TestDynamicSerializer:
         data = normalize_data(container_serializer.data)
         assert data == {
             "_links": {
-                "schema": "https://schemas.data.amsterdam.nl/datasets/test/afvalwegingen#containers",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/test/afvalwegingen/dataset#containers",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/afvalwegingen/containers/2/",
                     "title": "2",
@@ -286,7 +287,7 @@ class TestDynamicSerializer:
                             "href": "http://testserver/v1/afvalwegingen/clusters/123.456/",
                             "title": "123.456",
                         },
-                        "schema": "https://schemas.data.amsterdam.nl/datasets/test/afvalwegingen#clusters",  # noqa: E501
+                        "schema": "https://schemas.data.amsterdam.nl/datasets/test/afvalwegingen/dataset#clusters",  # noqa: E501
                     },
                     "id": "123.456",
                     "status": "open",
@@ -328,7 +329,7 @@ class TestDynamicSerializer:
                     "volgnummer": 1,
                     "identificatie": "0363",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#stadsdelen",  # NoQA
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#stadsdelen",  # NoQA
                 "wijk": [
                     {
                         "href": "http://testserver/v1/gebieden/wijken/03630000000001/?volgnummer=1",  # NoQA
@@ -375,7 +376,7 @@ class TestDynamicSerializer:
                     "href": "http://testserver/v1/vestiging/vestiging/1/",
                     "title": "1",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/dataset#vestiging",  # noqa: E501
                 "postAdres": {
                     "href": "http://testserver/v1/vestiging/adres/3/",
                     "title": "3",
@@ -402,7 +403,7 @@ class TestDynamicSerializer:
                     "href": "http://testserver/v1/vestiging/vestiging/2/",
                     "title": "2",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#vestiging",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/dataset#vestiging",  # noqa: E501
                 "postAdres": {
                     "href": "http://testserver/v1/vestiging/adres/3/",
                     "title": "3",
@@ -426,7 +427,7 @@ class TestDynamicSerializer:
         data = normalize_data(adres_serializer.data)
         assert data == {
             "_links": {
-                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/vestiging#adres",
+                "schema": "https://schemas.data.amsterdam.nl/datasets/vestiging/dataset#adres",
                 "self": {
                     "href": "http://testserver/v1/vestiging/adres/3/",
                     "title": "3",
@@ -500,7 +501,7 @@ class TestDynamicSerializer:
                 "self": {
                     "href": "http://testserver/v1/parkeervakken/parkeervakken/121138489047/",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/parkeervakken#parkeervakken",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/dataset#parkeervakken",  # noqa: E501
             },
             "geometry": None,
             "id": "121138489047",
@@ -578,7 +579,7 @@ class TestDynamicSerializer:
         assert data == {
             "_links": {
                 "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/121138489047/"},
-                "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/parkeervakken#parkeervakken",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/parkeervakken/dataset#parkeervakken",  # noqa: E501
             },
             "geometry": None,
             "id": "121138489047",

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -740,7 +740,7 @@ class TestEmbedTemporalTables:
                     "title": "03630012052035.1",
                     "volgnummer": 1,
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#buurten",
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
                 "self": {
                     "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=1",
                     "identificatie": "03630000000078",
@@ -810,7 +810,7 @@ class TestEmbedTemporalTables:
                         "identificatie": "03630950000000",
                     }
                 ],
-                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#buurten",
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
                 "self": {
                     "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=1",
                     "title": "03630000000078.1",
@@ -831,7 +831,7 @@ class TestEmbedTemporalTables:
         }
         assert dict(data["_embedded"]["ggwgebieden"][0]) == {
             "_links": {
-                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#ggwgebieden",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#ggwgebieden",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/gebieden/ggwgebieden/03630950000000/?volgnummer=1",  # noqa: E501
                     "title": "03630950000000.1",
@@ -877,7 +877,7 @@ class TestEmbedTemporalTables:
                     "title": "03630000000078",
                     "identificatie": "03630000000078",
                 },
-                "schema": "https://schemas.data.amsterdam.nl/datasets/meldingen/meldingen#statistieken",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/meldingen/dataset#statistieken",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/meldingen/statistieken/1/",
                     "title": "1",
@@ -900,7 +900,7 @@ class TestEmbedTemporalTables:
         assert response.status_code == 200, data
         assert data == {
             "_links": {
-                "schema": "https://schemas.data.amsterdam.nl/datasets/meldingen/meldingen#statistieken",  # noqa: E501
+                "schema": "https://schemas.data.amsterdam.nl/datasets/meldingen/dataset#statistieken",  # noqa: E501
                 "self": {
                     "href": "http://testserver/v1/meldingen/statistieken/1/",
                     "title": "1",
@@ -916,7 +916,7 @@ class TestEmbedTemporalTables:
             "_embedded": {
                 "buurt": {
                     "_links": {
-                        "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/gebieden#buurten",  # noqa: E501
+                        "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",  # noqa: E501
                         "self": {
                             "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2",  # noqa: E501
                             "title": "03630000000078.2",


### PR DESCRIPTION
# This Pull request contains changes to:

Construct dataset api URls using the `path` property of Dataset, that is introduced in the new version of schema-tools.
This replaces earlier logic based on datasetId.