### PR TITLE
Putting DSO-API on a diet: remove django.contrib.auth/contenttypes/messages

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -58,8 +58,6 @@ TIME_ZONE = "Europe/Amsterdam"
 # -- Application definition
 
 INSTALLED_APPS = [
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
     "django.contrib.staticfiles",
     "django.contrib.gis",
     "django.contrib.postgres",
@@ -87,7 +85,6 @@ MIDDLEWARE = [
 
 AUTHENTICATION_BACKENDS = [
     "schematools.contrib.django.auth_backend.ProfileAuthorizationBackend",
-    "django.contrib.auth.backends.ModelBackend",
 ]
 
 if DEBUG:
@@ -111,7 +108,6 @@ TEMPLATES = [
             "context_processors": [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
-                "django.contrib.messages.context_processors.messages",
             ],
         },
     },

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -6,7 +6,6 @@ from xml.etree import ElementTree as ET
 
 import orjson
 from django.apps import apps
-from django.contrib.auth.models import AnonymousUser
 from django.http.response import HttpResponseBase
 from django.utils.functional import SimpleLazyObject
 from rest_framework.request import Request
@@ -125,7 +124,6 @@ def api_request_with_scopes(scopes) -> Request:
     request.accept_crs = None  # for DSOSerializer, expects to be used with DSOViewMixin
     request.response_content_crs = None
 
-    request.user = AnonymousUser()
     request.user_scopes = UserScopes(
         query_params=request.GET,
         request_scopes=scopes,


### PR DESCRIPTION
These apps are not used at all, as the project doesn't need User models.
Nor do their tables have to be created.