### PR TITLE
Cleanup the merge of OpenAPI and API-index views and tests

### DIFF
--- a/src/dso_api/dynamic_api/views/__init__.py
+++ b/src/dso_api/dynamic_api/views/__init__.py
@@ -1,5 +1,6 @@
 """All views for the dynamically generated API, split by protocol type."""
-from .api import APIIndexView, DynamicApiViewSet, reload_patterns, viewset_factory
+from .api import DynamicApiViewSet, reload_patterns, viewset_factory
+from .index import APIIndexView
 from .mvt import DatasetMVTIndexView, DatasetMVTSingleView, DatasetMVTView
 from .oauth import oauth2_redirect
 from .wfs import DatasetWFSIndexView, DatasetWFSView

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -12,22 +12,15 @@ and model layer of this application.
 """
 from __future__ import annotations
 
-from typing import Iterable
-
 from django.db import models
 from django.http import Http404, JsonResponse
-from django.urls import reverse
 from django.utils.translation import gettext as _
 from more_itertools import first
 from rest_framework import viewsets
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from schematools.contrib.django.models import Dataset, DynamicModel
+from schematools.contrib.django.models import DynamicModel
 
 from dso_api.dynamic_api import filterset, locking, permissions, serializers
-from dso_api.dynamic_api.datasets import get_active_datasets
 from rest_framework_dso import fields
-from rest_framework_dso.renderers import BrowsableAPIRenderer, HALJSONRenderer
 from rest_framework_dso.views import DSOViewMixin
 
 
@@ -208,76 +201,3 @@ def viewset_factory(model: type[DynamicModel]) -> type[DynamicApiViewSet]:
         "table_id": model.table_schema()["id"],
     }
     return type(f"{model.__name__}ViewSet", (DynamicApiViewSet,), attrs)
-
-
-class APIIndexView(APIView):
-    """An overview of API endpoints for a list of Datasets,
-    in a JSON format compatible with developer.overheid.nl.
-    """
-
-    schema = None  # exclude from schema
-
-    # Restrict available formats to JSON and api
-    renderer_classes = [HALJSONRenderer, BrowsableAPIRenderer]
-
-    # For browsable API
-    name = "DSO-API"
-    description = (
-        "To use the DSO-API, see the documentation at <https://api.data.amsterdam.nl/v1/docs/>. "
-    )
-
-    # Set by as_view
-    api_type = "rest_json"
-
-    def get_datasets(self) -> Iterable[Dataset]:
-        return get_active_datasets().order_by("name")
-
-    def get_environments(self, ds: Dataset, base: str) -> list[dict]:
-        return [
-            {
-                "name": "production",
-                "api_url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
-                "specification_url": "",
-                "documentation_url": "",
-            }
-        ]
-
-    def get_related_apis(self, ds: Dataset, base: str) -> list[dict]:
-        """ Get list of other APIs exposing the same dataset """
-        return []
-
-    def get(self, request, *args, **kwargs):
-        # Data not needed for html view
-        if getattr(request, "accepted_media_type", None) == "text/html":
-            return Response()
-
-        base = request.build_absolute_uri("/").rstrip("/")
-        datasets = self.get_datasets()
-
-        result = {"datasets": {}}
-        for ds in datasets:
-            result["datasets"][ds.schema.id] = {
-                "id": ds.schema.id,
-                "short_name": ds.name,
-                "service_name": ds.schema.title or ds.name,
-                "status": ds.schema.get("status", "Beschikbaar"),
-                "description": ds.schema.description or "",
-                "tags": ds.schema.get("theme", []),
-                "terms_of_use": {
-                    "government_only": "auth" in ds.schema,
-                    "pay_per_use": False,
-                    "license": ds.schema.license,
-                },
-                "environments": self.get_environments(ds, base),
-                "related_apis": self.get_related_apis(ds, base),
-                "api_authentication": list(ds.schema.auth) or None,
-                "api_type": self.api_type,
-                "organization_name": "Gemeente Amsterdam",
-                "organization_oin": "00000001002564440000",
-                "contact": {
-                    "email": "datapunt@amsterdam.nl",
-                    "url": "https://github.com/Amsterdam/dso-api/issues",
-                },
-            }
-
-        return Response(result)

--- a/src/dso_api/dynamic_api/views/index.py
+++ b/src/dso_api/dynamic_api/views/index.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from django.urls import reverse
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from schematools.contrib.django.models import Dataset
+
+from dso_api.dynamic_api.datasets import get_active_datasets
+from rest_framework_dso.renderers import BrowsableAPIRenderer, HALJSONRenderer
+
+
+class APIIndexView(APIView):
+    """An overview of API endpoints for a list of Datasets,
+    in a JSON format compatible with developer.overheid.nl.
+    """
+
+    schema = None  # exclude from schema
+
+    # Restrict available formats to JSON and api
+    renderer_classes = [HALJSONRenderer, BrowsableAPIRenderer]
+
+    # For browsable API
+    name = "DSO-API"
+    description = (
+        "To use the DSO-API, see the documentation at <https://api.data.amsterdam.nl/v1/docs/>. "
+    )
+
+    # Set by as_view
+    api_type = "rest_json"
+
+    def get_datasets(self) -> Iterable[Dataset]:
+        return get_active_datasets().order_by("name")
+
+    def get_environments(self, ds: Dataset, base: str) -> list[dict]:
+        return [
+            {
+                "name": "production",
+                "api_url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
+                "specification_url": "",
+                "documentation_url": "",
+            }
+        ]
+
+    def get_related_apis(self, ds: Dataset, base: str) -> list[dict]:
+        """ Get list of other APIs exposing the same dataset """
+        return []
+
+    def get(self, request, *args, **kwargs):
+        # Data not needed for html view
+        if getattr(request, "accepted_media_type", None) == "text/html":
+            return Response()
+
+        base = request.build_absolute_uri("/").rstrip("/")
+        datasets = self.get_datasets()
+
+        result = {"datasets": {}}
+        for ds in datasets:
+            result["datasets"][ds.schema.id] = {
+                "id": ds.schema.id,
+                "short_name": ds.name,
+                "service_name": ds.schema.title or ds.name,
+                "status": ds.schema.get("status", "Beschikbaar"),
+                "description": ds.schema.description or "",
+                "tags": ds.schema.get("theme", []),
+                "terms_of_use": {
+                    "government_only": "auth" in ds.schema,
+                    "pay_per_use": False,
+                    "license": ds.schema.license,
+                },
+                "environments": self.get_environments(ds, base),
+                "related_apis": self.get_related_apis(ds, base),
+                "api_authentication": list(ds.schema.auth) or None,
+                "api_type": self.api_type,
+                "organization_name": "Gemeente Amsterdam",
+                "organization_oin": "00000001002564440000",
+                "contact": {
+                    "email": "datapunt@amsterdam.nl",
+                    "url": "https://github.com/Amsterdam/dso-api/issues",
+                },
+            }
+
+        return Response(result)

--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -16,7 +16,8 @@ from vectortiles.postgis.views import MVTView
 
 from dso_api.dynamic_api.datasets import get_active_datasets
 from dso_api.dynamic_api.permissions import CheckPermissionsMixin
-from dso_api.dynamic_api.views import APIIndexView
+
+from .index import APIIndexView
 
 logger = logging.getLogger(__name__)
 

--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -42,8 +42,9 @@ from schematools.contrib.django.models import Dataset, get_field_schema
 
 from dso_api.dynamic_api.datasets import get_active_datasets
 from dso_api.dynamic_api.permissions import CheckPermissionsMixin
-from dso_api.dynamic_api.views import APIIndexView
 from rest_framework_dso import crs
+
+from .index import APIIndexView
 
 FieldDef = Union[str, FeatureField]
 RE_SIMPLE_NAME = re.compile(

--- a/src/tests/test_dynamic_api/test_openapi.py
+++ b/src/tests/test_dynamic_api/test_openapi.py
@@ -1,7 +1,10 @@
+import logging
+
 import pytest
 from django.urls import NoReverseMatch, reverse
 
 from dso_api.dynamic_api import openapi
+from tests.utils import read_response
 
 
 @pytest.mark.django_db
@@ -17,3 +20,155 @@ def test_get_patterns(afval_dataset, fietspaaltjes_dataset, filled_router):
     assert reverse("dynamic_api:fietspaaltjes-fietspaaltjes-list", urlconf=tuple(patterns))
     with pytest.raises(NoReverseMatch):
         reverse("dynamic_api:afvalwegingen-containers-list", urlconf=tuple(patterns))
+
+
+@pytest.mark.django_db
+def test_openapi_swagger(api_client, afval_dataset, filled_router):
+    """Prove that the OpenAPI page can be rendered."""
+    url = reverse("dynamic_api:openapi-afvalwegingen")
+    assert url == "/v1/afvalwegingen/"
+
+    response = api_client.get(url, HTTP_ACCEPT="text/html")
+    assert response.status_code == 200
+    assert response["content-type"] == "text/html; charset=utf-8"
+    content = read_response(response)
+    assert "ui.initOAuth(" in content
+
+
+@pytest.mark.django_db
+def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_router, caplog):
+    """Prove that the OpenAPI page can be rendered."""
+    caplog.set_level(logging.WARNING)
+
+    # Prove the that OpenAPI view can be found at the endpoint
+    url = reverse("dynamic_api:openapi-afvalwegingen")
+    assert url == "/v1/afvalwegingen/"
+
+    response = api_client.get(url)
+    assert response.status_code == 200, response.data
+    assert response["content-type"] == "application/vnd.oai.openapi+json"
+    schema = response.data
+
+    # Prove that the main info block is correctly rendered
+    assert schema["info"] == {
+        "title": "Afvalwegingen",
+        "description": "unit testing version of afvalwegingen",
+        "version": "0.0.1",
+        "license": "CC0 1.0",
+        "contact": {"email": "datapunt@amsterdam.nl"},
+        "termsOfService": "https://data.amsterdam.nl/",
+    }
+
+    # Prove that only afvalwegingen are part of this OpenAPI page:
+    paths = sorted(schema["paths"].keys())
+    assert paths == [
+        "/v1/afvalwegingen/adres_loopafstand/",
+        "/v1/afvalwegingen/adres_loopafstand/{id}/",
+        "/v1/afvalwegingen/containers/",
+        "/v1/afvalwegingen/containers/{id}/",
+    ]
+
+    # Prove that the oauth model is exposed
+    assert schema["components"]["securitySchemes"]["oauth2"]["type"] == "oauth2"
+
+    # Prove that the serializer field types are reasonably converted
+    component_schemas = schema["components"]["schemas"]
+    container_properties = component_schemas["Afvalwegingencontainers"]["properties"]
+    assert "MultiPolygon" in component_schemas, list(component_schemas)
+    assert container_properties["geometry"]["$ref"] == "#/components/schemas/Point"
+    assert container_properties["id"]["type"] == "integer"
+    assert container_properties["datumLeegmaken"]["format"] == "date-time"
+
+    # Prove that various filters are properly exposed.
+    afval_parameters = {
+        param["name"]: param
+        for param in schema["paths"]["/v1/afvalwegingen/containers/"]["get"]["parameters"]
+    }
+    all_keys = ", ".join(afval_parameters.keys())
+    assert "datumCreatie" in afval_parameters, all_keys
+    assert afval_parameters["datumCreatie"] == {
+        "name": "datumCreatie",
+        "in": "query",
+        "description": "yyyy-mm-dd",
+        "schema": {"format": "date", "type": "string"},
+    }
+
+    # Prove that DSOOrderingFilter exposes parameters
+    assert "_format" in afval_parameters, all_keys
+    assert afval_parameters["_format"] == {
+        "name": "_format",
+        "in": "query",
+        "schema": {
+            "type": "string",
+            "enum": ["csv", "geojson", "json"],
+        },
+    }
+    assert "_sort" in afval_parameters, all_keys
+    assert afval_parameters["_sort"] == {
+        "name": "_sort",
+        "in": "query",
+        "required": False,
+        "description": "Which field to use when ordering the results.",
+        "schema": {"type": "string"},
+    }
+
+    # Prove that general page parameters are exposed
+    assert "_pageSize" in afval_parameters, all_keys
+    assert afval_parameters["_pageSize"] == {
+        "name": "_pageSize",
+        "in": "query",
+        "required": False,
+        "description": "Number of results to return per page.",
+        "schema": {"type": "integer"},
+    }
+
+    # Prove that expansion is documented
+    assert "_expand" in afval_parameters, all_keys
+    assert "_expandScope" in afval_parameters, all_keys
+    assert afval_parameters["_expandScope"] == {
+        "name": "_expandScope",
+        "description": "Comma separated list of named relations to expand.",
+        "in": "query",
+        "schema": {"type": "string"},
+        "examples": {
+            "AllValues": {
+                "summary": "All Values",
+                "value": "cluster",
+                "description": "Expand all fields, identical to only using _expand=true.",
+            },
+            "Cluster": {
+                "description": "Cluster-ID",
+                "summary": "cluster",
+                "value": "cluster",
+            },
+        },
+    }
+
+    # Prove that the lookups of LOOKUPS_BY_TYPE are parsed
+    # ([lt] for dates, [in] for keys)
+    assert "datumCreatie[lt]" in afval_parameters, all_keys
+    assert "clusterId[in]" in afval_parameters, all_keys
+    assert afval_parameters["clusterId[in]"] == {
+        "name": "clusterId[in]",
+        "in": "query",
+        "description": "Multiple values may be separated by commas.",
+        "explode": False,
+        "schema": {
+            "type": "array",
+            "items": {"nullable": True, "type": "string"},
+        },
+        "style": "form",
+    }
+    assert afval_parameters["clusterId[isnull]"] == {
+        "name": "clusterId[isnull]",
+        "in": "query",
+        "description": "true | false",
+        "schema": {"type": "boolean"},
+    }
+
+    # Prove that the extra headers are included
+    assert "Accept-Crs" in afval_parameters, all_keys
+    assert afval_parameters["Accept-Crs"]["in"] == "header"
+
+    log_messages = [m for m in caplog.messages if "DisableMigrations" not in m]
+    assert not log_messages, caplog.messages

--- a/src/tests/test_dynamic_api/test_views_index.py
+++ b/src/tests/test_dynamic_api/test_views_index.py
@@ -1,15 +1,13 @@
-import logging
-
 import pytest
 from django.urls import reverse
 from more_ds.network.url import URL
 
-from tests.utils import read_response
-
 
 @pytest.mark.django_db
-def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_router, drf_request):
-    """Prove that the OpenAPI page can be rendered."""
+def test_api_index_view(
+    api_client, afval_dataset, fietspaaltjes_dataset, filled_router, drf_request
+):
+    """Prove that the API index page can be rendered."""
     url = reverse("dynamic_api:api-root")
     assert url == "/v1/"
 
@@ -87,10 +85,10 @@ def test_root_view(api_client, afval_dataset, fietspaaltjes_dataset, filled_rout
 
 
 @pytest.mark.django_db
-def test_subpath_view(
+def test_api_index_subpath_view(
     api_client, afval_dataset_subpath, fietspaaltjes_dataset_subpath, filled_router, drf_request
 ):
-    """Prove that the OpenAPI sub index can be rendered.
+    """Prove that the API sub index can be rendered.
     And only the datasets on the sub path are shown.
     """
     url_sub = reverse("dynamic_api:sub-index")
@@ -211,155 +209,3 @@ def test_subpath_view(
             },
         }
     }
-
-
-@pytest.mark.django_db
-def test_openapi_swagger(api_client, afval_dataset, filled_router):
-    """Prove that the OpenAPI page can be rendered."""
-    url = reverse("dynamic_api:openapi-afvalwegingen")
-    assert url == "/v1/afvalwegingen/"
-
-    response = api_client.get(url, HTTP_ACCEPT="text/html")
-    assert response.status_code == 200
-    assert response["content-type"] == "text/html; charset=utf-8"
-    content = read_response(response)
-    assert "ui.initOAuth(" in content
-
-
-@pytest.mark.django_db
-def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_router, caplog):
-    """Prove that the OpenAPI page can be rendered."""
-    caplog.set_level(logging.WARNING)
-
-    # Prove the that OpenAPI view can be found at the endpoint
-    url = reverse("dynamic_api:openapi-afvalwegingen")
-    assert url == "/v1/afvalwegingen/"
-
-    response = api_client.get(url)
-    assert response.status_code == 200, response.data
-    assert response["content-type"] == "application/vnd.oai.openapi+json"
-    schema = response.data
-
-    # Prove that the main info block is correctly rendered
-    assert schema["info"] == {
-        "title": "Afvalwegingen",
-        "description": "unit testing version of afvalwegingen",
-        "version": "0.0.1",
-        "license": "CC0 1.0",
-        "contact": {"email": "datapunt@amsterdam.nl"},
-        "termsOfService": "https://data.amsterdam.nl/",
-    }
-
-    # Prove that only afvalwegingen are part of this OpenAPI page:
-    paths = sorted(schema["paths"].keys())
-    assert paths == [
-        "/v1/afvalwegingen/adres_loopafstand/",
-        "/v1/afvalwegingen/adres_loopafstand/{id}/",
-        "/v1/afvalwegingen/containers/",
-        "/v1/afvalwegingen/containers/{id}/",
-    ]
-
-    # Prove that the oauth model is exposed
-    assert schema["components"]["securitySchemes"]["oauth2"]["type"] == "oauth2"
-
-    # Prove that the serializer field types are reasonably converted
-    component_schemas = schema["components"]["schemas"]
-    container_properties = component_schemas["Afvalwegingencontainers"]["properties"]
-    assert "MultiPolygon" in component_schemas, list(component_schemas)
-    assert container_properties["geometry"]["$ref"] == "#/components/schemas/Point"
-    assert container_properties["id"]["type"] == "integer"
-    assert container_properties["datumLeegmaken"]["format"] == "date-time"
-
-    # Prove that various filters are properly exposed.
-    afval_parameters = {
-        param["name"]: param
-        for param in schema["paths"]["/v1/afvalwegingen/containers/"]["get"]["parameters"]
-    }
-    all_keys = ", ".join(afval_parameters.keys())
-    assert "datumCreatie" in afval_parameters, all_keys
-    assert afval_parameters["datumCreatie"] == {
-        "name": "datumCreatie",
-        "in": "query",
-        "description": "yyyy-mm-dd",
-        "schema": {"format": "date", "type": "string"},
-    }
-
-    # Prove that DSOOrderingFilter exposes parameters
-    assert "_format" in afval_parameters, all_keys
-    assert afval_parameters["_format"] == {
-        "name": "_format",
-        "in": "query",
-        "schema": {
-            "type": "string",
-            "enum": ["csv", "geojson", "json"],
-        },
-    }
-    assert "_sort" in afval_parameters, all_keys
-    assert afval_parameters["_sort"] == {
-        "name": "_sort",
-        "in": "query",
-        "required": False,
-        "description": "Which field to use when ordering the results.",
-        "schema": {"type": "string"},
-    }
-
-    # Prove that general page parameters are exposed
-    assert "_pageSize" in afval_parameters, all_keys
-    assert afval_parameters["_pageSize"] == {
-        "name": "_pageSize",
-        "in": "query",
-        "required": False,
-        "description": "Number of results to return per page.",
-        "schema": {"type": "integer"},
-    }
-
-    # Prove that expansion is documented
-    assert "_expand" in afval_parameters, all_keys
-    assert "_expandScope" in afval_parameters, all_keys
-    assert afval_parameters["_expandScope"] == {
-        "name": "_expandScope",
-        "description": "Comma separated list of named relations to expand.",
-        "in": "query",
-        "schema": {"type": "string"},
-        "examples": {
-            "AllValues": {
-                "summary": "All Values",
-                "value": "cluster",
-                "description": "Expand all fields, identical to only using _expand=true.",
-            },
-            "Cluster": {
-                "description": "Cluster-ID",
-                "summary": "cluster",
-                "value": "cluster",
-            },
-        },
-    }
-
-    # Prove that the lookups of LOOKUPS_BY_TYPE are parsed
-    # ([lt] for dates, [in] for keys)
-    assert "datumCreatie[lt]" in afval_parameters, all_keys
-    assert "clusterId[in]" in afval_parameters, all_keys
-    assert afval_parameters["clusterId[in]"] == {
-        "name": "clusterId[in]",
-        "in": "query",
-        "description": "Multiple values may be separated by commas.",
-        "explode": False,
-        "schema": {
-            "type": "array",
-            "items": {"nullable": True, "type": "string"},
-        },
-        "style": "form",
-    }
-    assert afval_parameters["clusterId[isnull]"] == {
-        "name": "clusterId[isnull]",
-        "in": "query",
-        "description": "true | false",
-        "schema": {"type": "boolean"},
-    }
-
-    # Prove that the extra headers are included
-    assert "Accept-Crs" in afval_parameters, all_keys
-    assert afval_parameters["Accept-Crs"]["in"] == "header"
-
-    log_messages = [m for m in caplog.messages if "DisableMigrations" not in m]
-    assert not log_messages, caplog.messages


### PR DESCRIPTION
There were 2 test_openapi files and one had the api-root tests in them too. The "APIIndexView" is also a base class for many other dataset types, which really deserved to be in a separate file too.
