### PR TITLE
Fixed listings and embedding to only return the right temporal records

### DIFF
--- a/src/dso_api/dynamic_api/middleware.py
+++ b/src/dso_api/dynamic_api/middleware.py
@@ -30,18 +30,6 @@ class DatasetMiddleware(MiddlewareMixin):
         scopes = request.get_token_scopes
         request.user_scopes = UserScopes(request.GET, scopes, self.all_profiles)
 
-    def process_view(self, request, view_func, view_args, view_kwargs):
-        """
-        Make current dataset available across whole application.
-        """
-        if not hasattr(request, "dataset"):
-            try:
-                request.dataset = view_func.cls.model._dataset_schema
-            except AttributeError:
-                pass
-
-        return None
-
 
 class TemporalTableMiddleware(MiddlewareMixin):
     """

--- a/src/dso_api/dynamic_api/temporal.py
+++ b/src/dso_api/dynamic_api/temporal.py
@@ -1,0 +1,136 @@
+"""Extra functionality to handle temporality.
+
+This includes things like:
+- Only retrieve certain historical versions of an object.
+- Reduce querysets/get_object logic
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal, Optional, Union
+
+from django.db import models
+from django.db.models import Q
+from django.utils.timezone import make_aware, now
+from more_itertools import first
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from schematools.types import DatasetTableSchema, TemporalDimensionFields
+from schematools.utils import to_snake_case
+
+
+class TemporalTableQuery:
+    """The temporal query from the request, mapped to the current table."""
+
+    table_schema: DatasetTableSchema
+    is_versioned: bool
+
+    #: Which historical version is requested.
+    version_field: Optional[str] = None
+    version_value: Optional[str] = None
+
+    #: Which date is requested
+    slice_dimension: Optional[str] = None
+    slice_value: Optional[Union[Literal["*"], date, datetime]] = None
+    slice_range_fields: Optional[TemporalDimensionFields] = None
+
+    def __bool__(self):
+        return self.is_versioned
+
+    def __init__(self, request: Request, table_schema: DatasetTableSchema):
+        temporal = table_schema.temporal
+        self.table_schema = table_schema
+        self.is_versioned = temporal is not None
+
+        if temporal is not None:
+            # See if a filter is made on a specific version
+            self.version_field = temporal.identifier  # e.g. "volgnummer"
+            self.version_value = request.GET.get(self.version_field, None)
+
+            # See if a filter is done on a particular point in time (e.g. ?geldigOp=yyyy-mm-dd)
+            for dimension, fields in temporal.dimensions.items():
+                if date_value := request.GET.get(dimension):
+                    self.slice_dimension = dimension  # e.g. geldigOp
+                    self.slice_value = self._parse_date(dimension, date_value)
+                    self.slice_range_fields = fields
+
+    def _parse_date(self, dimension: str, value: str) -> Union[Literal["*"], date, datetime]:
+        """Parse and validate the received date"""
+        if value == "*":
+            return "*"
+
+        try:
+            if "T" in value or " " in value:
+                return make_aware(datetime.fromisoformat(value))
+            else:
+                return date.fromisoformat(value)
+        except ValueError:
+            raise ValidationError(
+                f"Invalid date or date-time format for '{dimension}' parameter!"
+            ) from None
+
+    def filter_object_version(self, queryset: models.QuerySet) -> models.QuerySet:
+        """Apply an object-level filter such as "?volgnummer=...".
+        This should only be called for the top-level object.
+        """
+        if queryset.model.table_schema() != self.table_schema:
+            raise ValueError("QuerySet model type does not match")
+
+        if not self.is_versioned:
+            return queryset
+        elif self.version_value is None:
+            return self.filter_queryset(queryset)
+        else:
+            return queryset.filter(**{self.version_field: self.version_value})
+
+    def filter_queryset(self, queryset: models.QuerySet) -> models.QuerySet:
+        if queryset.model.table_schema() != self.table_schema:
+            raise ValueError("QuerySet model type does not match")
+
+        if not self.is_versioned or self.slice_value == "*":
+            # allow this method to be called unconditionally on objects,
+            # and allow ?geldigOp=* to return all data
+            return queryset
+
+        # Either take a given ?geldigOp=yyyy-mm-dd OR ?geldigOp=NOW()
+        slice_value = self.slice_value or now()
+        range_fields = self.slice_range_fields or self.default_range_fields
+
+        if range_fields is not None:
+            # start <= value AND (end IS NULL OR value < end)
+            start, end = map(to_snake_case, range_fields)
+            return queryset.filter(
+                Q(**{f"{start}__lte": slice_value})
+                & (Q(**{f"{end}__isnull": True}) | Q(**{f"{end}__gt": slice_value}))
+            ).order_by(f"-{start}")
+        else:
+            # Last attempt to get only the current temporal record; order by sequence.
+            # does SELECT DISTINCT ON(identifier) ... ORDER BY identifier, sequence DESC
+            # Alternative would be something like `HAVING sequence = MAX(SELECT sequence FROM ..)`
+            identifier = self.table_schema.identifier[0]  # from ["identificatie", "volgnummer"]
+            sequence_name = self.table_schema.temporal.identifier
+            return queryset.distinct(identifier).order_by(identifier, f"-{sequence_name}")
+
+    @property
+    def default_range_fields(self) -> Optional[TemporalDimensionFields]:
+        """Tell what the default fields would be to filter temporal objects."""
+        dimensions = self.table_schema.temporal.dimensions
+        return dimensions.get("geldigOp") or first(dimensions.values(), None)
+
+    @property
+    def url_parameters(self) -> dict[str, str]:
+        if self.slice_dimension:
+            # e.g. ?geldigOp=...
+            url_value = "*" if self.slice_value == "*" else self.slice_value.isoformat()
+            return {self.slice_dimension: url_value}
+        else:
+            return {}
+
+
+def filter_temporal_slice(request, queryset: models.QuerySet) -> models.QuerySet:
+    """Make sure a queryset will only return the requested temporal date."""
+    table_schema = queryset.model.table_schema()
+    if not table_schema.temporal:
+        return queryset
+    else:
+        return TemporalTableQuery(request, table_schema).filter_queryset(queryset)

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext as _
 from more_itertools import first
 from rest_framework import viewsets
 from schematools.contrib.django.models import DynamicModel
+from schematools.utils import to_snake_case
 
 from dso_api.dynamic_api import filterset, locking, permissions, serializers
 from rest_framework_dso import fields
@@ -51,7 +52,9 @@ class TemporalRetrieveModelMixin:
         if self.request.versioned and self.model.is_temporal():
             if self.request.table_temporal_slice is not None:
                 temporal_value = self.request.table_temporal_slice["value"]
-                start_field, end_field = self.request.table_temporal_slice["fields"]
+                start_field, end_field = map(
+                    to_snake_case, self.request.table_temporal_slice["fields"]
+                )
                 queryset = queryset.filter(**{f"{start_field}__lte": temporal_value}).filter(
                     models.Q(**{f"{end_field}__gte": temporal_value})
                     | models.Q(**{f"{end_field}__isnull": True})

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -80,7 +80,6 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authorization_django.authorization_middleware",
     "dso_api.dynamic_api.middleware.DatasetMiddleware",
-    "dso_api.dynamic_api.middleware.TemporalTableMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 2.2.0
+amsterdam-schema-tools[django] == 2.3.1
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==2.2.0
+amsterdam-schema-tools[django]==2.3.1
     # via -r requirements.in
 asgiref==3.3.4
     # via django

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -12,7 +12,7 @@ from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import connection
 from django.utils.functional import SimpleLazyObject
-from django.utils.timezone import get_current_timezone
+from django.utils.timezone import get_current_timezone, make_aware
 from jwcrypto.jwt import JWT
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
@@ -24,6 +24,8 @@ from tests.test_rest_framework_dso.models import Actor, Category, Location, Movi
 from tests.utils import api_request_with_scopes, to_drf_request
 
 HERE = Path(__file__).parent
+DATE_2021_FEB = make_aware(datetime(2021, 2, 28, 10, 0))
+DATE_2021_JUNE = make_aware(datetime(2021, 6, 11, 10, 0))
 
 
 @pytest.fixture()
@@ -971,12 +973,15 @@ def buurten_data(buurten_model) -> DynamicModel:
         id="03630000000078.1",
         identificatie="03630000000078",
         volgnummer=1,
+        begin_geldigheid=DATE_2021_FEB,
+        eind_geldigheid=DATE_2021_JUNE,  # Historical record!
         ligt_in_wijk_id="03630012052035.1",
     )
     return buurten_model.objects.create(
         id="03630000000078.2",
         identificatie="03630000000078",
         volgnummer=2,
+        begin_geldigheid=DATE_2021_JUNE,
         ligt_in_wijk_id="03630012052035.1",
     )
 
@@ -987,6 +992,7 @@ def bouwblokken_data(bouwblokken_model, buurten_data) -> DynamicModel:
         id="03630012096483.1",
         identificatie="03630012096483",
         volgnummer=1,
+        begin_geldigheid=DATE_2021_FEB,
         ligt_in_buurt_id="03630000000078.2",  # example (not actual)
     )
 
@@ -995,8 +1001,9 @@ def bouwblokken_data(bouwblokken_model, buurten_data) -> DynamicModel:
 def panden_data(panden_model, dossiers_model, bouwblokken_data):
     panden_model.objects.create(
         id="0363100012061164.3",
-        volgnummer=3,
         identificatie="0363100012061164",
+        volgnummer=3,
+        begin_geldigheid=DATE_2021_FEB,
         naam="Voorbeeldpand",
         ligt_in_bouwblok_id="03630012096483.1",
         heeft_dossier_id="GV00000406",
@@ -1009,9 +1016,10 @@ def wijken_data(wijken_model, stadsdelen_data) -> DynamicModel:
     return wijken_model.objects.create(
         id="03630012052035.1",
         identificatie="03630012052035",
+        volgnummer=1,
+        begin_geldigheid=DATE_2021_FEB,
         naam="Burgwallen-Nieuwe Zijde",
         code="A01",
-        volgnummer=1,
         ligt_in_stadsdeel=stadsdelen_data,
     )
 
@@ -1022,6 +1030,7 @@ def stadsdelen_data(stadsdelen_model) -> DynamicModel:
         id="03630000000018.1",
         identificatie="03630000000018",
         volgnummer=1,
+        begin_geldigheid=DATE_2021_FEB,
         naam="Centrum",
         code="A",
     )
@@ -1030,7 +1039,10 @@ def stadsdelen_data(stadsdelen_model) -> DynamicModel:
 @pytest.fixture()
 def ggwgebieden_data(ggwgebieden_model, buurten_data):
     ggwgebieden_model.objects.create(
-        id="03630950000000.1", identificatie="03630950000000", volgnummer=1
+        id="03630950000000.1",
+        identificatie="03630950000000",
+        volgnummer=1,
+        begin_geldigheid=DATE_2021_FEB,
     )
     ggwgebieden_model.bestaat_uit_buurten.through.objects.create(
         id="22",
@@ -1044,7 +1056,10 @@ def ggwgebieden_data(ggwgebieden_model, buurten_data):
 @pytest.fixture()
 def ggpgebieden_data(ggpgebieden_model, buurten_data):
     ggpgebieden_model.objects.create(
-        id="03630950000000.1", identificatie="03630950000000", volgnummer=1
+        id="03630950000000.1",
+        identificatie="03630950000000",
+        volgnummer=1,
+        begin_geldigheid=DATE_2021_FEB,
     )
     ggpgebieden_model.bestaat_uit_buurten.through.objects.create(
         id="33",
@@ -1052,7 +1067,7 @@ def ggpgebieden_data(ggpgebieden_model, buurten_data):
         bestaat_uit_buurten_id="03630000000078.1",
         bestaat_uit_buurten_identificatie="03630000000078",
         bestaat_uit_buurten_volgnummer=1,
-        begin_geldigheid="2020-01-04",
+        begin_geldigheid="2021-03-04",
         eind_geldigheid=None,
     )
 

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -59,7 +59,6 @@ class TestDynamicSerializer:
         assert afval_cluster_model is apps.get_model("afvalwegingen.clusters")
         assert afval_container_model is apps.get_model("afvalwegingen.containers")
 
-        drf_request.dataset = afval_schema
         afval_container = afval_container_model.objects.create(
             id=2,
             cluster_id=afval_cluster.pk,
@@ -116,13 +115,12 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_expand(afval_schema, afval_container_model, afval_cluster):
+    def test_expand(afval_container_model, afval_cluster):
         """Prove expanding works.
 
         The _embedded section is generated, using the cluster serializer.
         """
         drf_request = to_drf_request(api_request_with_scopes(["BAG/R"]))
-        drf_request.dataset = afval_schema
         ContainerSerializer = serializer_factory(afval_container_model)
         afval_container = afval_container_model.objects.create(id=2, cluster=afval_cluster)
 
@@ -168,13 +166,12 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_expand_none(afval_schema, afval_container_model):
+    def test_expand_none(afval_container_model):
         """Prove that expanding None values doesn't crash.
 
         The _embedded part has a None value instead.
         """
         drf_request = to_drf_request(api_request_with_scopes(["BAG/R"]))
-        drf_request.dataset = afval_schema
         ContainerSerializer = serializer_factory(afval_container_model)
         container_without_cluster = afval_container_model.objects.create(
             id=3,
@@ -205,14 +202,13 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_expand_broken_relation(afval_schema, afval_container_model):
+    def test_expand_broken_relation(afval_container_model):
         """Prove that expanding non-existing FK values values doesn't crash.
            Cluster will not be expanded to a url, because the pk_only_optimization
            has been switched off for hyperlinked related fields.
         The _embedded part has a None value instead.
         """
         drf_request = to_drf_request(api_request_with_scopes(["BAG/R"]))
-        drf_request.dataset = afval_schema
         ContainerSerializer = serializer_factory(afval_container_model)
         container_invalid_cluster = afval_container_model.objects.create(
             id=4,
@@ -266,7 +262,6 @@ class TestDynamicSerializer:
         # Update dataset in instance cache
         afval_container_model._dataset = afval_dataset
         afval_cluster_model._dataset = afval_dataset
-        drf_request.dataset = afval_dataset.schema
         ContainerSerializer = serializer_factory(afval_container_model, 0)
         afval_container = afval_container_model.objects.create(id=2, cluster=afval_cluster)
 
@@ -312,9 +307,8 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_backwards_relation(drf_request, gebieden_schema, gebieden_models):
+    def test_backwards_relation(drf_request, gebieden_models):
         """Show backwards"""
-        drf_request.dataset = gebieden_schema
         drf_request.table_temporal_slice = None
         stadsdelen_model = gebieden_models["stadsdelen"]
         wijken_model = gebieden_models["wijken"]
@@ -365,7 +359,6 @@ class TestDynamicSerializer:
     @staticmethod
     def test_multiple_backwards_relations(
         drf_request,
-        vestiging_schema,
         vestiging_adres_model,
         vestiging_vestiging_model,
         vestiging1,
@@ -373,8 +366,6 @@ class TestDynamicSerializer:
         post_adres1,
     ):
         """Show backwards"""
-        drf_request.dataset = vestiging_schema
-
         VestigingSerializer = serializer_factory(vestiging_vestiging_model)
 
         vestiging_serializer = VestigingSerializer(
@@ -464,15 +455,11 @@ class TestDynamicSerializer:
 
     @staticmethod
     def test_serializer_has_nested_table(
-        drf_request,
-        parkeervakken_schema,
-        parkeervakken_parkeervak_model,
-        parkeervakken_regime_model,
+        drf_request, parkeervakken_parkeervak_model, parkeervakken_regime_model
     ):
         """Prove that the serializer factory properly generates nested tables.
         Serialiser should contain reverse relations.
         """
-        drf_request.dataset = parkeervakken_schema
         parkeervak = parkeervakken_parkeervak_model.objects.create(
             id="121138489047",
             type="File",
@@ -541,17 +528,10 @@ class TestDynamicSerializer:
         }
 
     @staticmethod
-    def test_display_title_present(
-        drf_request,
-        fietspaaltjes_schema,
-        fietspaaltjes_model,
-        fietspaaltjes_data,
-    ):
+    def test_display_title_present(drf_request, fietspaaltjes_model, fietspaaltjes_data):
         """ Prove that title element shows display value if display field is specified """
 
         FietsplaatjesSerializer = serializer_factory(fietspaaltjes_model)
-
-        drf_request.dataset = fietspaaltjes_schema
 
         fietsplaatjes_serializer = FietsplaatjesSerializer(
             fietspaaltjes_data, context={"request": drf_request}
@@ -561,17 +541,11 @@ class TestDynamicSerializer:
 
     @staticmethod
     def test_no_display_title_present(
-        drf_request,
-        fietspaaltjes_schema_no_display,
-        fietspaaltjes_model_no_display,
-        fietspaaltjes_data_no_display,
+        drf_request, fietspaaltjes_model_no_display, fietspaaltjes_data_no_display
     ):
         """ Prove that title element is omitted if display field is not specified """
 
         FietsplaatjesSerializer = serializer_factory(fietspaaltjes_model_no_display)
-
-        drf_request.dataset = fietspaaltjes_schema_no_display
-
         fietsplaatjes_serializer = FietsplaatjesSerializer(
             fietspaaltjes_data_no_display, context={"request": drf_request}
         )
@@ -585,34 +559,22 @@ class TestDynamicSerializer:
         assert explosieven_model._meta.get_field("pdf").max_length == 200
 
     @staticmethod
-    def test_uri_field_can_validate(
-        drf_request, explosieven_schema, explosieven_model, explosieven_data
-    ):
+    def test_uri_field_can_validate(drf_request, explosieven_model, explosieven_data):
         """ Prove that a URLfield can be validated by the URIValidator """
 
         ExplosievenSerializer = serializer_factory(explosieven_model)
-
-        drf_request.dataset = explosieven_schema
-
-        validate_uri = URLValidator()
-
         explosieven_serializer = ExplosievenSerializer(
             explosieven_data, context={"request": drf_request}
         )
 
         # Validation passes if outcome is None
-        assert validate_uri(explosieven_serializer.data["pdf"]) is None
+        assert URLValidator()(explosieven_serializer.data["pdf"]) is None
 
     @staticmethod
-    def test_uri_field_is_URL_encoded(
-        drf_request, explosieven_schema, explosieven_model, explosieven_data
-    ):
+    def test_uri_field_is_URL_encoded(drf_request, explosieven_model, explosieven_data):
         """ Prove that a URLfield content is URL encoded i.e. space to %20 """
 
         ExplosievenSerializer = serializer_factory(explosieven_model)
-
-        drf_request.dataset = explosieven_schema
-
         explosieven_serializer = ExplosievenSerializer(
             explosieven_data, context={"request": drf_request}
         )
@@ -624,22 +586,17 @@ class TestDynamicSerializer:
 
     @staticmethod
     def test_email_field_can_validate_with_validator(
-        drf_request, explosieven_schema, explosieven_model, explosieven_data
+        drf_request, explosieven_model, explosieven_data
     ):
         """ Prove that a EmailField can be validated by the EmailValidator """
 
         ExplosievenSerializer = serializer_factory(explosieven_model)
-
-        drf_request.dataset = explosieven_schema
-
-        validate_email = EmailValidator()
-
         explosieven_serializer = ExplosievenSerializer(
             explosieven_data, context={"request": drf_request}
         )
 
         # Validation passes if outcome is None
-        assert validate_email(explosieven_serializer.data["emailadres"]) is None
+        assert EmailValidator()(explosieven_serializer.data["emailadres"]) is None
 
     @staticmethod
     def test_indirect_self_reference(ligplaatsen_model, filled_router):
@@ -655,7 +612,6 @@ class TestDynamicSerializer:
     ):
         """ Prove that only first letter is seen in Profile allows only it."""
         # does not have scope for Dataset or Table
-        drf_request.dataset = fietspaaltjes_schema
         drf_request.user_scopes = UserScopes(
             {},
             request_scopes=[],
@@ -693,7 +649,6 @@ class TestDynamicSerializer:
         drf_request, fietspaaltjes_schema, fietspaaltjes_model, fietspaaltjes_data
     ):
         """ Prove that only first letter is seen in Profile allows only it in listing. """
-        drf_request.dataset = fietspaaltjes_schema
         drf_request.user_scopes = UserScopes(
             {},
             request_scopes=[],
@@ -729,9 +684,7 @@ class TestDynamicSerializer:
         assert fietspaaltjes[0]["area"] == "A", fietspaaltjes_serializer.data
 
     @staticmethod
-    def test_download_url_field(
-        drf_request, download_url_dataset, download_url_schema, filled_router
-    ):
+    def test_download_url_field(drf_request, download_url_dataset, filled_router):
         """ Prove that download url will contain correct identifier. """
 
         dossier_model = filled_router.all_models["download"]["dossiers"]
@@ -743,9 +696,6 @@ class TestDynamicSerializer:
             ),
         )
         DossiersSerializer = serializer_factory(dossier_model)
-
-        drf_request.dataset = download_url_schema
-
         dossiers_serializer = DossiersSerializer(
             dossier_model.objects.all(),
             context={"request": drf_request},
@@ -762,9 +712,7 @@ class TestDynamicSerializer:
         assert "sp=r" in url
 
     @staticmethod
-    def test_download_url_field_empty_field(
-        drf_request, download_url_dataset, download_url_schema, filled_router
-    ):
+    def test_download_url_field_empty_field(drf_request, download_url_dataset, filled_router):
         """ Prove that empty download url not crashing api. """
 
         dossier_model = filled_router.all_models["download"]["dossiers"]
@@ -773,9 +721,6 @@ class TestDynamicSerializer:
             url="",
         )
         DossiersSerializer = serializer_factory(dossier_model)
-
-        drf_request.dataset = download_url_schema
-
         dossiers_serializer = DossiersSerializer(
             dossier_model.objects.all(),
             context={"request": drf_request},
@@ -786,11 +731,7 @@ class TestDynamicSerializer:
         assert dossiers[0]["url"] == ""
 
     @staticmethod
-    def test_loose_relation_serialization(
-        drf_request,
-        meldingen_schema,
-        statistieken_model,
-    ):
+    def test_loose_relation_serialization(drf_request, statistieken_model):
         """Prove that the serializer factory generates the right link
         for a loose relation field
         """
@@ -799,7 +740,6 @@ class TestDynamicSerializer:
             def __init__(self, model):
                 self.model = model
 
-        drf_request.dataset = meldingen_schema
         statistiek = statistieken_model.objects.create(
             id=1,
             buurt="03630000000078",

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -6,6 +6,7 @@ from django.core.validators import EmailValidator, URLValidator
 from schematools.permissions import UserScopes
 from schematools.types import ProfileSchema
 
+from dso_api.dynamic_api.fields import LooseRelationUrlField
 from dso_api.dynamic_api.serializers import clear_serializer_factory_cache, serializer_factory
 from rest_framework_dso.fields import EmbeddedField
 from rest_framework_dso.views import DSOViewMixin
@@ -749,6 +750,9 @@ class TestDynamicSerializer:
         statistieken_serializer = StatistiekenSerializer(
             statistiek,
             context={"request": drf_request, "view": DummyView(statistieken_model)},
+        )
+        assert isinstance(
+            statistieken_serializer.fields["_links"].fields["buurt"], LooseRelationUrlField
         )
 
         assert (

--- a/src/tests/test_dynamic_api/test_temporal_actions.py
+++ b/src/tests/test_dynamic_api/test_temporal_actions.py
@@ -136,28 +136,30 @@ class TestViews:
     def test_details_default_returns_latest_record(self, api_client, stadsdelen):
         """Prove that object can be requested by identification
         and response will contain only latest object."""
-        url = reverse("dynamic_api:gebieden-stadsdelen-list")
-        response = api_client.get(f"{url}{stadsdelen[0].identificatie}/")
+        identificatie = stadsdelen[0].identificatie
+        url = reverse("dynamic_api:gebieden-stadsdelen-detail", args=(identificatie,))
+        response = api_client.get(url)
         data = read_response_json(response)
 
         assert response.status_code == 200, data
         assert data["_links"]["self"]["volgnummer"] == 2, data
+        assert data["id"] == stadsdelen[1].id, data
 
     def test_details_can_be_requested_with_valid_date(self, api_client, stadsdelen):
-        """Prove that object can be requested by identification and date,
-        resulting in correct for that date object."""
-        url = reverse("dynamic_api:gebieden-stadsdelen-list")
-        response = api_client.get(f"{url}{stadsdelen[0].identificatie}/?geldigOp=2014-12-12")
+        """Prove that object can be requested by identification and date."""
+        identificatie = stadsdelen[0].identificatie
+        url = reverse("dynamic_api:gebieden-stadsdelen-detail", args=(identificatie,))
+        response = api_client.get(url, {"geldigOp": "2014-12-12"})
         data = read_response_json(response)
 
         assert response.status_code == 200, data
         assert data["_links"]["self"]["volgnummer"] == 1, data
 
     def test_details_can_be_requested_with_version(self, api_client, stadsdelen):
-        """Prove that object can be requested by identification and version,
-        resulting in correct for that version object."""
-        url = reverse("dynamic_api:gebieden-stadsdelen-list")
-        response = api_client.get(f"{url}{stadsdelen[0].identificatie}/?volgnummer=1")
+        """Prove that object can be requested by identification and version."""
+        identificatie = stadsdelen[0].identificatie
+        url = reverse("dynamic_api:gebieden-stadsdelen-detail", args=(identificatie,))
+        response = api_client.get(url, {"volgnummer": "1"})
         data = read_response_json(response)
 
         assert response.status_code == 200, data
@@ -168,8 +170,8 @@ class TestViews:
     ):
         """Prove that in case of temporal request links to objects will have request date.
         Allowing follow up date filtering further."""
-        url = reverse("dynamic_api:gebieden-ggwgebieden-list")
-        response = api_client.get(f"{url}{gebied.id}/?geldigOp=2014-05-01")
+        url = reverse("dynamic_api:gebieden-ggwgebieden-detail", args=(gebied.id,))
+        response = api_client.get(url, {"geldigOp": "2014-05-01"})
         data = read_response_json(response)
         assert data["_links"]["bestaatUitBuurten"] == [
             {

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -795,7 +795,7 @@ class TestEmbedTemporalTables:
         assert response.status_code == 200, data
         assert data["_embedded"]["ligtInWijk"]["id"] == "03630012052035.1"
         assert data["_embedded"]["ligtInWijk"]["_links"]["buurt"] == {
-            "count": 2,  # counts historical records too.
+            "count": 1,
             "href": "http://testserver/v1/gebieden/buurten/?ligtInWijkId=03630012052035.1",
         }
 
@@ -838,7 +838,7 @@ class TestEmbedTemporalTables:
                         },
                         "buurt": {
                             # See that the link is properly added
-                            "count": 2,  # counts historical records too.
+                            "count": 1,
                             "href": (
                                 "http://testserver/v1/gebieden/buurten/"
                                 "?ligtInWijkId=03630012052035.1"
@@ -1125,7 +1125,7 @@ class TestEmbedTemporalTables:
                                                 "volgnummer": 1,
                                             },
                                             "buurt": {
-                                                "count": 2,
+                                                "count": 1,
                                                 "href": (
                                                     "http://testserver/v1/gebieden/buurten/"
                                                     "?ligtInWijkId=03630012052035.1"
@@ -1215,40 +1215,17 @@ class TestEmbedTemporalTables:
         assert response.status_code == 200, data
         assert data["_embedded"]["ligtInWijk"][0]["id"] == "03630012052035.1"
         assert data["_embedded"]["ligtInWijk"][0]["_links"]["buurt"] == {
-            "count": 2,  # counts historical records too.
+            "count": 1,
             "href": (
                 "http://testserver/v1/gebieden/buurten/"
                 "?_format=json&ligtInWijkId=03630012052035.1"
             ),
         }
+        assert len(data["_embedded"]["buurten"]) == 1  # no historical records
         assert data == {
             "_embedded": {
                 "buurten": [
                     # Main response
-                    {
-                        "_links": {
-                            "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",  # noqa: E501
-                            "self": {
-                                "href": "http://testserver/v1/gebieden/buurten/03630000000078/?_format=json&volgnummer=1",  # noqa: E501
-                                "identificatie": "03630000000078",
-                                "title": "03630000000078.1",
-                                "volgnummer": 1,
-                            },
-                            "ligtInWijk": {
-                                "href": "http://testserver/v1/gebieden/wijken/03630012052035/?_format=json&volgnummer=1",  # noqa: E501
-                                "identificatie": "03630012052035",
-                                "title": "03630012052035.1",
-                                "volgnummer": 1,
-                            },
-                        },
-                        "id": "03630000000078.1",
-                        "naam": None,
-                        "code": None,
-                        "beginGeldigheid": "2021-02-28",
-                        "eindGeldigheid": "2021-06-11",
-                        "geometrie": None,
-                        "ligtInWijkId": "03630012052035",
-                    },
                     {
                         "_links": {
                             "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",  # noqa: E501
@@ -1286,7 +1263,7 @@ class TestEmbedTemporalTables:
                                 "volgnummer": 1,
                             },
                             "buurt": {
-                                "count": 2,
+                                "count": 1,
                                 "href": "http://testserver/v1/gebieden/buurten/?_format=json&ligtInWijkId=03630012052035.1",  # noqa: E501
                             },
                             "ligtInStadsdeel": {

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -789,7 +789,7 @@ class TestEmbedTemporalTables:
     ):
         """Prove that ligtInWijk shows up when expanded"""
 
-        url = reverse("dynamic_api:gebieden-buurten-detail", args=["03630000000078.1"])
+        url = reverse("dynamic_api:gebieden-buurten-detail", args=["03630000000078.2"])
         response = api_client.get(url, data={"_expand": "true"})
         data = read_response_json(response)
         assert response.status_code == 200, data
@@ -809,17 +809,17 @@ class TestEmbedTemporalTables:
                 },
                 "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
                 "self": {
-                    "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=1",
+                    "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2",
                     "identificatie": "03630000000078",
-                    "title": "03630000000078.1",
-                    "volgnummer": 1,
+                    "title": "03630000000078.2",
+                    "volgnummer": 2,
                 },
             },
-            "beginGeldigheid": "2021-02-28",
+            "beginGeldigheid": "2021-06-11",
             "code": None,
-            "eindGeldigheid": "2021-06-11",
+            "eindGeldigheid": None,
             "geometrie": None,
-            "id": "03630000000078.1",
+            "id": "03630000000078.2",
             "ligtInWijkId": "03630012052035",
             "naam": None,
             "_embedded": {
@@ -1172,7 +1172,7 @@ class TestEmbedTemporalTables:
         """Prove that temporal identifier fields have been removed from the body
         and only appear in the respective HAL envelopes"""
 
-        url = reverse("dynamic_api:gebieden-buurten-detail", args=["03630000000078.1"])
+        url = reverse("dynamic_api:gebieden-buurten-detail", args=["03630000000078.2"])
         response = api_client.get(url)
         data = read_response_json(response)
         assert response.status_code == 200, data
@@ -1186,17 +1186,17 @@ class TestEmbedTemporalTables:
                 },
                 "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
                 "self": {
-                    "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=1",
+                    "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2",
                     "identificatie": "03630000000078",
-                    "title": "03630000000078.1",
-                    "volgnummer": 1,
+                    "title": "03630000000078.2",
+                    "volgnummer": 2,
                 },
             },
-            "beginGeldigheid": "2021-02-28",
+            "beginGeldigheid": "2021-06-11",
             "code": None,
-            "eindGeldigheid": "2021-06-11",
+            "eindGeldigheid": None,
             "geometrie": None,
-            "id": "03630000000078.1",
+            "id": "03630000000078.2",
             "ligtInWijkId": "03630012052035",
             "naam": None,
         }

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -815,9 +815,9 @@ class TestEmbedTemporalTables:
                     "volgnummer": 1,
                 },
             },
-            "beginGeldigheid": None,
+            "beginGeldigheid": "2021-02-28",
             "code": None,
-            "eindGeldigheid": None,
+            "eindGeldigheid": "2021-06-11",
             "geometrie": None,
             "id": "03630000000078.1",
             "ligtInWijkId": "03630012052035",
@@ -857,7 +857,7 @@ class TestEmbedTemporalTables:
                     "id": "03630012052035.1",
                     "code": "A01",
                     "naam": "Burgwallen-Nieuwe Zijde",
-                    "beginGeldigheid": None,
+                    "beginGeldigheid": "2021-02-28",
                     "eindGeldigheid": None,
                     "ligtInStadsdeelId": "03630000000018",
                     "_embedded": {
@@ -879,7 +879,7 @@ class TestEmbedTemporalTables:
                                 },
                                 # wijken is excluded (repeated relation)
                             },
-                            "beginGeldigheid": None,
+                            "beginGeldigheid": "2021-02-28",
                             "code": "A",
                             "documentdatum": None,
                             "documentnummer": None,
@@ -927,7 +927,7 @@ class TestEmbedTemporalTables:
             "documentdatum": None,
             "documentnummer": None,
             "registratiedatum": None,
-            "beginGeldigheid": None,
+            "beginGeldigheid": "2021-02-28",
             "eindGeldigheid": None,
             "_embedded": {
                 "wijken": [
@@ -950,7 +950,7 @@ class TestEmbedTemporalTables:
                         "id": "03630012052035.1",
                         "code": "A01",
                         "naam": "Burgwallen-Nieuwe Zijde",
-                        "beginGeldigheid": None,
+                        "beginGeldigheid": "2021-02-28",
                         "eindGeldigheid": None,
                         "ligtInStadsdeelId": "03630000000018",
                     }
@@ -1006,7 +1006,7 @@ class TestEmbedTemporalTables:
                         "id": "0363100012061164.3",
                         "ligtInBouwblokId": "03630012096483",
                         "naam": "Voorbeeldpand",
-                        "beginGeldigheid": None,
+                        "beginGeldigheid": "2021-02-28T10:00:00",
                         "eindGeldigheid": None,
                         "heeftDossierId": "GV00000406",
                     }
@@ -1037,7 +1037,7 @@ class TestEmbedTemporalTables:
                                 "volgnummer": 2,
                             },
                         },
-                        "beginGeldigheid": None,
+                        "beginGeldigheid": "2021-02-28",
                         "code": None,
                         "eindGeldigheid": None,
                         "geometrie": None,
@@ -1074,7 +1074,7 @@ class TestEmbedTemporalTables:
                                 "naam": None,
                                 "code": None,
                                 "geometrie": None,
-                                "beginGeldigheid": None,
+                                "beginGeldigheid": "2021-06-11",
                                 "eindGeldigheid": None,
                                 "ligtInWijkId": "03630012052035",
                                 "_embedded": {
@@ -1098,7 +1098,7 @@ class TestEmbedTemporalTables:
                                                     },
                                                     # wijken is excluded (repeated relation)
                                                 },
-                                                "beginGeldigheid": None,
+                                                "beginGeldigheid": "2021-02-28",
                                                 "code": "A",
                                                 "documentdatum": None,
                                                 "documentnummer": None,
@@ -1142,7 +1142,7 @@ class TestEmbedTemporalTables:
                                                 "volgnummer": 1,
                                             },
                                         },
-                                        "beginGeldigheid": None,
+                                        "beginGeldigheid": "2021-02-28",
                                         "code": "A01",
                                         "eindGeldigheid": None,
                                         "id": "03630012052035.1",
@@ -1192,9 +1192,9 @@ class TestEmbedTemporalTables:
                     "volgnummer": 1,
                 },
             },
-            "beginGeldigheid": None,
+            "beginGeldigheid": "2021-02-28",
             "code": None,
-            "eindGeldigheid": None,
+            "eindGeldigheid": "2021-06-11",
             "geometrie": None,
             "id": "03630000000078.1",
             "ligtInWijkId": "03630012052035",
@@ -1244,8 +1244,8 @@ class TestEmbedTemporalTables:
                         "id": "03630000000078.1",
                         "naam": None,
                         "code": None,
-                        "beginGeldigheid": None,
-                        "eindGeldigheid": None,
+                        "beginGeldigheid": "2021-02-28",
+                        "eindGeldigheid": "2021-06-11",
                         "geometrie": None,
                         "ligtInWijkId": "03630012052035",
                     },
@@ -1268,7 +1268,7 @@ class TestEmbedTemporalTables:
                         "id": "03630000000078.2",
                         "code": None,
                         "naam": None,
-                        "beginGeldigheid": None,
+                        "beginGeldigheid": "2021-06-11",
                         "eindGeldigheid": None,
                         "geometrie": None,
                         "ligtInWijkId": "03630012052035",
@@ -1296,7 +1296,7 @@ class TestEmbedTemporalTables:
                                 "volgnummer": 1,
                             },
                         },
-                        "beginGeldigheid": None,
+                        "beginGeldigheid": "2021-02-28",
                         "code": "A01",
                         "eindGeldigheid": None,
                         "id": "03630012052035.1",
@@ -1315,7 +1315,7 @@ class TestEmbedTemporalTables:
                                     },
                                     # wijken is excluded here (forward/reverse relation loop)
                                 },
-                                "beginGeldigheid": None,
+                                "beginGeldigheid": "2021-02-28",
                                 "code": "A",
                                 "documentdatum": None,
                                 "documentnummer": None,
@@ -1381,9 +1381,9 @@ class TestEmbedTemporalTables:
                         "volgnummer": 1,
                     },
                 },
-                "beginGeldigheid": None,
+                "beginGeldigheid": "2021-02-28",
                 "code": None,
-                "eindGeldigheid": None,
+                "eindGeldigheid": "2021-06-11",
                 "geometrie": None,
                 "id": "03630000000078.1",
                 "ligtInWijkId": "03630012052035",
@@ -1418,8 +1418,8 @@ class TestEmbedTemporalTables:
             "geometrie": None,
             "naam": None,
             "code": None,
-            "eindGeldigheid": None,
-            "beginGeldigheid": None,
+            "eindGeldigheid": "2021-06-11",
+            "beginGeldigheid": "2021-02-28",
             "id": "03630000000078.1",
             "ligtInWijkId": "03630012052035",
             "_embedded": {
@@ -1447,7 +1447,7 @@ class TestEmbedTemporalTables:
             "geometrie": None,
             "id": "03630950000000.1",
             "eindGeldigheid": None,
-            "beginGeldigheid": None,
+            "beginGeldigheid": "2021-02-28",
             "naam": None,
             "registratiedatum": None,
         }
@@ -1478,15 +1478,15 @@ class TestEmbedTemporalTables:
                         "title": "03630000000078.1",
                         "volgnummer": 1,
                         "identificatie": "03630000000078",
-                        "beginGeldigheid": "2020-01-04",
-                        "eindGeldigheid": None,
+                        "beginGeldigheid": "2021-03-04",  # from relation!
+                        "eindGeldigheid": None,  # from relation!
                     },
                 ],
             },
             "geometrie": None,
             "id": "03630950000000.1",
             "eindGeldigheid": None,
-            "beginGeldigheid": None,
+            "beginGeldigheid": "2021-02-28",
             "naam": None,
             "registratiedatum": None,
         }
@@ -1564,7 +1564,7 @@ class TestEmbedTemporalTables:
                     "naam": None,
                     "geometrie": None,
                     "eindGeldigheid": None,
-                    "beginGeldigheid": None,
+                    "beginGeldigheid": "2021-06-11",
                     "id": "03630000000078.2",
                     "ligtInWijkId": "03630012052035.1",
                     "_embedded": {
@@ -2000,7 +2000,7 @@ class TestExportFormats:
         # fields don't include bestaatUitBuurten
         assert data == (
             "Registratiedatum,Naam,Begingeldigheid,Eindgeldigheid,Geometrie,Id\r\n"
-            ",,,,,03630950000000.1\r\n"
+            ",,2021-02-28,,,03630950000000.1\r\n"
         )
 
     DETAIL_FORMATS = {

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1543,7 +1543,7 @@ class TestEmbedTemporalTables:
                     "eindGeldigheid": None,
                     "beginGeldigheid": "2021-06-11",
                     "id": "03630000000078.2",
-                    "ligtInWijkId": "03630012052035.1",
+                    "ligtInWijkId": "03630012052035",
                     "_embedded": {
                         "ligtInWijk": None,
                     },


### PR DESCRIPTION
Each commit holds a clear step for this PR.

* Removed lots of old code that was no longer used.
* Listings now return only active versions.
* Embeds also return active versions only.
* Test code lacked `beginGeldigheid` data, was added.
* Cleaned up test code URL construction (list vs detail)