### PR TITLE
Implemented reverse embedding

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -606,11 +606,7 @@ def serializer_factory(
         ):
             continue
 
-        if isinstance(model_field, models.ManyToOneRel):
-            # Reverse relations are still part of the main body
-            _build_serializer_reverse_fk_field(serializer_part, model, model_field)
-        else:
-            _build_serializer_field(serializer_part, model, model_field, flat, nesting_level)
+        _build_serializer_field(serializer_part, model, model_field, flat, nesting_level)
 
     if not flat:
         _generate_nested_relations(serializer_part, model, nesting_level)

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -842,6 +842,7 @@ def _build_serializer_reverse_fk_field(
     format1 = additional_relation.format
 
     if format1 == "embedded":
+        # Shows the identifiers of each item inline.
         view_name = "dynamic_api:{}-{}-detail".format(
             to_snake_case(model.get_dataset_id()),
             to_snake_case(model_field.related_model.table_schema().id),
@@ -855,7 +856,10 @@ def _build_serializer_reverse_fk_field(
             ),
         )
     elif format1 == "summary":
+        # Only shows a count and href to the (potentially large) list of items.
         serializer_part.add_field(name, _RelatedSummaryField())
+    else:
+        logger.warning("Field %r uses unsupported format: %s", field_schema, format1)
 
 
 def _generate_nested_relations(

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -515,6 +515,7 @@ class SerializerAssemblyLine:
                     "model": model,
                     "fields": fields or [],
                     "extra_kwargs": {"depth": depth},
+                    "embedded_fields": {},
                     **meta_kwargs,
                 },
             ),
@@ -532,6 +533,11 @@ class SerializerAssemblyLine:
         self.class_attrs["Meta"].fields.append(name)
         if source is not None and source != name:
             self.class_attrs["Meta"].extra_kwargs[name] = {"source": source}
+
+    def add_embedded_field(self, name, field: AbstractEmbeddedField):
+        """Add an embedded field to the serializer-to-be."""
+        # field.__set_name__() handling will be triggered on class construction.
+        self.class_attrs[name] = field
 
     def construct_class(
         self, class_name, base_class: type[DynamicSerializer]
@@ -721,7 +727,7 @@ def _build_serializer_embedded_field(
     embedded_field.field_schema = get_field_schema(model_field)
 
     camel_name = toCamelCase(model_field.name)
-    serializer_part.class_attrs[camel_name] = embedded_field
+    serializer_part.add_embedded_field(camel_name, embedded_field)
 
 
 def _through_serializer_factory(

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.fields.related import RelatedField
 from django.db.models.fields.reverse_related import ForeignObjectRel
@@ -115,7 +116,7 @@ class AbstractEmbeddedField:
             # For ForeignKey/OneToOneField this resolves to "{field_name}_id"
             # For ManyToManyField this resolves to a manager object
             return self.parent_model._meta.get_field(self.source).attname
-        except models.FieldDoesNotExist:
+        except FieldDoesNotExist:
             # Allow non-FK relations, e.g. a "bag_id" to a completely different database
             if not self.source.endswith("_id"):
                 return f"{self.source}_id"

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -277,9 +277,7 @@ class DSOModelListSerializer(DSOListSerializer):
                 # All embedded result sets are updated during the iteration over
                 # the main data with the relevant ID's to fetch on-demand.
                 embedded_fields = {
-                    expand_match.name: EmbeddedResultSet(
-                        expand_match.field, serializer=expand_match.embedded_serializer
-                    )
+                    expand_match.name: EmbeddedResultSet.from_match(expand_match)
                     for expand_match in self.expanded_fields
                 }
 
@@ -628,11 +626,8 @@ class DSOModelSerializer(DSOSerializer, serializers.HyperlinkedModelSerializer):
                 continue
 
             # This just reuses the machinery for listings
-            result_set = EmbeddedResultSet(
-                embed_match.field,
-                serializer=embed_match.embedded_serializer,
-                main_instances=[instance],
-            )
+            result_set = EmbeddedResultSet.from_match(embed_match)
+            result_set.inspect_instance(instance)
 
             if not embed_match.field.is_array:
                 # Single object, embed as dict directly

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -73,19 +73,20 @@ class TestDynamicSerializer:
         ClusterSerializer = serializer_factory(afval_cluster_model)
 
         # Prove that EmbeddedField is created.
-        assert ContainerSerializer.Meta.embedded_fields == ["cluster"]
-        assert isinstance(ContainerSerializer.cluster, EmbeddedField)
+        assert set(ContainerSerializer.Meta.embedded_fields.keys()) == {"cluster"}
+        embedded_field: EmbeddedField = ContainerSerializer.Meta.embedded_fields["cluster"]
+        assert isinstance(embedded_field, EmbeddedField)
 
         # Prove that the EmbeddedField references the proper models and serializers.
         # This also tests whether there aren't any old references left.
-        assert ContainerSerializer.cluster.related_model is afval_cluster_model, (
+        assert embedded_field.related_model is afval_cluster_model, (
             "Old Django models were still referenced: "
-            f"id {id(ContainerSerializer.cluster.related_model)} vs "
+            f"id {id(embedded_field.related_model)} vs "
             f"id {id(afval_cluster_model)} "
-            f"(creation counter {ContainerSerializer.cluster.related_model.CREATION_COUNTER}"
+            f"(creation counter {embedded_field.related_model.CREATION_COUNTER}"
             f" vs {afval_cluster_model.CREATION_COUNTER})",
         )
-        assert ContainerSerializer.cluster.serializer_class.__name__ == ClusterSerializer.__name__
+        assert embedded_field.serializer_class.__name__ == ClusterSerializer.__name__
 
         # Prove that data is serialized with relations.
         # Both the cluster_id field and 'cluster' field are generated.

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -118,8 +118,8 @@ class TestViews:
         assert len(data["_embedded"]["wijken"]) == 1, data["_embedded"]["wijken"]
         wijken = data["_embedded"]["wijken"]
         assert wijken[0]["_links"]["self"]["volgnummer"] == 1, wijken[0]
-        assert wijken[0]["buurt"]["count"] == 1
-        query_params = parse.parse_qs(parse.urlparse(wijken[0]["buurt"]["href"]).query)
+        assert wijken[0]["_links"]["buurt"]["count"] == 1
+        query_params = parse.parse_qs(parse.urlparse(wijken[0]["_links"]["buurt"]["href"]).query)
         assert query_params["geldigOp"] == ["2015-01-02"]
 
     def test_details_record_can_be_requested_by_pk(self, api_client, stadsdelen):

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -794,7 +794,7 @@ class TestEmbedTemporalTables:
         data = read_response_json(response)
         assert response.status_code == 200, data
         assert data["_embedded"]["ligtInWijk"]["id"] == "03630012052035.1"
-        assert data["_embedded"]["ligtInWijk"]["buurt"] == {
+        assert data["_embedded"]["ligtInWijk"]["_links"]["buurt"] == {
             "count": 2,  # counts historical records too.
             "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",
         }
@@ -860,13 +860,6 @@ class TestEmbedTemporalTables:
                     "beginGeldigheid": None,
                     "eindGeldigheid": None,
                     "ligtInStadsdeelId": "03630000000018",
-                    "buurt": {
-                        # Note: still added by current API.
-                        "count": 2,
-                        "href": (
-                            "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1"
-                        ),
-                    },
                     "_embedded": {
                         # second level embedded
                         "ligtInStadsdeel": {
@@ -1108,13 +1101,6 @@ class TestEmbedTemporalTables:
                                             },
                                         },
                                         "beginGeldigheid": None,
-                                        "buurt": {
-                                            "count": 2,
-                                            "href": (
-                                                "http://testserver/v1/gebieden/buurten/"
-                                                "?ligtInWijkId=03630012052035.1"
-                                            ),
-                                        },
                                         "code": "A01",
                                         "eindGeldigheid": None,
                                         "id": "03630012052035.1",
@@ -1186,7 +1172,7 @@ class TestEmbedTemporalTables:
         data = read_response_json(response)
         assert response.status_code == 200, data
         assert data["_embedded"]["ligtInWijk"][0]["id"] == "03630012052035.1"
-        assert data["_embedded"]["ligtInWijk"][0]["buurt"] == {
+        assert data["_embedded"]["ligtInWijk"][0]["_links"]["buurt"] == {
             "count": 2,  # counts historical records too.
             "href": (
                 "http://testserver/v1/gebieden/buurten/"

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1179,6 +1179,128 @@ class TestEmbedTemporalTables:
                 "?_format=json&ligtInWijkId=03630012052035.1"
             ),
         }
+        assert data == {
+            "_embedded": {
+                "buurten": [
+                    # Main response
+                    {
+                        "_links": {
+                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",  # noqa: E501
+                            "self": {
+                                "href": "http://testserver/v1/gebieden/buurten/03630000000078/?_format=json&volgnummer=1",  # noqa: E501
+                                "identificatie": "03630000000078",
+                                "title": "03630000000078.1",
+                                "volgnummer": 1,
+                            },
+                            "ligtInWijk": {
+                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
+                                "identificatie": "03630012052035",
+                                "title": "03630012052035.1",
+                                "volgnummer": 1,
+                            },
+                        },
+                        "id": "03630000000078.1",
+                        "naam": None,
+                        "code": None,
+                        "beginGeldigheid": None,
+                        "eindGeldigheid": None,
+                        "geometrie": None,
+                        "ligtInWijkId": "03630012052035",
+                    },
+                    {
+                        "_links": {
+                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",  # noqa: E501
+                            "self": {
+                                "href": "http://testserver/v1/gebieden/buurten/03630000000078/?_format=json&volgnummer=2",  # noqa: E501
+                                "identificatie": "03630000000078",
+                                "title": "03630000000078.2",
+                                "volgnummer": 2,
+                            },
+                            "ligtInWijk": {
+                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
+                                "identificatie": "03630012052035",
+                                "title": "03630012052035.1",
+                                "volgnummer": 1,
+                            },
+                        },
+                        "id": "03630000000078.2",
+                        "code": None,
+                        "naam": None,
+                        "beginGeldigheid": None,
+                        "eindGeldigheid": None,
+                        "geometrie": None,
+                        "ligtInWijkId": "03630012052035",
+                    },
+                ],
+                "ligtInWijk": [
+                    # Embedded object in next section
+                    {
+                        "_links": {
+                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken",  # noqa: E501
+                            "self": {
+                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
+                                "identificatie": "03630012052035",
+                                "title": "03630012052035.1",
+                                "volgnummer": 1,
+                            },
+                            "buurt": {
+                                "count": 2,
+                                "href": "http://testserver/v1/gebieden/buurten/?_format=json&ligtInWijkId=03630012052035.1",  # noqa: E501
+                            },
+                            "ligtInStadsdeel": {
+                                "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?_format=json&volgnummer=1",  # noqa: E501
+                                "identificatie": "03630000000018",
+                                "title": "03630000000018.1",
+                                "volgnummer": 1,
+                            },
+                        },
+                        "beginGeldigheid": None,
+                        "code": "A01",
+                        "eindGeldigheid": None,
+                        "id": "03630012052035.1",
+                        "ligtInStadsdeelId": "03630000000018",
+                        "naam": "Burgwallen-Nieuwe Zijde",
+                        "_embedded": {
+                            # Nested embedding (1 level)
+                            "ligtInStadsdeel": {
+                                "_links": {
+                                    "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#stadsdelen",  # noqa: E501
+                                    "self": {
+                                        "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?_format=json&volgnummer=1",  # noqa: E501
+                                        "identificatie": "03630000000018",
+                                        "title": "03630000000018.1",
+                                        "volgnummer": 1,
+                                    },
+                                    "wijk": [
+                                        {
+                                            "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
+                                            "identificatie": "03630012052035",
+                                            "title": "03630012052035.1",
+                                            "volgnummer": 1,
+                                        }
+                                    ],
+                                },
+                                "beginGeldigheid": None,
+                                "code": "A",
+                                "documentdatum": None,
+                                "documentnummer": None,
+                                "eindGeldigheid": None,
+                                "geometrie": None,
+                                "id": "03630000000018.1",
+                                "naam": "Centrum",
+                                "registratiedatum": None,
+                            }
+                        },
+                    }
+                ],
+            },
+            "_links": {
+                "self": {
+                    "href": "http://testserver/v1/gebieden/buurten/?_format=json&_expand=true"
+                }
+            },
+            "page": {"number": 1, "size": 20},
+        }
 
     def test_detail_expand_true_for_nm_relation(
         self, api_client, buurten_data, ggwgebieden_data, filled_router

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -878,7 +878,7 @@ class TestEmbedTemporalTables:
                                     "volgnummer": 1,
                                 },
                                 "wijk": [
-                                    # Reverse relation
+                                    # Reverse relation (but already known by parent)
                                     {
                                         "href": (
                                             "http://testserver/v1/gebieden/wijken/03630012052035/"
@@ -899,6 +899,39 @@ class TestEmbedTemporalTables:
                             "id": "03630000000018.1",
                             "naam": "Centrum",
                             "registratiedatum": None,
+                            "_embedded": {
+                                "wijk": [
+                                    # Reverse relation (but already known by parent)
+                                    {
+                                        "_links": {
+                                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken",  # noqa: E501
+                                            "self": {
+                                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1",  # noqa: E501
+                                                "identificatie": "03630012052035",
+                                                "title": "03630012052035.1",
+                                                "volgnummer": 1,
+                                            },
+                                            "buurt": {
+                                                "count": 2,
+                                                "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",  # noqa: E501
+                                            },
+                                            "ligtInStadsdeel": {
+                                                # Recursive embed back to parent
+                                                "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?volgnummer=1",  # noqa: E501
+                                                "identificatie": "03630000000018",
+                                                "title": "03630000000018.1",
+                                                "volgnummer": 1,
+                                            },
+                                        },
+                                        "beginGeldigheid": None,
+                                        "code": "A01",
+                                        "eindGeldigheid": None,
+                                        "id": "03630012052035.1",
+                                        "ligtInStadsdeelId": "03630000000018",
+                                        "naam": "Burgwallen-Nieuwe " "Zijde",
+                                    }
+                                ]
+                            },
                         }
                     },
                 }
@@ -1272,6 +1305,7 @@ class TestEmbedTemporalTables:
                                         "volgnummer": 1,
                                     },
                                     "wijk": [
+                                        # Reverse relation
                                         {
                                             "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
                                             "identificatie": "03630012052035",
@@ -1289,6 +1323,39 @@ class TestEmbedTemporalTables:
                                 "id": "03630000000018.1",
                                 "naam": "Centrum",
                                 "registratiedatum": None,
+                                "_embedded": {
+                                    "wijk": [
+                                        # Reverse relation (but already known by parent)
+                                        {
+                                            "_links": {
+                                                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken",  # noqa: E501
+                                                "self": {
+                                                    "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
+                                                    "identificatie": "03630012052035",
+                                                    "title": "03630012052035.1",
+                                                    "volgnummer": 1,
+                                                },
+                                                "buurt": {
+                                                    "count": 2,
+                                                    "href": "http://testserver/v1/gebieden/buurten/?_format=json&ligtInWijkId=03630012052035.1",  # noqa: E501
+                                                },
+                                                "ligtInStadsdeel": {
+                                                    # Recursive embed back to parent
+                                                    "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?_format=json&volgnummer=1",  # noqa: E501
+                                                    "identificatie": "03630000000018",
+                                                    "title": "03630000000018.1",
+                                                    "volgnummer": 1,
+                                                },
+                                            },
+                                            "beginGeldigheid": None,
+                                            "code": "A01",
+                                            "eindGeldigheid": None,
+                                            "id": "03630012052035.1",
+                                            "ligtInStadsdeelId": "03630000000018",
+                                            "naam": "Burgwallen-Nieuwe " "Zijde",
+                                        }
+                                    ]
+                                },
                             }
                         },
                     }


### PR DESCRIPTION
The implementation is done by tracking the primary-keys in the `id_list` and query the foreign table on a foreign key. It allowed to keep the existing machinery in place, which relies on streaming data by collecting object identifier's during the rendering.

This also changes the way embedded fields can be registered. In the end it wasn't required to build this, but it's still a good feature to have. 