### PR TITLE
Fix nested expand support, was broken after 2 levels

### DIFF
--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -38,7 +38,7 @@ from dso_api.dynamic_api.datasets import get_active_datasets
 from dso_api.dynamic_api.locking import lock_for_writing
 from dso_api.dynamic_api.openapi import get_openapi_json_view
 from dso_api.dynamic_api.remote import remote_serializer_factory, remote_viewset_factory
-from dso_api.dynamic_api.serializers import get_view_name, serializer_factory
+from dso_api.dynamic_api.serializers import get_view_name, serializer_factory_cache
 from dso_api.dynamic_api.views import (
     APIIndexView,
     DatasetMVTSingleView,
@@ -161,7 +161,7 @@ class DynamicRouter(routers.DefaultRouter):
     def _initialize_viewsets(self) -> List[Type[DynamicModel]]:
         """Build all viewsets, serializers, models and URL routes."""
         # Generate new viewsets for dynamic models
-        serializer_factory.cache_clear()  # Avoid old cached data
+        serializer_factory_cache.clear()  # Avoid old cached data
         db_datasets = list(get_active_datasets().db_enabled())
         generated_models = self._build_db_models(db_datasets)
         dataset_routes = self._build_db_viewsets(db_datasets)

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -633,9 +633,9 @@ def _build_serializer_field(
     model_field: models.Field,
     flat: bool,
     nesting_level: int,
-    new_attrs,
-    fields,
-    extra_kwargs,
+    new_attrs: dict,
+    fields: list,
+    extra_kwargs: dict,
 ):
     """Build a serializer field, results are written in 'output' parameters"""
     # Add extra embedded part for related fields
@@ -650,7 +650,7 @@ def _build_serializer_field(
         ),
     ):
         # Embedded relations are only added to the main serializer.
-        _build_serializer_embeddded_field(model_field, nesting_level, new_attrs)
+        _build_serializer_embedded_field(model_field, nesting_level, new_attrs)
 
         if isinstance(model_field, LooseRelationField):
             # For loose relations, add an id char field.
@@ -668,8 +668,8 @@ def _build_serializer_field(
     _build_plain_serializer_field(model_field, fields, extra_kwargs)
 
 
-def _build_serializer_embeddded_field(
-    model_field: Union[RelatedField, LooseRelationField], nesting_level, new_attrs
+def _build_serializer_embedded_field(
+    model_field: Union[RelatedField, LooseRelationField], nesting_level: int, new_attrs: dict
 ):
     """Build a embedded field for the serializer"""
     EmbeddedFieldClass = (
@@ -772,7 +772,13 @@ def _through_serializer_factory(
     return type(serializer_name, (ThroughSerializer,), new_attrs)
 
 
-def _build_m2m_serializer(model, model_field, new_attrs, fields, extra_kwargs):
+def _build_m2m_serializer(
+    model: Type[DynamicModel],
+    model_field: models.Field,
+    new_attrs: dict,
+    fields: List[str],
+    extra_kwargs: dict,
+):
     """Add a serializer for a m2m field to the output parameters."""
 
     camel_name = toCamelCase(model_field.name)
@@ -785,7 +791,9 @@ def _build_m2m_serializer(model, model_field, new_attrs, fields, extra_kwargs):
     fields.append(camel_name)
 
 
-def _build_plain_serializer_field(model_field, fields, extra_kwargs):
+def _build_plain_serializer_field(
+    model_field: models.Field, fields: List[str], extra_kwargs: dict
+):
     """Add the field to the output parameters"""
     camel_name = toCamelCase(model_field.name)
     fields.append(camel_name)
@@ -794,7 +802,7 @@ def _build_plain_serializer_field(model_field, fields, extra_kwargs):
         extra_kwargs[camel_name] = {"source": model_field.name}
 
 
-def _build_serializer_related_id_field(model_field, fields, extra_kwargs):
+def _build_serializer_related_id_field(model_field: models.Field, fields, extra_kwargs):
     """Build the ``FIELD_id`` field for an related field."""
     camel_id_name = toCamelCase(model_field.attname)
     fields.append(camel_id_name)
@@ -803,7 +811,9 @@ def _build_serializer_related_id_field(model_field, fields, extra_kwargs):
         extra_kwargs[camel_id_name] = {"source": model_field.attname}
 
 
-def _build_serializer_loose_relation_id_field(model_field, fields, new_attrs):
+def _build_serializer_loose_relation_id_field(
+    model_field: LooseRelationField, fields: List[str], new_attrs: dict
+):
     """Build the ``FIELD_id`` field for a loose relation."""
     camel_name = toCamelCase(model_field.name)
     loose_id_field_name = f"{camel_name}Id"
@@ -811,7 +821,9 @@ def _build_serializer_loose_relation_id_field(model_field, fields, new_attrs):
     fields.append(loose_id_field_name)
 
 
-def _build_serializer_blob_field(model_field, field_schema, fields, new_attrs):
+def _build_serializer_blob_field(
+    model_field: models.Field, field_schema: dict, fields: List[str], new_attrs: dict
+):
     """Build the blob field"""
     camel_name = toCamelCase(model_field.name)
     new_attrs[camel_name] = AzureBlobFileField(
@@ -820,7 +832,9 @@ def _build_serializer_blob_field(model_field, field_schema, fields, new_attrs):
     )
 
 
-def _build_serializer_reverse_fk_field(model, model_field: models.ManyToOneRel, new_attrs, fields):
+def _build_serializer_reverse_fk_field(
+    model: Type[DynamicModel], model_field: models.ManyToOneRel, new_attrs: dict, fields: List[str]
+):
     """Build the ManyToOneRel field"""
     table_schema = model.table_schema()
     match = _find_reverse_fk_relation(table_schema, model_field)
@@ -863,7 +877,9 @@ def _find_reverse_fk_relation(
     )
 
 
-def _generate_nested_relations(model, fields, new_attrs, nesting_level):
+def _generate_nested_relations(
+    model: Type[DynamicModel], fields: list, new_attrs: dict, nesting_level: int
+):
     """Include fields that are implemented using nested tables."""
     schema_fields = {to_snake_case(f.name): f for f in model.table_schema().fields}
     for item in model._meta.related_objects:

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -547,7 +547,7 @@ def serializer_factory(
             )
 
     if not flat:
-        _generate_embedded_relations(model, fields, new_attrs, nesting_level)
+        _generate_nested_relations(model, fields, new_attrs, nesting_level)
 
     if "_links" in fields:
         # Generate the serializer for the _links field containing the relations according to HAL.
@@ -836,7 +836,8 @@ def _find_reverse_fk_relation(
     )
 
 
-def _generate_embedded_relations(model, fields, new_attrs, nesting_level):
+def _generate_nested_relations(model, fields, new_attrs, nesting_level):
+    """Include fields that are implemented using nested tables."""
     schema_fields = {to_snake_case(f.name): f for f in model.table_schema().fields}
     for item in model._meta.related_objects:
         # Do not create fields for django-created relations.
@@ -846,6 +847,6 @@ def _generate_embedded_relations(model, fields, new_attrs, nesting_level):
                 flat=(nesting_level + 1) >= MAX_EMBED_NESTING_LEVEL,
                 nesting_level=nesting_level + 1,
             )
-            fields.append(item.name)
 
             new_attrs[item.name] = related_serializer(many=True)
+            fields.append(item.name)

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -52,7 +52,7 @@ from rest_framework_dso.embedding import EmbeddedFieldMatch
 from rest_framework_dso.fields import AbstractEmbeddedField, EmbeddedField, EmbeddedManyToManyField
 from rest_framework_dso.serializers import DSOModelListSerializer, DSOModelSerializer
 
-MAX_EMBED_NESTING_LEVEL = 2
+MAX_EMBED_NESTING_LEVEL = 10
 
 
 class URLencodingURLfields:

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -8,6 +8,8 @@ from more_itertools import first
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 
+from rest_framework_dso.utils import unlazy_object
+
 
 def parse_request_fields(fields: Optional[str]):
     if not fields:
@@ -74,6 +76,8 @@ class AbstractEmbeddedField:
         if not isinstance(parent, self.parent_serializer_class):
             raise TypeError(f"Invalid parent for {self.__class__.__name__}.get_serializer()")
 
+        # Make sure the serializer is the true object, or other isinstance() checks will fail.
+        self.serializer_class = unlazy_object(self.serializer_class)
         embedded_serializer = self.serializer_class(context=parent.context, **kwargs)
         embedded_serializer.bind(field_name=self.field_name, parent=parent)
         return embedded_serializer
@@ -81,6 +85,8 @@ class AbstractEmbeddedField:
     @cached_property
     def related_model(self) -> Type[models.Model]:
         """Return the Django model class"""
+        # Make sure the serializer is the true object, or other isinstance() checks will fail.
+        self.serializer_class = unlazy_object(self.serializer_class)
         return self.serializer_class.Meta.model
 
     @cached_property

--- a/src/rest_framework_dso/utils.py
+++ b/src/rest_framework_dso/utils.py
@@ -1,0 +1,10 @@
+from django.utils.functional import LazyObject, empty
+
+
+def unlazy_object(obj):
+    if isinstance(obj, LazyObject):
+        if obj._wrapped is empty:
+            obj._setup()
+        return obj._wrapped
+    else:
+        return obj

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -357,7 +357,7 @@ class DSOViewMixin:
         # Workaround for DRF bug. When the response produces a generator, make sure the
         # Django middleware doesn't concat the stream. Unfortunately, it's not safe to
         # check what 'response.rendered_content' returns as that invokes the rendering.
-        if isgeneratorfunction(response.accepted_renderer.render):
+        if not response.exception and isgeneratorfunction(response.accepted_renderer.render):
             response = StreamingResponse.from_response(response)
 
         if hasattr(response.accepted_renderer, "finalize_response"):

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -853,7 +853,7 @@ def bag_schema(bag_schema_json) -> DatasetSchema:
 
 
 @pytest.fixture()
-def bag_dataset(bag_schema_json) -> Dataset:
+def bag_dataset(gebieden_dataset, bag_schema_json) -> Dataset:
     return Dataset.objects.create(name="bag", path="bag", schema_data=json.dumps(bag_schema_json))
 
 
@@ -896,6 +896,11 @@ def dossiers_model(bag_dataset, dynamic_models):
 
 
 @pytest.fixture()
+def bouwblokken_model(gebieden_dataset, dynamic_models):
+    return dynamic_models["gebieden"]["bouwblokken"]
+
+
+@pytest.fixture()
 def buurten_model(gebieden_dataset, dynamic_models):
     return dynamic_models["gebieden"]["buurten"]
 
@@ -903,6 +908,11 @@ def buurten_model(gebieden_dataset, dynamic_models):
 @pytest.fixture()
 def wijken_model(gebieden_dataset, dynamic_models):
     return dynamic_models["gebieden"]["wijken"]
+
+
+@pytest.fixture()
+def stadsdelen_model(gebieden_dataset, dynamic_models):
+    return dynamic_models["gebieden"]["stadsdelen"]
 
 
 @pytest.fixture()
@@ -929,34 +939,66 @@ def statistieken_data(statistieken_model, buurten_data):
 
 
 @pytest.fixture()
-def buurten_data(buurten_model):
+def buurten_data(buurten_model) -> DynamicModel:
+    # NOTE: 'wijken_data' is not included as fixture here.
+    # some tests appear to rely on having a broken relation.
     buurten_model.objects.create(
         id="03630000000078.1",
         identificatie="03630000000078",
         volgnummer=1,
         ligt_in_wijk_id="03630012052035.1",
     )
-    buurten_model.objects.create(
-        id="03630000000078.2", identificatie="03630000000078", volgnummer=2
+    return buurten_model.objects.create(
+        id="03630000000078.2",
+        identificatie="03630000000078",
+        volgnummer=2,
+        ligt_in_wijk_id="03630012052035.1",
     )
 
 
 @pytest.fixture()
-def panden_data(panden_model, dossiers_model):
+def bouwblokken_data(bouwblokken_model, buurten_data) -> DynamicModel:
+    return bouwblokken_model.objects.create(
+        id="03630012096483.1",
+        identificatie="03630012096483",
+        volgnummer=1,
+        ligt_in_buurt_id="03630000000078.2",  # example (not actual)
+    )
+
+
+@pytest.fixture()
+def panden_data(panden_model, dossiers_model, bouwblokken_data):
     panden_model.objects.create(
         id="0363100012061164.3",
         volgnummer=3,
         identificatie="0363100012061164",
         naam="Voorbeeldpand",
+        ligt_in_bouwblok_id="03630012096483.1",
         heeft_dossier_id="GV00000406",
     )
     dossiers_model.objects.create(dossier="GV00000406")
 
 
 @pytest.fixture()
-def wijken_data(wijken_model):
-    wijken_model.objects.create(
-        id="03630012052035.1", identificatie="03630012052035", volgnummer=1
+def wijken_data(wijken_model, stadsdelen_data) -> DynamicModel:
+    return wijken_model.objects.create(
+        id="03630012052035.1",
+        identificatie="03630012052035",
+        naam="Burgwallen-Nieuwe Zijde",
+        code="A01",
+        volgnummer=1,
+        ligt_in_stadsdeel=stadsdelen_data,
+    )
+
+
+@pytest.fixture()
+def stadsdelen_data(stadsdelen_model) -> DynamicModel:
+    return stadsdelen_model.objects.create(
+        id="03630000000018.1",
+        identificatie="03630000000018",
+        volgnummer=1,
+        naam="Centrum",
+        code="A",
     )
 
 

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -50,6 +50,19 @@
             "type": "string",
             "description": "Naamgeving van een pand (bv. naam van metrostation of bijzonder gebouw)."
           },
+          "ligtInBouwblok": {
+            "type": "object",
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              },
+              "volgnummer": {
+                "type": "integer"
+              }
+            },
+            "relation": "gebieden:bouwblokken",
+            "description": "Het bouwblok waarin het pand ligt."
+          },
           "heeftDossier": {
             "type": "string",
             "relation": "bag:dossiers",

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -8,6 +8,75 @@
   "crs": "EPSG:28992",
   "tables": [
     {
+      "id": "bouwblokken",
+      "type": "table",
+      "temporal": {
+        "identifier": "volgnummer",
+        "dimensions": {
+          "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
+        }
+      },
+      "schema": {
+        "$id": "https://github.com/Amsterdam/schemas/gebieden/bouwblokken.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "mainGeometry": "geometrie",
+        "identifier": ["identificatie", "volgnummer"],
+        "required": ["schema", "identificatie", "volgnummer"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "Unieke identificatie van het object."
+          },
+          "volgnummer": {
+            "type": "integer",
+            "description": "Uniek volgnummer van de toestand van het object."
+          },
+          "registratiedatum": {
+            "type": "string",
+            "format": "date-time",
+            "description": "De datum waarop de toestand is geregistreerd."
+          },
+          "code": {
+            "type": "string",
+            "description": "Officiële code van het object."
+          },
+          "beginGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is gecreëerd."
+          },
+          "eindGeldigheid": {
+            "type": "string",
+            "format": "date",
+            "description": "De datum waarop het object is komen te vervallen."
+          },
+          "ligtInBuurt": {
+            "type": "object",
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              },
+              "volgnummer": {
+                "type": "integer"
+              }
+            },
+            "relation": "gebieden:buurten",
+            "description": "De buurt waar het bouwblok in ligt."
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Polygon.json",
+            "description": "Geometrische beschrijving van een object."
+          }
+        }
+      }
+    },
+    {
       "id": "buurten",
       "type": "table",
       "temporal": {

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -6,7 +6,7 @@ from django.core.validators import EmailValidator, URLValidator
 from schematools.permissions import UserScopes
 from schematools.types import ProfileSchema
 
-from dso_api.dynamic_api.serializers import serializer_factory
+from dso_api.dynamic_api.serializers import serializer_factory, serializer_factory_cache
 from rest_framework_dso.fields import EmbeddedField
 from rest_framework_dso.views import DSOViewMixin
 from tests.utils import (
@@ -21,7 +21,7 @@ from tests.utils import (
 @pytest.fixture(autouse=True)
 def clear_caches():
     yield  # run tests first
-    serializer_factory.cache_clear()
+    serializer_factory_cache.clear()
 
 
 @pytest.fixture()

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -795,8 +795,347 @@ class TestEmbedTemporalTables:
         assert response.status_code == 200, data
         assert data["_embedded"]["ligtInWijk"]["id"] == "03630012052035.1"
         assert data["_embedded"]["ligtInWijk"]["buurt"] == {
-            "count": 1,
+            "count": 2,  # counts historical records too.
             "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",
+        }
+
+        assert data == {
+            "_links": {
+                "ligtInWijk": {
+                    "href": "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1",
+                    "identificatie": "03630012052035",
+                    "title": "03630012052035.1",
+                    "volgnummer": 1,
+                },
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
+                "self": {
+                    "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=1",
+                    "identificatie": "03630000000078",
+                    "title": "03630000000078.1",
+                    "volgnummer": 1,
+                },
+            },
+            "beginGeldigheid": None,
+            "code": None,
+            "eindGeldigheid": None,
+            "geometrie": None,
+            "id": "03630000000078.1",
+            "ligtInWijkId": "03630012052035",
+            "naam": None,
+            "_embedded": {
+                "ligtInWijk": {
+                    "_links": {
+                        "schema": (
+                            "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken"
+                        ),
+                        "self": {
+                            "href": (
+                                "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1"
+                            ),
+                            "identificatie": "03630012052035",
+                            "title": "03630012052035.1",
+                            "volgnummer": 1,
+                        },
+                        "buurt": {
+                            # See that the link is properly added
+                            "count": 2,  # counts historical records too.
+                            "href": (
+                                "http://testserver/v1/gebieden/buurten/"
+                                "?ligtInWijkId=03630012052035.1"
+                            ),
+                        },
+                        "ligtInStadsdeel": {
+                            "href": (
+                                "http://testserver/v1/gebieden/stadsdelen/03630000000018/"
+                                "?volgnummer=1"
+                            ),
+                            "identificatie": "03630000000018",
+                            "title": "03630000000018.1",
+                            "volgnummer": 1,
+                        },
+                    },
+                    "id": "03630012052035.1",
+                    "code": "A01",
+                    "naam": "Burgwallen-Nieuwe Zijde",
+                    "beginGeldigheid": None,
+                    "eindGeldigheid": None,
+                    "ligtInStadsdeelId": "03630000000018",
+                    "buurt": {
+                        # Note: still added by current API.
+                        "count": 2,
+                        "href": (
+                            "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1"
+                        ),
+                    },
+                    "_embedded": {
+                        # second level embedded
+                        "ligtInStadsdeel": {
+                            "_links": {
+                                "schema": (
+                                    "https://schemas.data.amsterdam.nl"
+                                    "/datasets/gebieden/dataset#stadsdelen"
+                                ),
+                                "self": {
+                                    "href": (
+                                        "http://testserver/v1/gebieden/stadsdelen/03630000000018/"
+                                        "?volgnummer=1"
+                                    ),
+                                    "identificatie": "03630000000018",
+                                    "title": "03630000000018.1",
+                                    "volgnummer": 1,
+                                },
+                                "wijk": [
+                                    # Reverse relation
+                                    {
+                                        "href": (
+                                            "http://testserver/v1/gebieden/wijken/03630012052035/"
+                                            "?volgnummer=1"
+                                        ),
+                                        "identificatie": "03630012052035",
+                                        "title": "03630012052035.1",
+                                        "volgnummer": 1,
+                                    }
+                                ],
+                            },
+                            "beginGeldigheid": None,
+                            "code": "A",
+                            "documentdatum": None,
+                            "documentnummer": None,
+                            "eindGeldigheid": None,
+                            "geometrie": None,
+                            "id": "03630000000018.1",
+                            "naam": "Centrum",
+                            "registratiedatum": None,
+                        }
+                    },
+                }
+            },
+        }
+
+    def test_nested_expand_list(
+        self, api_client, panden_data, buurten_data, wijken_data, filled_router
+    ):
+        """Prove that nesting of nesting also works."""
+        url = reverse("dynamic_api:bag-panden-list")
+        response = api_client.get(
+            url,
+            data={
+                "_expand": "true",
+                "_expandScope": "ligtInBouwblok.ligtInBuurt.ligtInWijk.ligtInStadsdeel",
+            },
+        )
+        data = read_response_json(response)
+        assert response.status_code == 200, data
+        assert data == {
+            "_embedded": {
+                "panden": [
+                    {
+                        "_links": {
+                            "schema": (
+                                "https://schemas.data.amsterdam.nl/datasets/bag/dataset#panden"
+                            ),
+                            "self": {
+                                "href": (
+                                    "http://testserver/v1/bag/panden/0363100012061164/"
+                                    "?volgnummer=3"
+                                ),
+                                "identificatie": "0363100012061164",
+                                "title": "0363100012061164.3",
+                                "volgnummer": 3,
+                            },
+                            "heeftDossier": {
+                                "href": "http://testserver/v1/bag/dossiers/GV00000406/",
+                                "title": "GV00000406",
+                            },
+                            "ligtInBouwblok": {
+                                "href": (
+                                    "http://testserver/v1/gebieden/bouwblokken/03630012096483/"
+                                    "?volgnummer=1"
+                                ),
+                                "identificatie": "03630012096483",
+                                "title": "03630012096483.1",
+                                "volgnummer": 1,
+                            },
+                        },
+                        "id": "0363100012061164.3",
+                        "ligtInBouwblokId": "03630012096483",
+                        "naam": "Voorbeeldpand",
+                        "beginGeldigheid": None,
+                        "eindGeldigheid": None,
+                        "heeftDossierId": "GV00000406",
+                    }
+                ],
+                "ligtInBouwblok": [
+                    {
+                        "_links": {
+                            "schema": (
+                                "https://schemas.data.amsterdam.nl"
+                                "/datasets/gebieden/dataset#bouwblokken"
+                            ),
+                            "self": {
+                                "href": (
+                                    "http://testserver/v1/gebieden/bouwblokken/03630012096483/"
+                                    "?volgnummer=1"
+                                ),
+                                "identificatie": "03630012096483",
+                                "title": "03630012096483.1",
+                                "volgnummer": 1,
+                            },
+                            "ligtInBuurt": {
+                                "href": (
+                                    "http://testserver/v1/gebieden/buurten/03630000000078/"
+                                    "?volgnummer=2"
+                                ),
+                                "identificatie": "03630000000078",
+                                "title": "03630000000078.2",
+                                "volgnummer": 2,
+                            },
+                        },
+                        "beginGeldigheid": None,
+                        "code": None,
+                        "eindGeldigheid": None,
+                        "geometrie": None,
+                        "id": "03630012096483.1",
+                        "ligtInBuurtId": "03630000000078",
+                        "registratiedatum": None,
+                        "_embedded": {
+                            "ligtInBuurt": {
+                                "_links": {
+                                    "schema": (
+                                        "https://schemas.data.amsterdam.nl"
+                                        "/datasets/gebieden/dataset#buurten"
+                                    ),
+                                    "self": {
+                                        "href": (
+                                            "http://testserver/v1/gebieden/buurten/03630000000078/"
+                                            "?volgnummer=2"
+                                        ),
+                                        "identificatie": "03630000000078",
+                                        "title": "03630000000078.2",
+                                        "volgnummer": 2,
+                                    },
+                                    "ligtInWijk": {
+                                        "href": (
+                                            "http://testserver/v1/gebieden/wijken/03630012052035/"
+                                            "?volgnummer=1"
+                                        ),
+                                        "identificatie": "03630012052035",
+                                        "title": "03630012052035.1",
+                                        "volgnummer": 1,
+                                    },
+                                },
+                                "id": "03630000000078.2",
+                                "naam": None,
+                                "code": None,
+                                "geometrie": None,
+                                "beginGeldigheid": None,
+                                "eindGeldigheid": None,
+                                "ligtInWijkId": "03630012052035",
+                                "_embedded": {
+                                    "ligtInWijk": {
+                                        "_embedded": {
+                                            "ligtInStadsdeel": {
+                                                "_links": {
+                                                    "schema": (
+                                                        "https://schemas.data.amsterdam.nl"
+                                                        "/datasets/gebieden/dataset#stadsdelen"
+                                                    ),
+                                                    "self": {
+                                                        "href": (
+                                                            "http://testserver/v1"
+                                                            "/gebieden/stadsdelen/03630000000018/"
+                                                            "?volgnummer=1"
+                                                        ),
+                                                        "identificatie": "03630000000018",
+                                                        "title": "03630000000018.1",
+                                                        "volgnummer": 1,
+                                                    },
+                                                    "wijk": [
+                                                        {
+                                                            "href": (
+                                                                "http://testserver/v1"
+                                                                "/gebieden/wijken/03630012052035/"
+                                                                "?volgnummer=1"
+                                                            ),
+                                                            "identificatie": "03630012052035",
+                                                            "title": "03630012052035.1",
+                                                            "volgnummer": 1,
+                                                        }
+                                                    ],
+                                                },
+                                                "beginGeldigheid": None,
+                                                "code": "A",
+                                                "documentdatum": None,
+                                                "documentnummer": None,
+                                                "eindGeldigheid": None,
+                                                "geometrie": None,
+                                                "id": "03630000000018.1",
+                                                "naam": "Centrum",
+                                                "registratiedatum": None,
+                                            }
+                                        },
+                                        "_links": {
+                                            "schema": (
+                                                "https://schemas.data.amsterdam.nl"
+                                                "/datasets/gebieden/dataset#wijken"
+                                            ),
+                                            "self": {
+                                                "href": (
+                                                    "http://testserver/v1"
+                                                    "/gebieden/wijken/03630012052035/"
+                                                    "?volgnummer=1"
+                                                ),
+                                                "identificatie": "03630012052035",
+                                                "title": "03630012052035.1",
+                                                "volgnummer": 1,
+                                            },
+                                            "buurt": {
+                                                "count": 2,
+                                                "href": (
+                                                    "http://testserver/v1/gebieden/buurten/"
+                                                    "?ligtInWijkId=03630012052035.1"
+                                                ),
+                                            },
+                                            "ligtInStadsdeel": {
+                                                "href": (
+                                                    "http://testserver/v1"
+                                                    "/gebieden/stadsdelen/03630000000018/"
+                                                    "?volgnummer=1"
+                                                ),
+                                                "identificatie": "03630000000018",
+                                                "title": "03630000000018.1",
+                                                "volgnummer": 1,
+                                            },
+                                        },
+                                        "beginGeldigheid": None,
+                                        "buurt": {
+                                            "count": 2,
+                                            "href": (
+                                                "http://testserver/v1/gebieden/buurten/"
+                                                "?ligtInWijkId=03630012052035.1"
+                                            ),
+                                        },
+                                        "code": "A01",
+                                        "eindGeldigheid": None,
+                                        "id": "03630012052035.1",
+                                        "ligtInStadsdeelId": "03630000000018",
+                                        "naam": "Burgwallen-Nieuwe " "Zijde",
+                                    }
+                                },
+                            }
+                        },
+                    }
+                ],
+            },
+            "_links": {
+                "self": {
+                    "href": (
+                        "http://testserver/v1/bag/panden/?_expand=true"
+                        "&_expandScope=ligtInBouwblok.ligtInBuurt.ligtInWijk.ligtInStadsdeel"
+                    )
+                }
+            },
+            "page": {"number": 1, "size": 20},
         }
 
     def test_detail_no_expand_for_temporal_fk_relation(
@@ -848,7 +1187,7 @@ class TestEmbedTemporalTables:
         assert response.status_code == 200, data
         assert data["_embedded"]["ligtInWijk"][0]["id"] == "03630012052035.1"
         assert data["_embedded"]["ligtInWijk"][0]["buurt"] == {
-            "count": 1,
+            "count": 2,  # counts historical records too.
             "href": (
                 "http://testserver/v1/gebieden/buurten/"
                 "?_format=json&ligtInWijkId=03630012052035.1"
@@ -1046,7 +1385,7 @@ class TestEmbedTemporalTables:
                     "eindGeldigheid": None,
                     "beginGeldigheid": None,
                     "id": "03630000000078.2",
-                    "ligtInWijkId": None,
+                    "ligtInWijkId": "03630012052035.1",
                     "_embedded": {
                         "ligtInWijk": None,
                     },


### PR DESCRIPTION
After increasing the number of allowed embedding, several bugs showed up. This PR also fixes those bugs.

* Added `ExpandScope` object that retains the nested embeds. Changed `fields_to_expand` to `expand_scope`, since the nested expand was lost by only passing `.keys()` to the sub-level serializer.
* Replaced `lru_cache()` with cachetools for `serializer_factory()`. This way the `nesting_level` no longer changes caching.
* Fixed recursion of the `serialize_factory()` for self-references, which avoided the LRU-cache.
* Completed BAG models for unit tests, so deep nesting could be tested.