### PR TITLE
API docs: order of tables are presented by order of appearance

### DIFF
--- a/docs/source/datasets.py
+++ b/docs/source/datasets.py
@@ -107,7 +107,7 @@ def sort_fields(
 def render_dataset_docs(dataset: DatasetSchema):
     snake_name = to_snake_case(dataset.id)
     main_title = dataset.title or snake_name.replace("_", " ").capitalize()
-    tables = [_get_table_context(t) for t in sort_tables(dataset.tables)]
+    tables = [_get_table_context(t) for t in dataset.tables]
     if any(t["has_geometry"] for t in tables):
         wfs_url = f"{BASE_URL}/v1/wfs/{snake_name}/"
     else:
@@ -134,7 +134,7 @@ def render_wfs_dataset_docs(dataset: DatasetSchema):
     """Render the docs for the WFS dataset."""
     snake_name = to_snake_case(dataset.id)
     main_title = dataset.title or snake_name.replace("_", " ").capitalize()
-    tables = [_get_feature_type_context(t) for t in sort_tables(dataset.tables)]
+    tables = [_get_feature_type_context(t) for t in dataset.tables]
     if all(not t["has_geometry"] for t in tables):
         return None
 


### PR DESCRIPTION
On request of datateam omgevingswet the presentation order of the tables within a dataset is not ordered on alphabet but on appearance within the Amsterdam schema specification. The order of the tables defined in the Amsterdam schema is based on a certain logical and intentional meaning. In respect of the self defined order of tables the datateams can use the docs more intuatieve.

# This Pull request contains changes to:
v1/docs/

# In case changes new features added
N.A.

# In case breaking changes introduced into API
N.A.

# In case this PR reverts changes in repo
N.A.
