### PR TITLE
Yrob/ab11749 improve  _links

### DIFF
--- a/src/rest_framework_dso/pagination.py
+++ b/src/rest_framework_dso/pagination.py
@@ -141,8 +141,7 @@ class DSOPageNumberPagination(DSOHTTPHeaderPageNumberPagination):
         return super().get_paginated_response(data)
 
     def _get_paginated_data(self, data: ReturnList) -> dict:
-        # Avoid adding ?_expand=.. and other parameters in the 'self' url.
-        self_link = self.request.build_absolute_uri(self.request.path)
+        self_link = self.request.build_absolute_uri()
         if self_link.endswith(".api"):
             self_link = self_link[:-4]
 

--- a/src/rest_framework_dso/pagination.py
+++ b/src/rest_framework_dso/pagination.py
@@ -146,16 +146,16 @@ class DSOPageNumberPagination(DSOHTTPHeaderPageNumberPagination):
         if self_link.endswith(".api"):
             self_link = self_link[:-4]
 
-        next_link = self.get_next_link()
-        prev_link = self.get_previous_link()
-
         # As Python 3.6 preserves dict ordering, no longer using OrderedDict.
         # While DSO 2.0 shows "prev", the HAL-JSON standard uses "previous".
         _links = {
             "self": {"href": self_link},
-            "next": {"href": next_link},
-            "previous": {"href": prev_link},
         }
+
+        if (next_link := self.get_next_link()) is not None:
+            _links["next"] = {"href": next_link}
+        if (prev_link := self.get_previous_link()) is not None:
+            _links["previous"] = {"href": prev_link}
 
         paginator = self.page.paginator
         page = {

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -65,8 +65,6 @@ def test_list_dynamic_view_reload(api_client, api_rf, router, bommen_dataset):
     assert data == {
         "_links": {
             "self": {"href": "http://testserver/v1/bommen/bommen/"},
-            "next": {"href": None},
-            "previous": {"href": None},
         },
         "_embedded": {"bommen": []},
         "page": {"number": 1, "size": 20, "totalElements": 0, "totalPages": 1},

--- a/src/tests/test_rest_framework_dso/test_serializers.py
+++ b/src/tests/test_rest_framework_dso/test_serializers.py
@@ -199,7 +199,7 @@ def test_fields_limit_works(api_rf, movie, fields):
 
     assert data == {
         "_links": {
-            "self": {"href": "http://testserver/"},
+            "self": {"href": drf_request.build_absolute_uri()},
         },
         "_embedded": {"movie": [{"name": "foo123"}]},
         "page": {"number": 1, "size": 20, "totalElements": 1, "totalPages": 1},

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -184,7 +184,7 @@ class TestExpand:
         data = read_response_json(response)
         assert data == {
             "_links": {
-                "self": {"href": "http://testserver/v1/movies"},
+                "self": {"href": "http://testserver/v1/movies?_expand=true"},
             },
             "_embedded": {
                 "movie": [
@@ -226,7 +226,9 @@ class TestExpand:
         data = read_response_json(response)
         assert data == {
             "_links": {
-                "self": {"href": "http://testserver/v1/movies"},
+                "self": {
+                    "href": f"http://testserver/v1/movies?{response.request['QUERY_STRING']}"
+                },
             },
             "_embedded": {
                 "movie": [
@@ -255,7 +257,9 @@ class TestExpand:
         data = read_response_json(response)
         assert data == {
             "_links": {
-                "self": {"href": "http://testserver/v1/movies"},
+                "self": {
+                    "href": f"http://testserver/v1/movies?{response.request['QUERY_STRING']}"
+                },
             },
             "_embedded": {
                 "movie": [
@@ -280,7 +284,7 @@ class TestExpand:
 
         assert data == {
             "_links": {
-                "self": {"href": "http://testserver/v1/movies"},
+                "self": {"href": "http://testserver/v1/movies?_expand=true"},
             },
             "_embedded": {
                 "movie": [

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -185,8 +185,6 @@ class TestExpand:
         assert data == {
             "_links": {
                 "self": {"href": "http://testserver/v1/movies"},
-                "next": {"href": None},
-                "previous": {"href": None},
             },
             "_embedded": {
                 "movie": [
@@ -229,8 +227,6 @@ class TestExpand:
         assert data == {
             "_links": {
                 "self": {"href": "http://testserver/v1/movies"},
-                "next": {"href": None},
-                "previous": {"href": None},
             },
             "_embedded": {
                 "movie": [
@@ -260,8 +256,6 @@ class TestExpand:
         assert data == {
             "_links": {
                 "self": {"href": "http://testserver/v1/movies"},
-                "next": {"href": None},
-                "previous": {"href": None},
             },
             "_embedded": {
                 "movie": [
@@ -287,8 +281,6 @@ class TestExpand:
         assert data == {
             "_links": {
                 "self": {"href": "http://testserver/v1/movies"},
-                "next": {"href": None},
-                "previous": {"href": None},
             },
             "_embedded": {
                 "movie": [


### PR DESCRIPTION
Updates to _links in line with user story [11749](https://dev.azure.com/CloudCompetenceCenter/Data%20Diensten/_workitems/edit/11749)

* The 'self' field now includes query parameters. 
* The 'previous' and 'next' fields are only included when their links exist.
So 'previous' is not shown on page 1 and they are not shown on single page results, etc.