### PR TITLE
No alphabetical sort order for fields.

### DIFF
--- a/docs/source/datasets.py
+++ b/docs/source/datasets.py
@@ -255,7 +255,7 @@ def _get_fields(
         if field.is_array_of_objects or field.is_object:
             result_fields.extend(_get_fields(field.sub_fields, parent_field=field))
 
-    return sort_fields(result_fields, table_identifier)
+    return result_fields
 
 
 def _get_field_context(field: DatasetFieldSchema, identifier: List[str]) -> Dict[str, Any]:


### PR DESCRIPTION
In addition to removing the alphabetical sort order for tables (within a dataset), also the alphabetical sort order for fields is removed. So it orders by the definition order in Amsterdam Schema. So the order is in line with the initial own logical order that the datateams specified in the schema.

# This Pull request contains changes to:
v1/docs/

# In case changes new features added
N.A.

# In case breaking changes introduced into API
N.A.

# In case this PR reverts changes in repo
N.A.
