### PR TITLE
AB#21447 unauthorized dataset overview not visible

### DIFF
--- a/src/rest_framework_dso/openapi.py
+++ b/src/rest_framework_dso/openapi.py
@@ -199,6 +199,10 @@ class DSOSchemaGenerator(generators.SchemaGenerator):
         },
     }
 
+    def has_view_permissions(self, *args, **kwargs):
+        """Schemas are public, so this is always true."""
+        return True
+
     def get_schema(self, request=None, public=False):
         """Improved schema generation, include more OpenAPI fields"""
         schema = super().get_schema(request=request, public=public)

--- a/src/tests/test_dynamic_api/test_openapi.py
+++ b/src/tests/test_dynamic_api/test_openapi.py
@@ -64,6 +64,8 @@ def test_openapi_json(api_client, afval_dataset, fietspaaltjes_dataset, filled_r
     assert paths == [
         "/v1/afvalwegingen/adres_loopafstand/",
         "/v1/afvalwegingen/adres_loopafstand/{id}/",
+        "/v1/afvalwegingen/clusters/",
+        "/v1/afvalwegingen/clusters/{id}/",
         "/v1/afvalwegingen/containers/",
         "/v1/afvalwegingen/containers/{id}/",
     ]


### PR DESCRIPTION
On the dataset overview page in openapi a
"No operations defined in spec!" message was shown where the endpoints should be, when user
was unauthorized. But schemas are public so endpoints should be visible.
This sets schema generator as_view_permissions() to always return true.

# This Pull request contains changes to:

<Please fill information>

# In case changes new features added

- [ ] Customer friendly documentation added into `docs/`.
- [ ] Developer friendly documentation added into `DEVELOPMENT|README.md`

# In case breaking changes introduced into API

- [ ] There is customer notification plan: ....

# In case this PR reverts changes in repo

- [ ] Extra details describing reasoning: ...
