### PR TITLE
Remove deprecated fields from pagination in docs

### DIFF
--- a/docs/source/generic/rest.rst
+++ b/docs/source/generic/rest.rst
@@ -89,8 +89,6 @@ De velden uit het ``page`` object worden ook als HTTP headers in de response ter
 
 * ``X-Pagination-Page``: Het huidige paginanummer.
 * ``X-Pagination-Limit``: de grootte van een pagina.
-* ``X-Pagination-Count``: Optioneel, het totaal aantal pagina's.
-* ``X-Total-Count``: Optioneel, het totaal aantal records over alle pagina's heen.
 
 
 Filtering


### PR DESCRIPTION
`totalElements` and `totalPages` have been removed in https://github.com/Amsterdam/dso-api/commit/14c1c796c8af00148e556654cb8a160627335335, but linger in the docs. This minor PR removes these fields from the example response in the pagination section of the docs.