### PR TITLE
Implement reverse M2M embedded field and optimize querying.

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -443,7 +443,9 @@ class DynamicLinksSerializer(DynamicSerializer):
         return fields
 
     @cached_property
-    def parent_source_fields(self) -> list[Union[models.Field, ForeignObjectRel]]:
+    def parent_source_fields(
+        self,
+    ) -> list[Union[RelatedField, LooseRelationField, ForeignObjectRel]]:
         """Find the ORM relationship fields that lead to this serializer instance"""
         source_fields = []
         parent = self.parent

--- a/src/rest_framework_dso/embedding.py
+++ b/src/rest_framework_dso/embedding.py
@@ -96,10 +96,11 @@ class ExpandScope:
             field_tree = self._nested_fields_to_expand
         elif self.auto_expand_all:
             # Top-level, need to find all fields
+            # We auto-expand only for a limited set of levels, to avoid returning way too much
             field_tree = get_all_embedded_field_names(
                 parent_serializer.__class__,
                 allow_m2m=allow_m2m,
-                max_depth=MAX_EXPAND_ALL_DEPTH,  # auto-expand only for 2 levels
+                max_depth=MAX_EXPAND_ALL_DEPTH,
             )
         else:
             # Top-level, find all field that were requested.
@@ -229,9 +230,11 @@ def get_all_embedded_field_names(
     The output format is identical to group_dotted_names().
     """
     result = {}
+    embedded_fields: dict[str, AbstractEmbeddedField] = getattr(
+        serializer_class.Meta, "embedded_fields", {}
+    )
 
-    for field_name in getattr(serializer_class.Meta, "embedded_fields", ()):
-        field: AbstractEmbeddedField = get_embedded_field(serializer_class, field_name)
+    for field_name, field in embedded_fields.items():
         if field.is_array and not allow_m2m:
             continue
 

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -149,7 +149,9 @@ class AbstractEmbeddedField:
         return self.parent_serializer_class.Meta.model
 
     @cached_property
-    def source_field(self) -> Union[models.Field, models.ForeignObjectRel]:
+    def source_field(
+        self,
+    ) -> Union[RelatedField, LooseRelationField, models.ForeignObjectRel]:
         return self.parent_model._meta.get_field(self.source)
 
     @cached_property

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -123,7 +123,7 @@ class AbstractEmbeddedField:
         # Make sure the serializer is the true object, or other isinstance() checks will fail.
         self.serializer_class = unlazy_object(self.serializer_class)
         embedded_serializer = self.serializer_class(context=parent.context, **kwargs)
-        embedded_serializer.bind(field_name=self.field_name, parent=parent)
+        embedded_serializer.bind(field_name=self.source, parent=parent)
         return embedded_serializer
 
     @cached_property

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1059,7 +1059,10 @@ def ggpgebieden_data(ggpgebieden_model, buurten_data):
 def woningbouwplannen_data(woningbouwplan_model, buurten_data):
     woningbouwplan_model.objects.create(id="1")
     woningbouwplan_model.buurten.through.objects.create(
-        woningbouwplan_id="1", buurten_id="03630000000078"
+        id=1000,
+        woningbouwplan_id="1",
+        buurten_id=buurten_data.id,
+        buurten_identificatie=buurten_data.identificatie,
     )
     # woningbouwplan_model.objects.create(id="2", testbuurt="03630000000078")
     # woningbouwplan_model.bestaat_uit_buurten.through.objects.create(

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -389,7 +389,7 @@
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
         "additionalRelations": {
-          "wijk": {
+          "wijken": {
             "table": "wijken",
             "field": "ligtInStadsdeel",
             "format": "embedded"

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -306,11 +306,7 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_backwards_relation(
-        drf_request,
-        gebieden_schema,
-        gebieden_models,
-    ):
+    def test_backwards_relation(drf_request, gebieden_schema, gebieden_models):
         """Show backwards"""
         drf_request.dataset = gebieden_schema
         drf_request.table_temporal_slice = None
@@ -340,7 +336,7 @@ class TestDynamicSerializer:
                     "identificatie": "0363",
                 },
                 "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#stadsdelen",  # NoQA
-                "wijk": [
+                "wijken": [
                     {
                         "href": "http://testserver/v1/gebieden/wijken/03630000000001/?volgnummer=1",  # NoQA
                         "title": "03630000000001.1",

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -193,5 +193,5 @@ class TestViews:
             "volgnummer",
         }
         assert fetch_query_keys(
-            data["_embedded"]["stadsdelen"][1]["_links"]["wijk"][0]["href"]
+            data["_embedded"]["stadsdelen"][1]["_links"]["wijken"][0]["href"]
         ) == {"_format", "volgnummer"}

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -877,7 +877,7 @@ class TestEmbedTemporalTables:
                                     "title": "03630000000018.1",
                                     "volgnummer": 1,
                                 },
-                                "wijk": [
+                                "wijken": [
                                     # Reverse relation (but already known by parent)
                                     {
                                         "href": (
@@ -900,7 +900,7 @@ class TestEmbedTemporalTables:
                             "naam": "Centrum",
                             "registratiedatum": None,
                             "_embedded": {
-                                "wijk": [
+                                "wijken": [
                                     # Reverse relation (but already known by parent)
                                     {
                                         "_links": {
@@ -1076,7 +1076,7 @@ class TestEmbedTemporalTables:
                                                         "title": "03630000000018.1",
                                                         "volgnummer": 1,
                                                     },
-                                                    "wijk": [
+                                                    "wijken": [
                                                         {
                                                             "href": (
                                                                 "http://testserver/v1"
@@ -1304,7 +1304,7 @@ class TestEmbedTemporalTables:
                                         "title": "03630000000018.1",
                                         "volgnummer": 1,
                                     },
-                                    "wijk": [
+                                    "wijken": [
                                         # Reverse relation
                                         {
                                             "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
@@ -1324,7 +1324,7 @@ class TestEmbedTemporalTables:
                                 "naam": "Centrum",
                                 "registratiedatum": None,
                                 "_embedded": {
-                                    "wijk": [
+                                    "wijken": [
                                         # Reverse relation (but already known by parent)
                                         {
                                             "_links": {

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -894,6 +894,70 @@ class TestEmbedTemporalTables:
             },
         }
 
+    def test_detail_expand_true_reverse_fk_relation(self, api_client, wijken_data, filled_router):
+        """Prove that the reverse stadsdelen.wijken can be expanded"""
+
+        url = reverse("dynamic_api:gebieden-stadsdelen-detail", args=["03630000000018.1"])
+        response = api_client.get(url, data={"_expand": "true"})
+        data = read_response_json(response)
+        assert response.status_code == 200, data
+
+        assert data == {
+            "_links": {
+                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#stadsdelen",
+                "self": {
+                    "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?volgnummer=1",  # noqa: E501
+                    "identificatie": "03630000000018",
+                    "title": "03630000000018.1",
+                    "volgnummer": 1,
+                },
+                "wijken": [
+                    {
+                        "href": "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1",  # noqa: E501
+                        "identificatie": "03630012052035",
+                        "title": "03630012052035.1",
+                        "volgnummer": 1,
+                    }
+                ],
+            },
+            "id": "03630000000018.1",
+            "code": "A",
+            "naam": "Centrum",
+            "geometrie": None,
+            "documentdatum": None,
+            "documentnummer": None,
+            "registratiedatum": None,
+            "beginGeldigheid": None,
+            "eindGeldigheid": None,
+            "_embedded": {
+                "wijken": [
+                    # reverse relation
+                    {
+                        "_links": {
+                            "buurt": {
+                                "count": 0,
+                                "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",  # noqa: E501
+                            },
+                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken",  # noqa: E501
+                            "self": {
+                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1",  # noqa: E501
+                                "identificatie": "03630012052035",
+                                "title": "03630012052035.1",
+                                "volgnummer": 1,
+                            },
+                            # ligtInStadsdeel is removed (as it's a backward->forward match)
+                        },
+                        "id": "03630012052035.1",
+                        "code": "A01",
+                        "naam": "Burgwallen-Nieuwe Zijde",
+                        "beginGeldigheid": None,
+                        "eindGeldigheid": None,
+                        "ligtInStadsdeelId": "03630000000018",
+                    }
+                ]
+            },
+        }
+
     def test_nested_expand_list(
         self, api_client, panden_data, buurten_data, wijken_data, filled_router
     ):

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -877,18 +877,7 @@ class TestEmbedTemporalTables:
                                     "title": "03630000000018.1",
                                     "volgnummer": 1,
                                 },
-                                "wijken": [
-                                    # Reverse relation (but already known by parent)
-                                    {
-                                        "href": (
-                                            "http://testserver/v1/gebieden/wijken/03630012052035/"
-                                            "?volgnummer=1"
-                                        ),
-                                        "identificatie": "03630012052035",
-                                        "title": "03630012052035.1",
-                                        "volgnummer": 1,
-                                    }
-                                ],
+                                # wijken is excluded (repeated relation)
                             },
                             "beginGeldigheid": None,
                             "code": "A",
@@ -899,39 +888,6 @@ class TestEmbedTemporalTables:
                             "id": "03630000000018.1",
                             "naam": "Centrum",
                             "registratiedatum": None,
-                            "_embedded": {
-                                "wijken": [
-                                    # Reverse relation (but already known by parent)
-                                    {
-                                        "_links": {
-                                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken",  # noqa: E501
-                                            "self": {
-                                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?volgnummer=1",  # noqa: E501
-                                                "identificatie": "03630012052035",
-                                                "title": "03630012052035.1",
-                                                "volgnummer": 1,
-                                            },
-                                            "buurt": {
-                                                "count": 2,
-                                                "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",  # noqa: E501
-                                            },
-                                            "ligtInStadsdeel": {
-                                                # Recursive embed back to parent
-                                                "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?volgnummer=1",  # noqa: E501
-                                                "identificatie": "03630000000018",
-                                                "title": "03630000000018.1",
-                                                "volgnummer": 1,
-                                            },
-                                        },
-                                        "beginGeldigheid": None,
-                                        "code": "A01",
-                                        "eindGeldigheid": None,
-                                        "id": "03630012052035.1",
-                                        "ligtInStadsdeelId": "03630000000018",
-                                        "naam": "Burgwallen-Nieuwe " "Zijde",
-                                    }
-                                ]
-                            },
                         }
                     },
                 }
@@ -1076,18 +1032,7 @@ class TestEmbedTemporalTables:
                                                         "title": "03630000000018.1",
                                                         "volgnummer": 1,
                                                     },
-                                                    "wijken": [
-                                                        {
-                                                            "href": (
-                                                                "http://testserver/v1"
-                                                                "/gebieden/wijken/03630012052035/"
-                                                                "?volgnummer=1"
-                                                            ),
-                                                            "identificatie": "03630012052035",
-                                                            "title": "03630012052035.1",
-                                                            "volgnummer": 1,
-                                                        }
-                                                    ],
+                                                    # wijken is excluded (repeated relation)
                                                 },
                                                 "beginGeldigheid": None,
                                                 "code": "A",
@@ -1304,15 +1249,7 @@ class TestEmbedTemporalTables:
                                         "title": "03630000000018.1",
                                         "volgnummer": 1,
                                     },
-                                    "wijken": [
-                                        # Reverse relation
-                                        {
-                                            "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
-                                            "identificatie": "03630012052035",
-                                            "title": "03630012052035.1",
-                                            "volgnummer": 1,
-                                        }
-                                    ],
+                                    # wijken is excluded here (forward/reverse relation loop)
                                 },
                                 "beginGeldigheid": None,
                                 "code": "A",
@@ -1323,39 +1260,6 @@ class TestEmbedTemporalTables:
                                 "id": "03630000000018.1",
                                 "naam": "Centrum",
                                 "registratiedatum": None,
-                                "_embedded": {
-                                    "wijken": [
-                                        # Reverse relation (but already known by parent)
-                                        {
-                                            "_links": {
-                                                "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#wijken",  # noqa: E501
-                                                "self": {
-                                                    "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
-                                                    "identificatie": "03630012052035",
-                                                    "title": "03630012052035.1",
-                                                    "volgnummer": 1,
-                                                },
-                                                "buurt": {
-                                                    "count": 2,
-                                                    "href": "http://testserver/v1/gebieden/buurten/?_format=json&ligtInWijkId=03630012052035.1",  # noqa: E501
-                                                },
-                                                "ligtInStadsdeel": {
-                                                    # Recursive embed back to parent
-                                                    "href": "http://testserver/v1/gebieden/stadsdelen/03630000000018/?_format=json&volgnummer=1",  # noqa: E501
-                                                    "identificatie": "03630000000018",
-                                                    "title": "03630000000018.1",
-                                                    "volgnummer": 1,
-                                                },
-                                            },
-                                            "beginGeldigheid": None,
-                                            "code": "A01",
-                                            "eindGeldigheid": None,
-                                            "id": "03630012052035.1",
-                                            "ligtInStadsdeelId": "03630000000018",
-                                            "naam": "Burgwallen-Nieuwe " "Zijde",
-                                        }
-                                    ]
-                                },
                             }
                         },
                     }

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1617,9 +1617,10 @@ class TestEmbedTemporalTables:
         assert data["_embedded"]["buurten"][0]["id"] == "03630000000078.2"
         assert data["_embedded"]["woningbouwplan"][0]["_links"]["buurten"] == [
             {
-                "href": "http://testserver/v1/gebieden/buurten/03630000000078/",
-                "title": "03630000000078",
+                "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2",
+                "title": "03630000000078.2",
                 "identificatie": "03630000000078",
+                "volgnummer": 2,
             }
         ]
         #  Check that the embedded buurten contains the correct "identificatie",
@@ -1693,7 +1694,7 @@ class TestEmbedTemporalTables:
         # check that "buurten" still contains the correct list
         assert (
             data["_links"]["buurten"][0]["href"]
-            == "http://testserver/v1/gebieden/buurten/03630000000078/"
+            == "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2"
         )
 
 


### PR DESCRIPTION
Based on insights from reverse-embedded FK fields, the M2M implementation could be optimized. Before it queried the through table for *each* individual record to find related ID's. Now it collects a list of source ID's, and adjusts the query-filter to retrieve related objects in a single query. This also made the implementation of the reverse M2M very easy: the reverse ORM path has to be followed.

The old code also mixed up "identificatie" and "pk" fields, meaning that historical/temporal data likely wasn't returned at all. Tests also had this bug, and gave a false-negative after making changes. It turned out that the tested through table was incorrectly filled with non-existant IDs.

Additionally, repeated relations (forward/back/forward) became a problem. The serializers properly detect that the same relation object is traversed again and filter out those fields in both `_links` and the embedding.