### PR TITLE
Use new dataset urls in documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ Sphinx == 3.5.2
 sphinx-rtd-theme == 0.5.1
 Pillow == 8.2.0
 python-string-utils == 1.0.0
-amsterdam-schema-tools == 0.21.10
+amsterdam-schema-tools == 0.23.2
 
 # Required by Sphinx too
 jinja2 >= 2.11.3

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -76,7 +76,7 @@ class DynamicAPIIndexView(APIIndexView):
                 "name": "production",
                 "api_url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
                 "specification_url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
-                "documentation_url": f"{base}/v1/docs/datasets/{ds.schema.id}.html",
+                "documentation_url": f"{base}/v1/docs/datasets/{ds.path}.html",
             }
         ]
 

--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -98,7 +98,7 @@ class DatasetWFSIndexView(APIIndexView):
                 "specification_url": base
                 + reverse("dynamic_api:wfs", kwargs={"dataset_name": ds.name})
                 + "?SERVICE=WFS&REQUEST=GetCapabilities",
-                "documentation_url": f"{base}/v1/docs/wfs-datasets/{ds.schema.id}.html",
+                "documentation_url": f"{base}/v1/docs/wfs-datasets/{ds.path}.html",
             }
         ]
 

--- a/src/tests/test_openapi.py
+++ b/src/tests/test_openapi.py
@@ -125,7 +125,7 @@ def test_subpath_view(
                         "name": "production",
                         "api_url": BASE / "v1/sub/path/afvalwegingen/",
                         "specification_url": BASE / "v1/sub/path/afvalwegingen/",
-                        "documentation_url": BASE / "v1/docs/datasets/afvalwegingen.html",
+                        "documentation_url": BASE / "v1/docs/datasets/sub/path/afvalwegingen.html",
                     }
                 ],
                 "related_apis": [
@@ -154,7 +154,7 @@ def test_subpath_view(
                         "name": "production",
                         "api_url": BASE / "v1/sub/fietspaaltjes/",
                         "specification_url": BASE / "v1/sub/fietspaaltjes/",
-                        "documentation_url": BASE / "v1/docs/datasets/fietspaaltjes.html",
+                        "documentation_url": BASE / "v1/docs/datasets/sub/fietspaaltjes.html",
                     }
                 ],
                 "related_apis": [
@@ -193,7 +193,7 @@ def test_subpath_view(
                         "name": "production",
                         "api_url": BASE / "v1/sub/path/afvalwegingen/",
                         "specification_url": BASE / "v1/sub/path/afvalwegingen/",
-                        "documentation_url": BASE / "v1/docs/datasets/afvalwegingen.html",
+                        "documentation_url": BASE / "v1/docs/datasets/sub/path/afvalwegingen.html",
                     }
                 ],
                 "related_apis": [


### PR DESCRIPTION
The documentation was using the dataset name to create urls.
It now uses the dataset.path property like the rest of the application.
Also updates links to the docs in the index views.

