### PR TITLE
Remove spaces from field ids in test schemas

### DIFF
--- a/src/tests/files/afval.json
+++ b/src/tests/files/afval.json
@@ -33,16 +33,16 @@
             "type": "string",
             "description": "Serienummer van container"
           },
-          "eigenaar naam": {
+          "eigenaar_naam": {
             "type": "string",
             "description": "Naam van eigenaar"
           },
-          "datum creatie": {
+          "datum_creatie": {
             "type": "string",
             "format": "date",
             "description": "Datum aangemaakt"
           },
-          "datum leegmaken": {
+          "datum_leegmaken": {
             "type": "string",
             "format": "date-time",
             "description": "Datum leeggemaakt"

--- a/src/tests/files/fietspaaltjes.json
+++ b/src/tests/files/fietspaaltjes.json
@@ -34,10 +34,10 @@
             "area": {
               "type": "string"
             },
-            "score 2013": {
+            "score_2013": {
               "type": "string"
             },
-            "score current": {
+            "score_current": {
               "type": "string"
             },
             "count": {

--- a/src/tests/files/fietspaaltjes_no_display.json
+++ b/src/tests/files/fietspaaltjes_no_display.json
@@ -33,10 +33,10 @@
             "area": {
               "type": "string"
             },
-            "score 2013": {
+            "score_2013": {
               "type": "string"
             },
-            "score current": {
+            "score_current": {
               "type": "string"
             },
             "count": {

--- a/src/tests/files/parkeervakken.json
+++ b/src/tests/files/parkeervakken.json
@@ -16,8 +16,8 @@
         "additionalFilters": {
           "regimes.inWerkingOp": {
             "type": "range",
-            "start": "regimes.begin tijd",
-            "end": "regimes.eind tijd"
+            "start": "regimes.begintijd",
+            "end": "regimes.eindtijd"
           }
         },
         "properties": {
@@ -44,7 +44,7 @@
             "type": "string",
             "description": ""
           },
-          "e type": {
+          "e_type": {
             "type": "string",
             "description": ""
           },
@@ -64,7 +64,7 @@
                   "type": "string",
                   "description": ""
                 },
-                "e type": {
+                "e_type": {
                   "type": "string",
                   "description": ""
                 },
@@ -80,19 +80,19 @@
                   "type": "string",
                   "description": ""
                 },
-                "begin tijd": {
+                "begintijd": {
                   "type": "time",
                   "description": ""
                 },
-                "eind tijd": {
+                "eindtijd": {
                   "type": "time",
                   "description": ""
                 },
-                "begin datum": {
+                "begindatum": {
                   "type": "date",
                   "description": ""
                 },
-                "eind datum": {
+                "einddatum": {
                   "type": "date",
                   "description": ""
                 },

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -37,10 +37,10 @@ class TestDynamicFilterSet:
             e_type="E9",
             kenteken="69-SF-NT",
             opmerking="",
-            eind_tijd="23:59:00",
-            begin_tijd="00:00:00",
-            eind_datum=None,
-            begin_datum=None,
+            eindtijd="23:59:00",
+            begintijd="00:00:00",
+            einddatum=None,
+            begindatum=None,
         )
         other_parkeervak = parkeervakken_parkeervak_model.objects.create(
             id="121138489006",
@@ -61,10 +61,10 @@ class TestDynamicFilterSet:
             e_type="E6b",
             kenteken="69-SF-NT",
             opmerking="",
-            eind_tijd="23:59:00",
-            begin_tijd="00:00:00",
-            eind_datum=None,
-            begin_datum=None,
+            eindtijd="23:59:00",
+            begintijd="00:00:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         filterset_class = filterset_factory(Parkeervakken)
@@ -109,10 +109,10 @@ class TestDynamicFilterSet:
             e_type="",
             kenteken="",
             opmerking="",
-            begin_tijd="00:00:00",
-            eind_tijd="07:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="00:00:00",
+            eindtijd="07:59:00",
+            einddatum=None,
+            begindatum=None,
         )
         parkeervakken_regime_model.objects.create(
             id=3,
@@ -124,10 +124,10 @@ class TestDynamicFilterSet:
             e_type="E6b",
             kenteken="",
             opmerking="",
-            begin_tijd="08:00:00",
-            eind_tijd="09:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="08:00:00",
+            eindtijd="09:59:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         parkeervakken_regime_model.objects.create(
@@ -140,10 +140,10 @@ class TestDynamicFilterSet:
             e_type="",
             kenteken="",
             opmerking="",
-            begin_tijd="10:00:00",
-            eind_tijd="23:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="10:00:00",
+            eindtijd="23:59:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         extra_parkeervak = parkeervakken_parkeervak_model.objects.create(
@@ -165,10 +165,10 @@ class TestDynamicFilterSet:
             e_type="",
             kenteken="",
             opmerking="",
-            begin_tijd="00:00:00",
-            eind_tijd="23:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="00:00:00",
+            eindtijd="23:59:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         exclude_parkeervak = parkeervakken_parkeervak_model.objects.create(
@@ -190,10 +190,10 @@ class TestDynamicFilterSet:
             e_type="",
             kenteken="",
             opmerking="",
-            begin_tijd="00:00:00",
-            eind_tijd="07:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="00:00:00",
+            eindtijd="07:59:00",
+            einddatum=None,
+            begindatum=None,
         )
         parkeervakken_regime_model.objects.create(
             id=6,
@@ -205,10 +205,10 @@ class TestDynamicFilterSet:
             e_type="E7",
             kenteken="",
             opmerking="",
-            begin_tijd="08:00:00",
-            eind_tijd="09:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="08:00:00",
+            eindtijd="09:59:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         parkeervakken_regime_model.objects.create(
@@ -221,10 +221,10 @@ class TestDynamicFilterSet:
             e_type="",
             kenteken="",
             opmerking="",
-            begin_tijd="10:00:00",
-            eind_tijd="23:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="10:00:00",
+            eindtijd="23:59:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         response = APIClient().get(
@@ -271,10 +271,10 @@ class TestDynamicFilterSet:
             e_type="E6b",
             kenteken="",
             opmerking="",
-            begin_tijd=None,
-            eind_tijd="10:00:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd=None,
+            eindtijd="10:00:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         response = APIClient().get(
@@ -321,10 +321,10 @@ class TestDynamicFilterSet:
             e_type="E6b",
             kenteken="",
             opmerking="",
-            begin_tijd="08:00:00",
-            eind_tijd=None,
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="08:00:00",
+            eindtijd=None,
+            einddatum=None,
+            begindatum=None,
         )
 
         response = APIClient().get(

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -480,10 +480,10 @@ class TestDynamicSerializer:
             e_type="E6b",
             kenteken="69-SF-NT",
             opmerking="",
-            eind_tijd="23:59:00",
-            begin_tijd="00:00:00",
-            eind_datum=None,
-            begin_datum=None,
+            eindtijd="23:59:00",
+            begintijd="00:00:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         ParkeervakSerializer = serializer_factory(parkeervakken_parkeervak_model)
@@ -519,11 +519,11 @@ class TestDynamicSerializer:
                     "aantal": None,
                     "eType": "E6b",
                     "kenteken": "69-SF-NT",
-                    "eindTijd": "23:59:00",
+                    "eindtijd": "23:59:00",
                     "opmerking": "",
-                    "beginTijd": "00:00:00",
-                    "eindDatum": None,
-                    "beginDatum": None,
+                    "begintijd": "00:00:00",
+                    "einddatum": None,
+                    "begindatum": None,
                 }
             ],
         }

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -491,7 +491,7 @@ class TestAuth:
     ):
         """Prove that protected fields are shown
         with an auth scope and there is a valid token"""
-        patch_field_auth(afval_schema, "containers", "eigenaar naam", auth=["BAG/R"])
+        patch_field_auth(afval_schema, "containers", "eigenaar_naam", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
@@ -506,7 +506,7 @@ class TestAuth:
     ):
         """Prove that protected fields are shown
         with an auth scope connected to Profile that gives access to specific field."""
-        patch_field_auth(afval_schema, "containers", "eigenaar naam", auth=["BAG/R"])
+        patch_field_auth(afval_schema, "containers", "eigenaar_naam", auth=["BAG/R"])
         models.Profile.create_for_schema(
             ProfileSchema.from_dict(
                 {
@@ -517,7 +517,7 @@ class TestAuth:
                             "tables": {
                                 "containers": {
                                     "fields": {
-                                        "eigenaar naam": "read",
+                                        "eigenaar_naam": "read",
                                     }
                                 }
                             }
@@ -540,7 +540,7 @@ class TestAuth:
     ):
         """Prove that protected fields are *not* shown
         with an auth scope and there is not a valid token"""
-        patch_field_auth(afval_schema, "containers", "eigenaar naam", auth=["BAG/R"])
+        patch_field_auth(afval_schema, "containers", "eigenaar_naam", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         response = api_client.get(url)
         data = read_response_json(response)
@@ -581,10 +581,10 @@ class TestAuth:
             e_type="",
             kenteken="",
             opmerking="",
-            begin_tijd="00:00:00",
-            eind_tijd="23:59:00",
-            eind_datum=None,
-            begin_datum=None,
+            begintijd="00:00:00",
+            eindtijd="23:59:00",
+            einddatum=None,
+            begindatum=None,
         )
 
         # First fetch with BAG/R token


### PR DESCRIPTION
Some of the schemas used for testing still have spaces in identifiers, which we haven't allowed for quite some time. This just bit me when I tried looking up fields by id on the parkeervakken schema.

I caught all of them if `git grep '".* .*":' src/tests` is to be trusted.