### PR TITLE
AB#5522 mvt and wfs views on sub paths

### DIFF
--- a/src/dso_api/dynamic_api/urls.py
+++ b/src/dso_api/dynamic_api/urls.py
@@ -14,16 +14,7 @@ def get_patterns(router_urls):
     return [
         path("reload/", views.reload_patterns),
         path("mvt/", views.DatasetMVTIndexView.as_view(), name="mvt-index"),
-        path(
-            "mvt/<dataset_name>/", views.DatasetMVTSingleView.as_view(), name="mvt-single-dataset"
-        ),
-        path(
-            "mvt/<dataset_name>/<table_name>/<int:z>/<int:x>/<int:y>.pbf",
-            views.DatasetMVTView.as_view(),
-            name="mvt-pbf",
-        ),
         path("wfs/", views.DatasetWFSIndexView.as_view()),
-        path("wfs/<dataset_name>/", views.DatasetWFSView.as_view(), name="wfs"),
         path("", include(router_urls)),
         # Swagger, OpenAPI and OAuth2 login logic.
         path("oauth2-redirect.html", views.oauth2_redirect, name="oauth2-redirect"),

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 from django.urls import reverse
+from more_ds.network.url import URL
 
 from tests.utils import read_response
 
@@ -16,7 +17,7 @@ def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_rout
     assert response.status_code == 200, response.data
 
     # Prove that response contains the correct data
-    base = drf_request.build_absolute_uri("/").rstrip("/")
+    BASE = URL(drf_request.build_absolute_uri("/").rstrip("/"))
     assert response.data == {
         "datasets": {
             "afvalwegingen": {
@@ -34,14 +35,14 @@ def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_rout
                 "environments": [
                     {
                         "name": "production",
-                        "api_url": f"{base}/v1/afvalwegingen/",
-                        "specification_url": f"{base}/v1/afvalwegingen/",
-                        "documentation_url": f"{base}/v1/docs/datasets/afvalwegingen.html",
+                        "api_url": BASE / "v1/afvalwegingen/",
+                        "specification_url": BASE / "v1/afvalwegingen/",
+                        "documentation_url": BASE / "v1/docs/datasets/afvalwegingen.html",
                     }
                 ],
                 "related_apis": [
-                    {"type": "WFS", "url": f"{base}/v1/wfs/afvalwegingen/"},
-                    {"type": "MVT", "url": f"{base}/v1/mvt/afvalwegingen/"},
+                    {"type": "WFS", "url": BASE / "v1/wfs/afvalwegingen/"},
+                    {"type": "MVT", "url": BASE / "v1/mvt/afvalwegingen/"},
                 ],
                 "api_authentication": None,
                 "api_type": "rest_json",
@@ -63,14 +64,14 @@ def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_rout
                 "environments": [
                     {
                         "name": "production",
-                        "api_url": f"{base}/v1/fietspaaltjes/",
-                        "specification_url": f"{base}/v1/fietspaaltjes/",
-                        "documentation_url": f"{base}/v1/docs/datasets/fietspaaltjes.html",
+                        "api_url": BASE / "v1/fietspaaltjes/",
+                        "specification_url": BASE / "v1/fietspaaltjes/",
+                        "documentation_url": BASE / "v1/docs/datasets/fietspaaltjes.html",
                     }
                 ],
                 "related_apis": [
-                    {"type": "WFS", "url": f"{base}/v1/wfs/fietspaaltjes/"},
-                    {"type": "MVT", "url": f"{base}/v1/mvt/fietspaaltjes/"},
+                    {"type": "WFS", "url": BASE / "v1/wfs/fietspaaltjes/"},
+                    {"type": "MVT", "url": BASE / "v1/mvt/fietspaaltjes/"},
                 ],
                 "api_authentication": None,
                 "api_type": "rest_json",
@@ -104,7 +105,7 @@ def test_subpath_view(
     assert response_subpath.status_code == 200, response_subpath.data
 
     # Prove that response contains the correct data with both datasets
-    base = drf_request.build_absolute_uri("/").rstrip("/")
+    BASE = URL(drf_request.build_absolute_uri("/").rstrip("/"))
     assert response_sub.data == {
         "datasets": {
             "afvalwegingen": {
@@ -122,14 +123,14 @@ def test_subpath_view(
                 "environments": [
                     {
                         "name": "production",
-                        "api_url": f"{base}/v1/sub/path/afvalwegingen/",
-                        "specification_url": f"{base}/v1/sub/path/afvalwegingen/",
-                        "documentation_url": f"{base}/v1/docs/datasets/afvalwegingen.html",
+                        "api_url": BASE / "v1/sub/path/afvalwegingen/",
+                        "specification_url": BASE / "v1/sub/path/afvalwegingen/",
+                        "documentation_url": BASE / "v1/docs/datasets/afvalwegingen.html",
                     }
                 ],
                 "related_apis": [
-                    {"type": "WFS", "url": f"{base}/v1/wfs/afvalwegingen/"},
-                    {"type": "MVT", "url": f"{base}/v1/mvt/afvalwegingen/"},
+                    {"type": "WFS", "url": BASE / "v1/wfs/sub/path/afvalwegingen/"},
+                    {"type": "MVT", "url": BASE / "v1/mvt/sub/path/afvalwegingen/"},
                 ],
                 "api_authentication": None,
                 "api_type": "rest_json",
@@ -151,14 +152,14 @@ def test_subpath_view(
                 "environments": [
                     {
                         "name": "production",
-                        "api_url": f"{base}/v1/sub/fietspaaltjes/",
-                        "specification_url": f"{base}/v1/sub/fietspaaltjes/",
-                        "documentation_url": f"{base}/v1/docs/datasets/fietspaaltjes.html",
+                        "api_url": BASE / "v1/sub/fietspaaltjes/",
+                        "specification_url": BASE / "v1/sub/fietspaaltjes/",
+                        "documentation_url": BASE / "v1/docs/datasets/fietspaaltjes.html",
                     }
                 ],
                 "related_apis": [
-                    {"type": "WFS", "url": f"{base}/v1/wfs/fietspaaltjes/"},
-                    {"type": "MVT", "url": f"{base}/v1/mvt/fietspaaltjes/"},
+                    {"type": "WFS", "url": BASE / "v1/wfs/sub/fietspaaltjes/"},
+                    {"type": "MVT", "url": BASE / "v1/mvt/sub/fietspaaltjes/"},
                 ],
                 "api_authentication": None,
                 "api_type": "rest_json",
@@ -190,14 +191,14 @@ def test_subpath_view(
                 "environments": [
                     {
                         "name": "production",
-                        "api_url": f"{base}/v1/sub/path/afvalwegingen/",
-                        "specification_url": f"{base}/v1/sub/path/afvalwegingen/",
-                        "documentation_url": f"{base}/v1/docs/datasets/afvalwegingen.html",
+                        "api_url": BASE / "v1/sub/path/afvalwegingen/",
+                        "specification_url": BASE / "v1/sub/path/afvalwegingen/",
+                        "documentation_url": BASE / "v1/docs/datasets/afvalwegingen.html",
                     }
                 ],
                 "related_apis": [
-                    {"type": "WFS", "url": f"{base}/v1/wfs/afvalwegingen/"},
-                    {"type": "MVT", "url": f"{base}/v1/mvt/afvalwegingen/"},
+                    {"type": "WFS", "url": BASE / "v1/wfs/sub/path/afvalwegingen/"},
+                    {"type": "MVT", "url": BASE / "v1/mvt/sub/path/afvalwegingen/"},
                 ],
                 "api_authentication": None,
                 "api_type": "rest_json",


### PR DESCRIPTION
The mvt and wfs views were not using the dataset.path
property yet. So datasets with subpaths appeared on
their old paths. This update fixes that.

MVT and WFS url pattern logic is moved from get_patterns
into the custom router. Because get_patterns doesnt work with
nested paths.