### PR TITLE
Improve error message when using large pages in HTML view

### DIFF
--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -150,7 +150,9 @@ class BrowsableAPIRenderer(RendererMixin, renderers.BrowsableAPIRenderer):
             and view.paginator.get_page_size(request) > BROWSABLE_MAX_PAGE_SIZE
         ):
             raise ValidationError(
-                "Browsable HTML API does not support this page size.", code="_pageSize"
+                "Browsable HTML API does not support this page size. "
+                "Use ?_format=json if you want larger pages.",
+                code="_pageSize",
             )
 
         ret = super().render(

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -579,12 +579,18 @@ class TestExceptionHandler:
             "invalid-params": [
                 {
                     "name": "_pageSize",
-                    "reason": "Browsable HTML API does not support this page size.",
+                    "reason": (
+                        "Browsable HTML API does not support this page size. "
+                        "Use ?_format=json if you want larger pages."
+                    ),
                     "type": "urn:apiexception:invalid:_pageSize",
                 }
             ],
             "status": 400,
             "title": "Invalid input.",
             "type": "urn:apiexception:invalid",
-            "x-validation-errors": ["Browsable HTML API does not support this page size."],
+            "x-validation-errors": [
+                "Browsable HTML API does not support this page size. "
+                "Use ?_format=json if you want larger pages."
+            ],
         }


### PR DESCRIPTION
Momenteel staat de HTML preview geen grote pagina’s toe. Dat deden we eerst omdat dit de server kon overbelasten. Nu de output streaming ingeladen wordt mag een grotere pagina nog wel, maar loopt de browser er waarschijnlijk in vast. Vandaar het compromis om alsnog een foutmelding te tonen.