### PR TITLE
Refactor authentication to use native schema objects (DSO-API part)

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -1,107 +1,31 @@
-from dataclasses import dataclass, field
-from typing import Dict, List, Set, Type
+from typing import List
 
-from cachetools.func import ttl_cache
-from django.contrib.auth.models import AnonymousUser, _user_has_perm
-from django.db.models import Model
+from django.core.exceptions import PermissionDenied
 from rest_framework import permissions
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.viewsets import ViewSetMixin
-from schematools.contrib.django import models
-from schematools.utils import to_snake_case, toCamelCase
+from schematools.permissions import UserScopes
 
 from rest_framework_dso.embedding import EmbeddedFieldMatch
 
 
-@dataclass
-class TableScopes:
-    """OAuth scopes for tables and fields."""
-
-    # Table and dataset scopes.
-    table: Set[str] = field(default_factory=set)
-    # Scope per field.
-    fields: Dict[str, str] = field(default_factory=dict)
-
-
-@ttl_cache(maxsize=None, ttl=60 * 60)
-def fetch_scopes_for_dataset_table(dataset_id: str, table_id: str):
-    """ Get the scopes for a dataset and table, based on the Amsterdam schema information """
-
-    # Make sure that names are snake_cased
-    # if used for a lookup in models.DatasetTable.objects
-    # TODO: do snake_case transformations at one centralized place to
-    # to be used in code (as much as possible)
-    dataset_id = to_snake_case(dataset_id)
-    table_id = to_snake_case(table_id)
-
-    try:
-        table = models.DatasetTable.objects.get(name=table_id, dataset__name=dataset_id)
-    except models.DatasetTable.DoesNotExist:
-        return TableScopes()
-
-    return TableScopes(
-        table=frozenset(level.auth for level in [table, table.dataset] if level.auth is not None),
-        fields={field.name: field.auth for field in table.fields.all() if field.auth is not None},
-    )
-
-
-@ttl_cache(ttl=60 * 60)
-def fetch_scopes_for_model(model: Type[Model]) -> TableScopes:
-    """ Get the scopes for a Django model, based on the Amsterdam schema information """
-
-    # If it is not a DSO-based model, we leave it alone
-    if not hasattr(model, "_dataset_schema"):
-        return TableScopes()
-    table = model._table_schema.id
-    dataset = model._meta.app_label
-
-    return fetch_scopes_for_dataset_table(dataset, table)
-
-
-def get_unauthorized_fields(request, model) -> Set[str]:
-    """Returns a list of field names to be excluded from a response."""
-    # is_authorized_for is added by authorization_django middleware
-    # only if an authorization check is necessary.
-    if not hasattr(request, "is_authorized_for"):
-        return set()
-
-    model_scopes = fetch_scopes_for_model(model)
-    unauthorized_fields = set()
-
-    for model_field in model._meta.get_fields():
-        required = model_scopes.table
-        field_scope = model_scopes.fields.get(model_field.name)
-        if field_scope is not None:
-            required = required | set([field_scope])
-
-        if not request.is_authorized_for(*required):
-            permission_key = get_permission_key_for_field(model_field)
-            if not request_has_permission(request=request, perm=permission_key):
-                unauthorized_fields.add(toCamelCase(model_field.name))
-
-    return unauthorized_fields
-
-
 def filter_unauthorized_expands(
-    request, expanded_fields: List[EmbeddedFieldMatch], skip_unauth=False
+    user_scopes: UserScopes, expanded_fields: List[EmbeddedFieldMatch], skip_unauth=False
 ) -> List[EmbeddedFieldMatch]:
     """Remove expanded fields if these are not accessible"""
-    if not hasattr(request, "is_authorized_for"):
-        # Not using 'authorization_django' middleware.
-        return expanded_fields
-
     result = []
     for match in expanded_fields:
-        scopes = fetch_scopes_for_model(match.field.related_model)
-        if not request.is_authorized_for(*scopes.table):
+        field_perm = user_scopes.has_field_access(match.field.field_schema)
+        table_perm = user_scopes.has_table_access(match.field.related_model.table_schema())
+        if field_perm and table_perm:
+            # Only add the field when there is permission
+            result.append(match)
+        else:
             if skip_unauth:
                 # Not allowed, but can silently drop for "auto expand all"
                 continue
 
             # Explicitly mentioned, raise error.
             raise PermissionDenied(f"Eager loading not allowed for field '{match.full_name}'")
-
-        result.append(match)
 
     return result
 
@@ -111,73 +35,61 @@ class HasOAuth2Scopes(permissions.BasePermission):
     Custom permission to check auth scopes from Amsterdam schema.
     """
 
-    def _has_permission(self, request, view, dataset_id=None, table_id=None):
+    def has_permission(self, request, view):
+        """Tests whether a view can be requested."""
         if request.method == "OPTIONS":
             return True
-        scopes = fetch_scopes_for_dataset_table(dataset_id, table_id)
-        if request.is_authorized_for(*scopes.table):
-            return True  # authorized by scope
-        # Check for DRF classes (not WFS, MVT).
-        elif isinstance(view, ViewSetMixin):
-            if view.action_map["get"] == "retrieve":  # is a detailview
-                request.auth_profile.valid_query_params = (
-                    request.auth_profile.get_valid_query_params() + view.table_schema.identifier
-                )
-            active_profiles = request.auth_profile.get_active_profiles(dataset_id, table_id)
-            if active_profiles:
-                return True
-        return False
 
-    def has_permission_for_models(self, request, view, models):
-        return all(
-            self._has_permission(
-                request,
-                view,
-                dataset_id=model._dataset_schema["id"],
-                table_id=model._table_schema["id"],
-            )
-            for model in models
-        )
-
-    def has_permission(self, request, view):
-        """Based on the model that is associated with the view
-        the Dataset and DatasetTable (if available)
-        are checked for their 'auth' field.
-
-        This method overrides BasePermission.has_permission."""
-        if hasattr(view, "dataset_id") and hasattr(view, "table_id"):
-            return self._has_permission(
-                request, view, dataset_id=view.dataset_id, table_id=view.table_id
-            )
-        else:
+        try:
+            model = view.model
+        except AttributeError:
             model = view.get_serializer_class().Meta.model
-            return self.has_permission_for_models(request, view, [model])
+
+        if isinstance(view, ViewSetMixin) and view.action_map["get"] == "retrieve":
+            # For detail views, consider the identifier to be part of the query parameters already.
+            # This affects the mandatoryFilterSets matching on profile objects.
+            request.user_scopes.add_query_params(view.table_schema.identifier)
+
+        return request.user_scopes.has_table_access(model.table_schema())
 
     def has_object_permission(self, request, view, obj):
-        """ This method is not called for list views """
-        # XXX For now, this is OK, later on we need to add row-level permissions
-        return self._has_permission(
-            request,
-            view,
-            dataset_id=obj._dataset_schema["id"],
-            table_id=obj._table_schema["id"],
-        )
+        """Tests whether the view may access a particular object."""
+        if request.method == "OPTIONS":
+            return True
+
+        # NOTE: For now, this is OK, later on we need to add row-level permissions.
+        return request.user_scopes.has_table_access(obj.table_schema())
+
+    def has_permission_for_models(self, request, view, models):
+        """Tests whether a set of models can be accessed.
+        This variation doesn't exist in the standard DRF permission logic, but is used
+        for the WFS/VMT views that reuse this permission class for checks.
+        """
+        if request.method == "OPTIONS":
+            return True
+
+        return all(request.user_scopes.has_table_access(model.table_schema()) for model in models)
 
 
-def get_permission_key_for_field(model_field):
-    model = model_field.model
-    return models.generate_permission_key(
-        model._meta.app_label, model._meta.model_name, model_field.name
-    )
+class CheckPermissionsMixin:
+    """Mixin that adds a ``check_permissions()`` function to the view,
+    which supports the DRF-plugins for permission checks on a non-DRF view (e.g. WFS/MVT).
+    """
 
+    #: Custom permission that checks amsterdam schema auth settings
+    permission_classes = [HasOAuth2Scopes]
 
-def request_has_permission(request, perm, obj=None):
-    """Checks if request has permission by using authentication backend."""
-    if not hasattr(request, "user") or request.user is None:
-        request.user = AnonymousUser()
+    def check_permissions(self, request, models):
+        """
+        Check if the request should be permitted.
+        """
+        for permission in self.get_permissions():
+            if not permission.has_permission_for_models(request, self, models):
+                # Is Django's PermissionDenied so non-DRF views can handle this.
+                raise PermissionDenied()
 
-    if not hasattr(request.user, "request"):
-        # Backport request in order to get ProfileAuthBackend working
-        request.user.request = request
-
-    return _user_has_perm(request.user, perm, obj)
+    def get_permissions(self):
+        """
+        Instantiates and returns the list of permissions that this view requires.
+        """
+        return [permission() for permission in self.permission_classes]

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -292,7 +292,7 @@ class APIIndexView(APIView):
                 },
                 "environments": self.get_environments(ds, base),
                 "related_apis": self.get_related_apis(ds, base),
-                "api_authentication": ds.schema.auth,
+                "api_authentication": list(ds.schema.auth) or None,
                 "api_type": self.api_type,
                 "organization_name": "Gemeente Amsterdam",
                 "organization_oin": "00000001002564440000",

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,3 @@
-cachetools == 4.2.2
 Django == 3.1.12
 django-environ == 0.4.5
 django-cors-headers == 3.7.0
@@ -10,7 +9,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 0.21.13
+amsterdam-schema-tools[django] == 0.22.0
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==0.21.13
+amsterdam-schema-tools[django]==0.22.0
     # via -r requirements.in
 asgiref==3.3.4
     # via django
@@ -19,7 +19,6 @@ azure-storage-blob==12.8.0
     # via -r requirements.in
 cachetools==4.2.2
     # via
-    #   -r requirements.in
     #   amsterdam-schema-tools
     #   google-auth
 certifi==2020.12.5

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -17,8 +17,8 @@ from django.utils.timezone import get_current_timezone
 from jwcrypto.jwt import JWT
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
-from schematools.contrib.django.auth_backend import RequestProfile
 from schematools.contrib.django.models import Dataset, DynamicModel, Profile
+from schematools.permissions import UserScopes
 from schematools.types import DatasetSchema, ProfileSchema
 
 from rest_framework_dso.crs import RD_NEW
@@ -44,8 +44,11 @@ def api_request(api_rf) -> WSGIRequest:
     request.response_content_crs = None
 
     request.user = AnonymousUser()
-    request.auth_profile = RequestProfile(request)
-    request.is_authorized_for = lambda *scopes: True
+    request.is_authorized_for = lambda *scopes: True  # note: this is copied into user_scopes
+    request.user_scopes = UserScopes(
+        query_params=request.GET,
+        is_authorized_for=request.is_authorized_for,
+    )
 
     # Temporal modifications. Usually done via TemporalTableMiddleware
     request.versioned = False

--- a/src/tests/test_dynamic_api/remote/test_views.py
+++ b/src/tests/test_dynamic_api/remote/test_views.py
@@ -6,7 +6,7 @@ import urllib3
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 from schematools.contrib.django import models
-from schematools.types import DatasetTableSchema
+from schematools.types import DatasetTableSchema, ProfileSchema
 from urllib3_mock import Responses
 
 from dso_api.dynamic_api.remote.clients import RemoteClient
@@ -137,22 +137,24 @@ def test_remote_detail_view_with_profile_scope(
     brp_schema_json,
     brp_endpoint_url,
 ):
-    models.Profile.objects.create(
-        name="profiel",
-        scopes=["PROFIEL/SCOPE"],
-        schema_data={
-            "datasets": {
-                "brp_test": {
-                    "tables": {
-                        "ingeschrevenpersonen": {
-                            "mandatoryFilterSets": [
-                                ["id"],
-                            ],
+    models.Profile.create_for_schema(
+        ProfileSchema.from_dict(
+            {
+                "name": "profiel",
+                "scopes": ["PROFIEL/SCOPE"],
+                "datasets": {
+                    "brp_test": {
+                        "tables": {
+                            "ingeschrevenpersonen": {
+                                "mandatoryFilterSets": [
+                                    ["id"],
+                                ],
+                            }
                         }
                     }
-                }
+                },
             }
-        },
+        )
     )
     # creating custom brp2 copy, as ttl_cache will keep auth value after this test
     # which breaks the other tests

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -4,17 +4,24 @@ import math
 
 import orjson
 import pytest
+from django.apps import apps
 from django.contrib.gis.geos import Point
 from django.db import connection
 from django.urls import NoReverseMatch, reverse
 from rest_framework.response import Response
 from schematools.contrib.django import models
 from schematools.contrib.django.db import create_tables
+from schematools.types import ProfileSchema
 
-from dso_api.dynamic_api.permissions import fetch_scopes_for_dataset_table, fetch_scopes_for_model
 from rest_framework_dso.crs import CRS, RD_NEW
 from rest_framework_dso.response import StreamingResponse
-from tests.utils import read_response, read_response_json
+from tests.utils import (
+    patch_dataset_auth,
+    patch_field_auth,
+    patch_table_auth,
+    read_response,
+    read_response_json,
+)
 
 
 class AproxFloat(float):
@@ -28,13 +35,6 @@ class AproxFloat(float):
 GEOJSON_POINT = [
     AproxFloat(c) for c in Point(10, 10, srid=RD_NEW.srid).transform("EPSG:4326", clone=True)
 ]
-
-
-@pytest.fixture(autouse=True)
-def clear_caches():
-    yield  # run tests first
-    fetch_scopes_for_dataset_table.cache_clear()
-    fetch_scopes_for_model.cache_clear()
 
 
 @pytest.mark.django_db
@@ -158,150 +158,149 @@ class TestAuth:
     """ Test authorization """
 
     def test_mandatory_filters(
-        self, api_client, fetch_auth_token, parkeervakken_parkeervak_model, filled_router
+        self,
+        api_client,
+        fetch_auth_token,
+        parkeervakken_schema,
+        parkeervakken_parkeervak_model,
+        filled_router,
     ):
         """
         Tests that profile permissions with are activated
         through querying with the right mandatoryFilterSets
         """
-        # need to reload router, regimes is a nested table
-        # and router will not know of it's existence
-        models.Profile.objects.create(
-            name="parkeerwacht",
-            scopes=["PROFIEL/SCOPE"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {
-                                "mandatoryFilterSets": [
-                                    ["buurtcode", "type"],
-                                    ["regimes.inWerkingOp"],
-                                ]
+        patch_table_auth(parkeervakken_schema, "parkeervakken", auth=["DATASET/SCOPE"])
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "parkeerwacht",
+                    "scopes": ["PROFIEL/SCOPE"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "permissions": "read",
+                                    "mandatoryFilterSets": [
+                                        ["buurtcode", "type"],
+                                        ["regimes.inWerkingOp"],
+                                    ],
+                                }
                             }
                         }
-                    }
+                    },
                 }
-            },
+            )
         )
-        models.Profile.objects.create(
-            name="parkeerwacht",
-            scopes=["PROFIEL2/SCOPE"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {"mandatoryFilterSets": [["regimes.aantal[gte]"]]}
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "parkeerwacht",
+                    "scopes": ["PROFIEL2/SCOPE"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "permissions": "read",
+                                    "mandatoryFilterSets": [
+                                        ["regimes.aantal[gte]"],
+                                    ],
+                                }
+                            }
                         }
-                    }
+                    },
                 }
-            },
+            )
         )
 
-        models.DatasetTable.objects.filter(name="parkeervakken").update(auth="DATASET/SCOPE")
+        def _get(token, params=""):
+            return api_client.get(f"{base_url}{params}", HTTP_AUTHORIZATION=f"Bearer {token}")
+
         token = fetch_auth_token(["PROFIEL/SCOPE"])
         base_url = reverse("dynamic_api:parkeervakken-parkeervakken-list")
         assert api_client.get(base_url).status_code == 403
-        assert api_client.get(base_url, HTTP_AUTHORIZATION=f"Bearer {token}").status_code == 403
-        assert (
-            api_client.get(
-                f"{base_url}?buurtcode=A05d", HTTP_AUTHORIZATION=f"Bearer {token}"
-            ).status_code
-            == 403
-        )
-        assert (
-            api_client.get(
-                f"{base_url}?buurtcode=A05d&type=E9",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            ).status_code
-            == 200
-        )
-        assert (
-            api_client.get(
-                f"{base_url}?regimes.inWerkingOp=20:05",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            ).status_code
-            == 200
-        )
-        assert (
-            api_client.get(
-                f"{base_url}?regimes.inWerkingOp=", HTTP_AUTHORIZATION=f"Bearer {token}"
-            ).status_code
-            == 403
-        )
-        assert (
-            api_client.get(
-                f"{base_url}?regimes.inWerkingOp", HTTP_AUTHORIZATION=f"Bearer {token}"
-            ).status_code
-            == 403
-        )
+        assert _get(token).status_code == 403
 
-        token = fetch_auth_token(["DATASET/SCOPE", "PROFIEL/SCOPE"])
-        assert api_client.get(base_url, HTTP_AUTHORIZATION=f"Bearer {token}").status_code == 200
-        token = fetch_auth_token(["DATASET/SCOPE"])
-        assert api_client.get(base_url, HTTP_AUTHORIZATION=f"Bearer {token}").status_code == 200
-        token = fetch_auth_token(["PROFIEL/SCOPE", "PROFIEL2/SCOPE"])
-        assert (
-            api_client.get(
-                f"{base_url}?regimes.inWerkingOp=20:05",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            ).status_code
-            == 200
-        )
-        assert (
-            api_client.get(
-                f"{base_url}?regimes.aantal[gte]=2",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            ).status_code
-            == 200
-        )
+        # See that only the proper filters activate the profile (via mandatoryFilterSets)
+        assert _get(token, "?buurtcode=A05d").status_code == 403
+        assert _get(token, "?buurtcode=A05d&type=E9").status_code == 200
+        assert _get(token, "?regimes.inWerkingOp=20:05").status_code == 200
+        assert _get(token, "?regimes.inWerkingOp=").status_code == 403
+        assert _get(token, "?regimes.inWerkingOp").status_code == 403
+
+        # See that 'auth' satisfies without needing a profile
+        token2 = fetch_auth_token(["DATASET/SCOPE", "PROFIEL/SCOPE"])
+        assert _get(token2).status_code == 200
+
+        token3 = fetch_auth_token(["DATASET/SCOPE"])
+        assert _get(token3).status_code == 200
+
+        # See that both profiles can be active
+        token4 = fetch_auth_token(["PROFIEL/SCOPE", "PROFIEL2/SCOPE"])
+        assert _get(token4, "?regimes.inWerkingOp=20:05").status_code == 200
+        assert _get(token4, "?regimes.aantal[gte]=2").status_code == 200
 
     def test_profile_field_permissions(
-        self, api_client, fetch_auth_token, parkeervakken_parkeervak_model, filled_router
+        self,
+        api_client,
+        fetch_auth_token,
+        parkeervakken_schema,
+        parkeervakken_parkeervak_model,
+        filled_router,
     ):
         """
         Tests combination of profiles with auth scopes on dataset level.
         Profiles should be activated only when one of it's mandatoryFilterSet
         is queried. And field permissions should be inherited from dataset scope first.
         """
-        models.Profile.objects.create(
-            name="parkeerwacht",
-            scopes=["PROFIEL/SCOPE"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {
-                                "mandatoryFilterSets": [
-                                    ["id"],
-                                ],
-                                "fields": {"type": "read", "soort": "letters:1"},
+        # Patch the whole dataset so related tables are also restricted
+        patch_dataset_auth(parkeervakken_schema, auth=["DATASET/SCOPE"])
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "parkeerwacht",
+                    "scopes": ["PROFIEL/SCOPE"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "mandatoryFilterSets": [
+                                        ["id"],
+                                    ],
+                                    "fields": {
+                                        "type": "read",
+                                        "soort": "letters:1",
+                                    },
+                                }
                             }
                         }
-                    }
+                    },
                 }
-            },
+            )
         )
-        models.Profile.objects.create(
-            name="parkeerwacht2",
-            scopes=["PROFIEL2/SCOPE"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {
-                                "mandatoryFilterSets": [
-                                    ["id", "type"],
-                                ],
-                                "fields": {"type": "letters:1", "soort": "read"},
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "parkeerwacht2",
+                    "scopes": ["PROFIEL2/SCOPE"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "mandatoryFilterSets": [
+                                        ["id", "type"],
+                                    ],
+                                    "fields": {
+                                        "type": "letters:1",
+                                        "soort": "read",
+                                    },
+                                }
                             }
                         }
-                    }
+                    },
                 }
-            },
+            )
         )
-        models.Dataset.objects.filter(name="parkeervakken").update(auth="DATASET/SCOPE")
-        parkeervak = parkeervakken_parkeervak_model.objects.create(
+        parkeervakken_parkeervak_model.objects.create(
             id=1,
             type="Langs",
             soort="NIET FISCA",
@@ -313,109 +312,152 @@ class TestAuth:
         base_url = reverse("dynamic_api:parkeervakken-parkeervakken-list")
         response = api_client.get(f"{base_url}?id=1", HTTP_AUTHORIZATION=f"Bearer {token}")
         data = read_response_json(response)
+        assert response.status_code == 200, data
         parkeervak_data = data["_embedded"]["parkeervakken"][0]
+        assert parkeervak_data == {
+            "_links": {
+                "schema": (
+                    "https://schemas.data.amsterdam.nl"
+                    "/datasets/parkeervakken/dataset#parkeervakken"
+                ),
+                "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/"},
+            },
+            # no ID field.
+            "soort": "N",  # letters:1
+            "type": "Langs",  # read permission
+        }
 
-        # assert that a single profile is activated
-        assert parkeervak_data["type"] == parkeervak.type
-        assert parkeervak_data["soort"] == parkeervak.soort[:1]
-        # assert that there is no table scope
-        assert "id" not in parkeervak_data.keys()
-
-        # 2) profile and dataset scope
+        # 2) profile and dataset scope -> all allowed (auth of dataset is satisfied)
         token = fetch_auth_token(["PROFIEL/SCOPE", "DATASET/SCOPE"])
         response = api_client.get(f"{base_url}?id=1", HTTP_AUTHORIZATION=f"Bearer {token}")
         data = read_response_json(response)
+        assert response.status_code == 200, data
         parkeervak_data = data["_embedded"]["parkeervakken"][0]
-        # assert that dataset scope permissions overrules lower profile permission
-        assert parkeervak_data["soort"] == parkeervak.soort
-        assert "id" in parkeervak_data.keys()
+        assert parkeervak_data == {
+            "_links": {
+                "schema": (
+                    "https://schemas.data.amsterdam.nl"
+                    "/datasets/parkeervakken/dataset#parkeervakken"
+                ),
+                "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/"},
+            },
+            # Full data!
+            "id": "1",
+            "type": "Langs",
+            "soort": "NIET FISCA",
+            "aantal": 1.0,
+            "eType": None,
+            "geometry": None,
+            "buurtcode": None,
+            "straatnaam": None,
+            "regimes": [],
+        }
 
-        # 3) two profile scopes
+        # 3) two profile scopes, only one matches (mandatory filtersets)
         token = fetch_auth_token(["PROFIEL/SCOPE", "PROFIEL2/SCOPE"])
         # trigger one profile
         response = api_client.get(f"{base_url}?id=1", HTTP_AUTHORIZATION=f"Bearer {token}")
         data = read_response_json(response)
-
         parkeervak_data = data["_embedded"]["parkeervakken"][0]
-        # assert that only the profile is used that passed it's mandatory filterset restrictions
-        assert parkeervak_data["soort"] == parkeervak.soort[:1]
-        # trigger both profiles
+        assert parkeervak_data == {
+            "_links": {
+                "schema": (
+                    "https://schemas.data.amsterdam.nl"
+                    "/datasets/parkeervakken/dataset#parkeervakken"
+                ),
+                "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/"},
+            },
+            "soort": "N",  # letters:1
+            "type": "Langs",  # read permission
+        }
+
+        # 4) both profiles + mandatory filtersets
         response = api_client.get(
             f"{base_url}?id=1&type=Langs", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         data = read_response_json(response)
-
+        assert response.status_code == 200, data
         parkeervak_data = data["_embedded"]["parkeervakken"][0]
-        # assert that both profiles are triggered and the highest permission reigns
-        assert parkeervak_data["type"] == parkeervak.type
-        assert parkeervak_data["soort"] == parkeervak.soort
+        assert parkeervak_data == {
+            "_links": {
+                "schema": (
+                    "https://schemas.data.amsterdam.nl"
+                    "/datasets/parkeervakken/dataset#parkeervakken"
+                ),
+                "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/"},
+            },
+            "type": "Langs",  # read permission
+            "soort": "NIET FISCA",  # read permission
+        }
 
     def test_auth_on_dataset_schema_protects_containers(
-        self, api_client, afval_dataset, filled_router
+        self, api_client, afval_schema, afval_dataset, filled_router
     ):
         """Prove that auth protection at dataset level leads to a 403 on the container listview."""
+        patch_dataset_auth(afval_schema, auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.get(url)
         assert response.status_code == 403, response.data
 
     def test_auth_on_dataset_schema_protects_cluster(
-        self, api_client, afval_dataset, filled_router
+        self, api_client, afval_schema, afval_dataset, filled_router
     ):
         """Prove that auth protection at dataset level leads to a 403 on the cluster listview."""
+        patch_dataset_auth(afval_schema, auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-clusters-list")
-        models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.get(url)
         assert response.status_code == 403, response.data
 
-    def test_auth_on_table_schema_protects(self, api_client, afval_dataset, filled_router):
+    def test_auth_on_table_schema_protects(
+        self, api_client, afval_schema, afval_dataset, filled_router
+    ):
         """Prove that auth protection at table level (container)
         leads to a 403 on the container listview."""
+        patch_table_auth(afval_schema, "containers", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
         response = api_client.get(url)
         assert response.status_code == 403, response.data
 
     def test_auth_on_table_schema_does_not_protect_sibling_tables(
-        self, api_client, fetch_auth_token, afval_dataset, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_dataset, filled_router
     ):
         """Prove that auth protection at table level (cluster)
         does not protect the container list view."""
+        patch_table_auth(afval_schema, "clusters", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
         response = api_client.get(url)
         assert response.status_code == 200, response.data
 
     def test_auth_on_table_schema_with_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that auth protected table (container) can be
         viewed with a token with the correct scope."""
+        patch_table_auth(afval_schema, "containers", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         assert response.status_code == 200, response.data
 
     def test_auth_on_table_schema_with_token_for_invalid_scope(
-        self, api_client, fetch_auth_token, afval_dataset, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_dataset, filled_router
     ):
         """Prove that auth protected table (container) cannot be
         viewed with a token with an incorrect scope.
         """
+        patch_table_auth(afval_schema, "containers", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/RSN"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         assert response.status_code == 403, response.data
 
     def test_auth_on_embedded_fields_with_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that expanded fields are shown when a reference field is protected
         with an auth scope and there is a valid token"""
+        patch_table_auth(afval_schema, "clusters", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(
             url, data={"_expand": "true"}, HTTP_AUTHORIZATION=f"Bearer {token}"
@@ -425,99 +467,104 @@ class TestAuth:
         assert "cluster" in data["_embedded"], data
 
     def test_auth_on_embedded_fields_without_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that expanded fields are *not* shown when a reference field is protected
         with an auth scope. For expand=true, we return a result,
         without the fields that are protected"""
+        patch_table_auth(afval_schema, "clusters", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
         response = api_client.get(url, data={"_expand": "true"})
         data = read_response_json(response)
         assert response.status_code == 200, data
         assert "cluster" not in data["_embedded"], data
 
     def test_auth_on_specified_embedded_fields_without_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that a 403 is returned when asked for a specific expanded field that is protected
         and there is no authorization in the token for that field.
         """
+        patch_table_auth(afval_schema, "clusters", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetTable.objects.filter(name="clusters").update(auth="BAG/R")
         response = api_client.get(url, data={"_expandScope": "cluster"})
         assert response.status_code == 403, response.data
 
     def test_auth_on_individual_fields_with_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that protected fields are shown
         with an auth scope and there is a valid token"""
+        patch_field_auth(afval_schema, "containers", "eigenaar naam", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetField.objects.filter(name="eigenaar_naam").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert "eigenaarNaam" in set(
-            field_name for field_name in data["_embedded"]["containers"][0].keys()
-        ), data["_embedded"]["containers"][0].keys()
+        field_names = data["_embedded"]["containers"][0].keys()
+        assert "eigenaarNaam" in field_names, field_names
 
     def test_auth_on_individual_fields_with_token_for_valid_scope_per_profile(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that protected fields are shown
         with an auth scope connected to Profile that gives access to specific field."""
-        models.Profile.objects.create(
-            name="brk_readall",
-            scopes=["BRK/RSN"],
-            schema_data={
-                "datasets": {
-                    "afvalwegingen": {
-                        "tables": {"containers": {"fields": {"eigenaarNaam": "read"}}}
-                    }
+        patch_field_auth(afval_schema, "containers", "eigenaar naam", auth=["BAG/R"])
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "brk_readall",
+                    "scopes": ["BRK/RSN"],
+                    "datasets": {
+                        "afvalwegingen": {
+                            "tables": {
+                                "containers": {
+                                    "fields": {
+                                        "eigenaar naam": "read",
+                                    }
+                                }
+                            }
+                        }
+                    },
                 }
-            },
+            )
         )
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetField.objects.filter(name="eigenaar_naam").update(auth="BAG/R")
         token = fetch_auth_token(["BRK/RO", "BRK/RSN"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert "eigenaarNaam" in set(
-            field_name for field_name in data["_embedded"]["containers"][0].keys()
-        ), data["_embedded"]["containers"][0].keys()
+        field_names = data["_embedded"]["containers"][0].keys()
+        assert "eigenaarNaam" in field_names, field_names  # profile read access
 
     def test_auth_on_individual_fields_without_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """Prove that protected fields are *not* shown
         with an auth scope and there is not a valid token"""
+        patch_field_auth(afval_schema, "containers", "eigenaar naam", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        models.DatasetField.objects.filter(name="eigenaar_naam").update(auth="BAG/R")
         response = api_client.get(url)
         data = read_response_json(response)
 
         assert response.status_code == 200, data
-        assert "eigenaarNaam" not in set(
-            field_name for field_name in data["_embedded"]["containers"][0].keys()
-        ), data
+        field_names = data["_embedded"]["containers"][0].keys()
+        assert "eigenaarNaam" not in field_names, field_names  # profile read access
 
     def test_auth_on_field_level_is_not_cached(
         self,
         api_client,
         fetch_auth_token,
+        parkeervakken_schema,
         parkeervakken_parkeervak_model,
         parkeervakken_regime_model,
         filled_router,
     ):
         """Prove that Auth is not cached."""
+        patch_field_auth(parkeervakken_schema, "parkeervakken", "regimes", "dagen", auth=["BAG/R"])
         url = reverse("dynamic_api:parkeervakken-parkeervakken-list")
-
-        models.DatasetField.objects.filter(name="dagen").update(auth="BAG/R")
 
         parkeervak = parkeervakken_parkeervak_model.objects.create(
             id="121138489666",
@@ -544,41 +591,45 @@ class TestAuth:
             begin_datum=None,
         )
 
+        # First fetch with BAG/R token
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         data = read_response_json(response)
 
-        assert "dagen" in data["_embedded"]["parkeervakken"][0]["regimes"][0].keys()
+        field_names = data["_embedded"]["parkeervakken"][0]["regimes"][0].keys()
+        assert "dagen" in field_names, field_names
 
+        # Fetch again without BAG/R token, should not return field
         public_response = api_client.get(url)
         public_data = read_response_json(public_response)
-
-        assert "dagen" not in public_data["_embedded"]["parkeervakken"][0]["regimes"][0].keys()
+        field_names = public_data["_embedded"]["parkeervakken"][0]["regimes"][0].keys()
+        assert "dagen" not in field_names, field_names
 
     def test_auth_on_dataset_protects_detail_view(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """ Prove that protection at datasets level protects detail views """
+        patch_dataset_auth(afval_schema, auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-detail", args=[1])
-        models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.get(url)
         assert response.status_code == 403, response.data
 
     def test_auth_on_datasettable_protects_detail_view(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, afval_schema, fetch_auth_token, afval_container, filled_router
     ):
         """ Prove that protection at datasets level protects detail views """
+        patch_table_auth(afval_schema, "containers", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-detail", args=[1])
-        models.DatasetTable.objects.filter(name="containers").update(auth="BAG/R")
+
         response = api_client.get(url)
         assert response.status_code == 403, response.data
 
     def test_auth_on_dataset_detail_with_token_for_valid_scope(
-        self, api_client, fetch_auth_token, afval_container, filled_router
+        self, api_client, fetch_auth_token, afval_schema, afval_container, filled_router
     ):
         """ Prove that protection at datasets level protects detail views """
+        patch_dataset_auth(afval_schema, auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-detail", args=[1])
-        models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
         assert response.status_code == 200, response.data
@@ -594,76 +645,108 @@ class TestAuth:
         """Prove that having no scope on the dataset, but a
         mandatory query on ['id'] gives access to its detailview.
         """
+        patch_table_auth(parkeervakken_schema, "parkeervakken", auth=["DATASET/SCOPE"])
         parkeervakken_parkeervak_model.objects.create(id="121138489047")
-        models.Dataset.objects.filter(name="parkeervakken").update(auth="DATASET/SCOPE")
-        models.Profile.objects.create(
-            name="mag_niet",
-            scopes=["MAY/NOT"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {"mandatoryFilterSets": [["buurtcode", "type"]]}
-                        }
-                    }
-                }
-            },
-        )
-        models.Profile.objects.create(
-            name="mag_wel",
-            scopes=["MAY/ENTER"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {
-                                "mandatoryFilterSets": [["buurtcode", "type"], ["id"]]
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "mag_niet",
+                    "scopes": ["MAY/NOT"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "permissions": "read",
+                                    "mandatoryFilterSets": [
+                                        ["buurtcode", "type"],
+                                    ],
+                                }
                             }
                         }
-                    }
+                    },
                 }
-            },
+            )
         )
-        models.Profile.objects.create(
-            name="alleen_volgnummer",
-            scopes=["ONLY/VOLGNUMMER"],
-            schema_data={
-                "datasets": {
-                    "parkeervakken": {
-                        "tables": {
-                            "parkeervakken": {"mandatoryFilterSets": [["id", "volgnummer"]]}
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "mag_wel",
+                    "scopes": ["MAY/ENTER"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "permissions": "read",
+                                    "mandatoryFilterSets": [
+                                        ["buurtcode", "type"],
+                                        ["id"],
+                                    ],
+                                }
+                            }
                         }
-                    }
+                    },
                 }
-            },
+            )
         )
-        detail = reverse("dynamic_api:parkeervakken-parkeervakken-detail", args=["121138489047"])
-        detail_met_volgnummer = detail + "?volgnummer=3"
+        models.Profile.create_for_schema(
+            ProfileSchema.from_dict(
+                {
+                    "name": "alleen_volgnummer",
+                    "scopes": ["ONLY/VOLGNUMMER"],
+                    "datasets": {
+                        "parkeervakken": {
+                            "tables": {
+                                "parkeervakken": {
+                                    "permissions": "read",
+                                    "mandatoryFilterSets": [
+                                        ["id", "volgnummer"],
+                                    ],
+                                }
+                            }
+                        }
+                    },
+                }
+            )
+        )
+
+        detail_url = reverse(
+            "dynamic_api:parkeervakken-parkeervakken-detail", args=["121138489047"]
+        )
+        detail_met_volgnummer = detail_url + "?volgnummer=3"
+
         may_not = fetch_auth_token(["MAY/NOT"])
         may_enter = fetch_auth_token(["MAY/ENTER"])
         dataset_scope = fetch_auth_token(["DATASET/SCOPE"])
         profiel_met_volgnummer = fetch_auth_token(["ONLY/VOLGNUMMER"])
-        response = api_client.get(detail, HTTP_AUTHORIZATION=f"Bearer {may_not}")
+
+        response = api_client.get(detail_url, HTTP_AUTHORIZATION=f"Bearer {may_not}")
         assert response.status_code == 403, response.data
-        response = api_client.get(detail, HTTP_AUTHORIZATION=f"Bearer {may_enter}")
+
+        response = api_client.get(detail_url, HTTP_AUTHORIZATION=f"Bearer {may_enter}")
         assert response.status_code == 200, response.data
+
         response = api_client.get(detail_met_volgnummer, HTTP_AUTHORIZATION=f"Bearer {may_enter}")
         assert response.status_code == 200, response.data
-        response = api_client.get(detail, HTTP_AUTHORIZATION=f"Bearer {dataset_scope}")
+
+        response = api_client.get(detail_url, HTTP_AUTHORIZATION=f"Bearer {dataset_scope}")
         assert response.status_code == 200, response.data
-        response = api_client.get(detail, HTTP_AUTHORIZATION=f"Bearer {profiel_met_volgnummer}")
+
+        response = api_client.get(
+            detail_url, HTTP_AUTHORIZATION=f"Bearer {profiel_met_volgnummer}"
+        )
         assert response.status_code == 403, response.data
+
         response = api_client.get(
             detail_met_volgnummer, HTTP_AUTHORIZATION=f"Bearer {profiel_met_volgnummer}"
         )
         assert response.status_code == 200, response.data
 
     def test_auth_options_requests_are_not_protected(
-        self, api_client, afval_dataset, filled_router
+        self, api_client, afval_schema, afval_dataset, filled_router
     ):
         """Prove that options requests are not protected"""
+        patch_dataset_auth(afval_schema, auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-clusters-list")
-        models.Dataset.objects.filter(name="afvalwegingen").update(auth="BAG/R")
         response = api_client.options(url)
         assert response.status_code == 200, response.data
 
@@ -693,11 +776,9 @@ class TestAuth:
         leads to a 403 on the adresLoopafstand listview even if table name
         is in camelCase."""
         url = reverse("dynamic_api:afvalwegingen-adres_loopafstand-list")
-        models.DatasetTable.objects.filter(name="adres_loopafstand").update(auth="SOME_AUTH/SCOPE")
-        scopes_for_camelcased_table_name = fetch_scopes_for_dataset_table(
-            afval_schema["id"], "adresLoopafstand"
-        )
-        assert scopes_for_camelcased_table_name.table == {"SOME_AUTH/SCOPE"}
+        table_schema = apps.get_model("afvalwegingen", "adres_loopafstand").table_schema()
+        table_schema["auth"] = {"SOME_AUTH/SCOPE"}
+
         response = api_client.get(url)
         assert response.status_code == 403, response.data
 

--- a/src/tests/test_dynamic_api/test_views_mvt.py
+++ b/src/tests/test_dynamic_api/test_views_mvt.py
@@ -1,16 +1,6 @@
 import mapbox_vector_tile
 import pytest
 
-from dso_api.dynamic_api.permissions import fetch_scopes_for_dataset_table, fetch_scopes_for_model
-
-
-@pytest.fixture(autouse=True)
-def clear_caches():
-    yield  # run tests first
-    fetch_scopes_for_dataset_table.cache_clear()
-    fetch_scopes_for_model.cache_clear()
-
-
 CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
 
 

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -3,15 +3,7 @@ from typing import List
 import pytest
 from schematools.contrib.django.db import create_tables
 
-from dso_api.dynamic_api.permissions import fetch_scopes_for_dataset_table, fetch_scopes_for_model
 from tests.utils import read_response_xml, xml_element_to_dict
-
-
-@pytest.fixture(autouse=True)
-def clear_caches():
-    yield  # run tests first
-    fetch_scopes_for_dataset_table.cache_clear()
-    fetch_scopes_for_model.cache_clear()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This uses the new schematools authorisation framework (more info there). Instead of basing authorisation on top of the exported data in Django models, the low-level schema objects are queried by a single integrated rule engine. The UserScopes object handles both the "auth" and "profile" rules.

This also removes the need to match on field-names. Instead the model fields have a direct reference back to the schema field.

Likewise, get_fields() can exclude fields directly now and apply transformations on a field-level instead of manipulating the dict afterwards.
