### PR TITLE
Cleanup ugly unused to_representation() logic

### DIFF
--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional, Union
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.exceptions import FieldDoesNotExist
@@ -345,6 +346,20 @@ class DSOGeometryField(GeometryField):
         else:
             # Return GeoJSON for json/html/api formats
             return super().to_representation(value)
+
+
+class DSOURLField(serializers.URLField):
+    """Ensure the URL is properly encoded"""
+
+    def to_representation(self, value):
+        try:
+            bits = urlsplit(value)
+        except ValueError:
+            return value
+        else:
+            return urlunsplit(
+                (bits.scheme, bits.netloc, quote(bits.path), quote(bits.query), bits.fragment)
+            )
 
 
 class GeoJSONIdentifierField(serializers.Field):

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -596,6 +596,8 @@ class DSOModelSerializer(DSOSerializer, serializers.HyperlinkedModelSerializer):
     _default_list_serializer_class = DSOModelListSerializer
     serializer_field_mapping = {
         **serializers.HyperlinkedModelSerializer.serializer_field_mapping,
+        # Override the URL field
+        models.URLField: fields.DSOURLField,
         # Override what django_rest_framework_gis installs in the app ready() signal:
         gis_models.GeometryField: fields.DSOGeometryField,
         gis_models.PointField: fields.DSOGeometryField,


### PR DESCRIPTION
While working on the temporal links, it turns out the hacks of `to_representation()` were no longer actively used.

The new `_temporal_link_serializer_factory()` logic already places proper fields for temporal relationships in the serializer. Hence the check for `not data[...]` always returned false.