### PR TITLE
Fix embedding warning for summary field

### DIFF
--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -41,6 +41,7 @@ from rest_framework_dso.embedding import (
     get_serializer_lookups,
 )
 from rest_framework_dso.fields import (
+    AbstractEmbeddedField,
     DSOGeometryField,
     DSORelatedLinkField,
     DSOSelfLinkField,
@@ -136,6 +137,19 @@ class ExpandMixin:
             serializer = serializer.parent
 
         return ".".join(reversed(path)) if len(path) > 1 else ""
+
+    @classmethod
+    def get_embedded_field(cls, field_name, prefix="") -> AbstractEmbeddedField:
+        """Retrieve an embedded field from the serializer class."""
+        embedded_fields = getattr(cls.Meta, "embedded_fields", {})
+        try:
+            return embedded_fields[field_name]
+        except KeyError:
+            msg = f"Eager loading is not supported for field '{prefix}{field_name}'"
+            if embedded_fields:
+                available = f", {prefix}".join(sorted(embedded_fields.keys()))
+                msg = f"{msg}, available options are: {prefix}{available}"
+            raise ParseError(msg) from None
 
     def __init_subclass__(cls, **kwargs):
         """Initialize the embedded field to have knowledge of this class instance.

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1337,6 +1337,26 @@ class TestEmbedTemporalTables:
             "page": {"number": 1, "size": 20},
         }
 
+    def test_expand_warning_reverse_summary(
+        self, api_client, buurten_data, wijken_data, filled_router
+    ):
+        """Prove that expanding on an additionalRelations with format=summary is not possible,
+        AND that it shows a custom error message to improve developer experience.
+        """
+        url = reverse("dynamic_api:gebieden-wijken-list")
+        response = api_client.get(url, {"_format": "json", "_expandScope": "buurt"})
+        data = read_response_json(response)
+        assert response.status_code == 400, data
+        assert data == {
+            "detail": (
+                "The field 'buurt' is not available for embedding"
+                " as it's a summary of a huge listing."
+            ),
+            "status": 400,
+            "title": "Malformed request.",
+            "type": "urn:apiexception:parse_error",
+        }
+
     def test_detail_expand_true_for_nm_relation(
         self, api_client, buurten_data, ggwgebieden_data, filled_router
     ):


### PR DESCRIPTION
This improves the developer experience. Quoting the ticket:

> Summary links kunnen niet expanded worden omdat het de verwachting is dat deze gebruikt worden voor resultaten die te groot zijn om ongepagineerd in te sluiten (e.g. alle panden in Amsterdam.)
> 
> Dit is echter verwarrend voor ontwikkelaars op het moment dus moet beter uitgelegd worden.