### PR TITLE
AB#20567 Bugfix breadcrumbs work when dataset has empty title

### DIFF
--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -110,7 +110,7 @@ def get_openapi_json_view(dataset: Dataset):
     # The second strategy is chosen here to keep the whole endpoint enumeration logic intact.
     # Patterns is a lazy object so it's not evaluated yet while the URLconf is being constructed.
     openapi_view = get_schema_view(
-        title=dataset_schema.title,
+        title=dataset_schema.title or dataset_schema.id,
         description=dataset_schema.description or "",
         renderer_classes=[renderers.JSONOpenAPIRenderer],
         patterns=_lazy_get_dataset_patterns(dataset_schema.id),


### PR DESCRIPTION
# This Pull request contains changes to:

Als een dastaset een leeg title veld heeft, wordt zn breadcrumb een lege string.
Deze commit  fixed dat.

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
