### PR TITLE
Restore remote authorization

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -11,7 +11,7 @@ from rest_framework_dso.embedding import EmbeddedFieldMatch
 audit_log = logging.getLogger("dso_api.audit")
 
 
-def _log_access(request, access: bool):
+def log_access(request, access: bool):
     if access:
         audit_log.info(
             "%s %s: access granted with %s",
@@ -72,7 +72,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
 
         access = request.user_scopes.has_table_access(model.table_schema())
 
-        _log_access(request, access)
+        log_access(request, access)
         return access
 
     def has_object_permission(self, request, view, obj):
@@ -83,7 +83,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
         # NOTE: For now, this is OK, later on we need to add row-level permissions.
         access = request.user_scopes.has_table_access(obj.table_schema())
 
-        _log_access(request, access)
+        log_access(request, access)
         return access
 
     def has_permission_for_models(self, request, view, models):
@@ -98,7 +98,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
             request.user_scopes.has_table_access(model.table_schema()) for model in models
         )
 
-        _log_access(request, access)
+        log_access(request, access)
         return access
 
 

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -11,23 +11,6 @@ from rest_framework_dso.embedding import EmbeddedFieldMatch
 audit_log = logging.getLogger("dso_api.audit")
 
 
-def _log_access(request, access: bool):
-    if access:
-        audit_log.info(
-            "%s %s: access granted with %s",
-            request.method,
-            request.path,
-            request.user_scopes,
-        )
-    else:
-        audit_log.info(
-            "%s %s: access denied with %s",
-            request.method,
-            request.path,
-            request.user_scopes,
-        )
-
-
 def filter_unauthorized_expands(
     user_scopes: UserScopes, expanded_fields: List[EmbeddedFieldMatch], skip_unauth=False
 ) -> List[EmbeddedFieldMatch]:
@@ -72,7 +55,13 @@ class HasOAuth2Scopes(permissions.BasePermission):
 
         access = request.user_scopes.has_table_access(model.table_schema())
 
-        _log_access(request, access)
+        audit_log.info(
+            "%s %s: access %s with %s",
+            request.method,
+            request.path,
+            "granted" if access else "denied",
+            request.user_scopes,
+        )
         return access
 
     def has_object_permission(self, request, view, obj):
@@ -83,7 +72,13 @@ class HasOAuth2Scopes(permissions.BasePermission):
         # NOTE: For now, this is OK, later on we need to add row-level permissions.
         access = request.user_scopes.has_table_access(obj.table_schema())
 
-        _log_access(request, access)
+        audit_log.info(
+            "%s %s: access %s with %s",
+            request.method,
+            request.path,
+            "granted" if access else "denied",
+            request.user_scopes,
+        )
         return access
 
     def has_permission_for_models(self, request, view, models):
@@ -98,7 +93,13 @@ class HasOAuth2Scopes(permissions.BasePermission):
             request.user_scopes.has_table_access(model.table_schema()) for model in models
         )
 
-        _log_access(request, access)
+        audit_log.info(
+            "%s %s: access %s with %s",
+            request.method,
+            request.path,
+            "granted" if access else "denied",
+            request.user_scopes,
+        )
         return access
 
 

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -11,6 +11,23 @@ from rest_framework_dso.embedding import EmbeddedFieldMatch
 audit_log = logging.getLogger("dso_api.audit")
 
 
+def _log_access(request, access: bool):
+    if access:
+        audit_log.info(
+            "%s %s: access granted with %s",
+            request.method,
+            request.path,
+            request.user_scopes,
+        )
+    else:
+        audit_log.info(
+            "%s %s: access denied with %s",
+            request.method,
+            request.path,
+            request.user_scopes,
+        )
+
+
 def filter_unauthorized_expands(
     user_scopes: UserScopes, expanded_fields: List[EmbeddedFieldMatch], skip_unauth=False
 ) -> List[EmbeddedFieldMatch]:
@@ -55,13 +72,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
 
         access = request.user_scopes.has_table_access(model.table_schema())
 
-        audit_log.info(
-            "%s %s: access %s with %s",
-            request.method,
-            request.path,
-            "granted" if access else "denied",
-            request.user_scopes,
-        )
+        _log_access(request, access)
         return access
 
     def has_object_permission(self, request, view, obj):
@@ -72,13 +83,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
         # NOTE: For now, this is OK, later on we need to add row-level permissions.
         access = request.user_scopes.has_table_access(obj.table_schema())
 
-        audit_log.info(
-            "%s %s: access %s with %s",
-            request.method,
-            request.path,
-            "granted" if access else "denied",
-            request.user_scopes,
-        )
+        _log_access(request, access)
         return access
 
     def has_permission_for_models(self, request, view, models):
@@ -93,13 +98,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
             request.user_scopes.has_table_access(model.table_schema()) for model in models
         )
 
-        audit_log.info(
-            "%s %s: access %s with %s",
-            request.method,
-            request.path,
-            "granted" if access else "denied",
-            request.user_scopes,
-        )
+        _log_access(request, access)
         return access
 
 

--- a/src/tests/files/hcbrk.json
+++ b/src/tests/files/hcbrk.json
@@ -6,7 +6,6 @@
   "description": "Deze dataset maakt de HaalCentraal BRK API toegankelijk, bij gebruik van login credentials. De velden zijn gebaseerd op het schema van Haal-Centraal.",
   "version": "0.0.1",
   "crs": "EPSG:28992",
-  "auth": "BRK/RSN",
   "tables": [
     {
       "id": "kadastraalonroerendezaken",
@@ -45,6 +44,7 @@
           },
           "koopsom": {
             "type": "object",
+            "auth": "BRK/RO",
             "properties": {
               "koopsom": {
                 "type": "integer"
@@ -56,12 +56,14 @@
           },
           "toelichtingBewaarder": {
             "type": "string",
+            "auth": "BRK/RO",
             "description": "Hier kan een toelichting staan van de bewaarder."
           },
           "type": {
             "type": "string"
           },
           "aardCultuurBebouwd": {
+            "auth": "BRK/RO",
             "type": "object",
             "properties": {
               "code": {
@@ -146,12 +148,14 @@
             }
           },
           "zakelijkGerechtigdeIdentificaties": {
+            "auth": "BRK/RO",
             "type": "array",
             "items": {
               "type": "string"
             }
           },
           "privaatrechtelijkeBeperkingIdentificaties": {
+            "auth": "BRK/RO",
             "type": "array",
             "items": {
               "type": "string"
@@ -159,6 +163,7 @@
           },
           "hypotheekIdentificaties": {
             "type": "array",
+            "auth": "BRK/RO",
             "items": {
               "type": "string"
             }
@@ -170,6 +175,7 @@
     {
       "id": "kadasternatuurlijkpersonen",
       "type": "table",
+      "auth": ["BRK/RS", "BRK/RSN"],
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -218,6 +224,7 @@
           },
           "kadastraalOnroerendeZaakIdentificaties": {
             "type": "array",
+            "auth": "BRK/RSN",
             "items": {
               "type": "string"
             }


### PR DESCRIPTION
Remote authorization is restored (currently, it's left entirely to the remote). Results of authorization checks are logged. Connection to HC-BRK is not yet established, but the parts are in place. In `tests/files`, there's a preliminary version of the detailed HC-BRK authorizing schema.