### PR TITLE
Silence Django "Reloading models is not advised" warning

### DIFF
--- a/src/manage.py
+++ b/src/manage.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dso_api.settings")
@@ -12,4 +13,7 @@ if __name__ == "__main__":
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
-    execute_from_command_line(sys.argv)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*Reloading models is not advised.*")
+        execute_from_command_line(sys.argv)


### PR DESCRIPTION
With autoreload on, I get so many warnings that I lose all logs. This disables the warning.

Because [the docs](https://docs.python.org/3/library/warnings.html#temporarily-suppressing-warnings) warn so strictly against doing this in multithreaded code, I've attached the filter update at the highest possible point. The lowest would be in [`model_factory`](https://github.com/Amsterdam/schema-tools/blob/bbc17c64d4ff160206c41d3304031381b19ab7c9/src/schematools/contrib/django/factories.py#L457-L471).