### PR TITLE
Provide URL schemes for proxy configs in owasp_scan.py

### DIFF
--- a/src/.jenkins/owasp_vulnerability_scan/owasp_scan.py
+++ b/src/.jenkins/owasp_vulnerability_scan/owasp_scan.py
@@ -15,7 +15,7 @@ def test_owasp_check():
     # by browsing to localhost:8090
     zap = ZAPv2(
         apikey=apiKey,
-        proxies={"http": "owasp:8090", "https": "owasp:8090"},
+        proxies={"http": "http://owasp:8090", "https": "https://owasp:8090"},
     )
 
     print("Stopping all current scans. To prevent scan slowdowns.")


### PR DESCRIPTION
Previously this worked without specify either `http://` or `https://`.
However after the upgrade to Python 3.9 this stopped working. Tried
looking whether this was caused by an upgraded dependency (`urllib3` or
`requests`) but couldn't find anything that might have caused this.

`urllib3` did add support for HTTPS proxies going from 1.25.x to 1.26.0.
Hence that seemed a plausible cause. But still couldn't find an exact
cause.

Note that `requests` documentation has stated for ages _that proxy URLs
must include the scheme_ hence our original usage in `owasp_scan` has
always faulty to begin with.
