### PR TITLE
Improve error message from routers._validate_model

### DIFF
--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -442,7 +442,7 @@ def _validate_model(model: type[DynamicModel]):
                     if "No installed app with label" not in str(e):
                         raise
                     # Report the dataset we're working with.
-                    raise LookupError(str(e) + f" (model = {model.get_dataset_schema()})") from e
+                    raise LookupError(f"{e} (model = {model.get_dataset_schema()})") from e
                 available = sorted(model._meta.model_name for model in dataset_app.get_models())
                 raise ImproperlyConfigured(
                     f"Field {field} does not point to an existing model:"

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Iterable
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db import connection, models
+from django.db import connection
 from django.urls import NoReverseMatch, URLPattern, path, reverse
 from rest_framework import routers
 from schematools.contrib.django.factories import remove_dynamic_models
@@ -426,7 +426,7 @@ class DynamicRouter(routers.DefaultRouter):
         remove_dynamic_models()
 
 
-def _validate_model(model: type[models.Model]):
+def _validate_model(model: type[DynamicModel]):
     """Validate whether the model's foreign keys point to actual resolved models.
     This is a check against incorrect definitions, which eases debugging in case it happens.
     Otherwise the error is likely something like "str has no attribute _meta" deep inside
@@ -436,7 +436,13 @@ def _validate_model(model: type[models.Model]):
         if field.remote_field is not None:
             if isinstance(field.remote_field.model, str):
                 app_label = field.remote_field.model.split(".")[0]
-                dataset_app = apps.get_app_config(app_label)
+                try:
+                    dataset_app = apps.get_app_config(app_label)
+                except LookupError as e:
+                    if "No installed app with label" not in str(e):
+                        raise
+                    # Report the dataset we're working with.
+                    raise LookupError(str(e) + f" (model = {model.get_dataset_schema()})") from e
                 available = sorted(model._meta.model_name for model in dataset_app.get_models())
                 raise ImproperlyConfigured(
                     f"Field {field} does not point to an existing model:"

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -800,9 +800,8 @@ def _through_serializer_factory(m2m_field: models.ManyToManyField) -> type[Throu
     target_model = m2m_field.related_model
     target_table_schema = m2m_field.related_model.table_schema()
     try:
-        target_fk_name = (
-            m2m_field.m2m_reverse_field_name()
-        )  # second foreign key of the through model
+        # second foreign key of the through model
+        target_fk_name = m2m_field.m2m_reverse_field_name()
     except AttributeError as e:
         # Adorn this exception with a clue about what we're trying to do,
         # as a debugging aid for the occasional "'ManyToManyField' object has no attribute

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -810,7 +810,7 @@ def _through_serializer_factory(m2m_field: models.ManyToManyField) -> type[Throu
 
         # In Python 3.10, AttributeError has a name attribute, but we support 3.9.
         if "_m2m_reverse_name_cache" in str(e):
-            raise AttributeError(f"{e} ({m2m_field})")
+            raise AttributeError(f"{e} ({m2m_field})") from e
         else:
             raise
 

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -799,7 +799,20 @@ def _through_serializer_factory(m2m_field: models.ManyToManyField) -> type[Throu
     through_model = m2m_field.remote_field.through
     target_model = m2m_field.related_model
     target_table_schema = m2m_field.related_model.table_schema()
-    target_fk_name = m2m_field.m2m_reverse_field_name()  # second foreign key of the through model
+    try:
+        target_fk_name = (
+            m2m_field.m2m_reverse_field_name()
+        )  # second foreign key of the through model
+    except AttributeError as e:
+        # Adorn this exception with a clue about what we're trying to do,
+        # as a debugging aid for the occasional "'ManyToManyField' object has no attribute
+        # '_m2m_reverse_name_cache'".
+
+        # In Python 3.10, AttributeError has a name attribute, but we support 3.9.
+        if "_m2m_reverse_name_cache" in str(e):
+            raise AttributeError(f"{e} ({m2m_field})")
+        else:
+            raise
 
     # Start serializer construction.
     # The "href" field reads the target of the M2M table.


### PR DESCRIPTION
Now prints which model was being validated when a an app cannot be
found:

    LookupError: No installed app with label 'bag'. (model = kadastraleobjecten)
