### PR TITLE
Yrob/swagger improvements

### DIFF
--- a/src/templates/dso_api/dynamic_api/oauth2_redirect.html
+++ b/src/templates/dso_api/dynamic_api/oauth2_redirect.html
@@ -63,6 +63,7 @@
             }
         } else {
             oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+            window.opener.dsoShowToken(qp)
         }
         window.close();
     }

--- a/src/templates/dso_api/dynamic_api/swagger_ui.js
+++ b/src/templates/dso_api/dynamic_api/swagger_ui.js
@@ -1,4 +1,4 @@
-const swagger_settings  = {{settings|safe}}
+  const swagger_settings  = {{settings|safe}}
 
 const ui = SwaggerUIBundle({
   url: "{{schema_url|safe}}",
@@ -16,6 +16,19 @@ const ui = SwaggerUIBundle({
   },
   ...swagger_settings
 })
+
+// Show access token in swagger login screen
+window.dsoShowToken = (token) => {
+  let access_token = token.access_token
+  let el =  document.getElementsByClassName("auth-container")[0].getElementsByClassName("wrapper")[0]
+  el.innerHTML =`<div style="position:relative">
+                    <label>access token</label>
+                    <textarea rows=5 style="background-color:rgb(51,51,51); color:white; min-height:unset">${access_token}</textarea>
+                    <div class="copy-to-clipboard" style="bottom: 15px; right: 20px;" onclick="navigator.clipboard.writeText('${access_token}')">
+                      <button></button>
+                    </div>
+                  </div>`
+}
 
 /// Initiate Swagger UI with extra options.
 ui.initOAuth({

--- a/src/templates/dso_api/dynamic_api/swagger_ui.js
+++ b/src/templates/dso_api/dynamic_api/swagger_ui.js
@@ -10,6 +10,8 @@ const ui = SwaggerUIBundle({
     SwaggerUIBundle.plugins.DownloadUrl
   ],
   layout: "BaseLayout",
+  persistAuthorization: true,
+  tryItOutEnabled: true,
   requestInterceptor: (request) => {
     request.headers["X-CSRFToken"] = "{{csrf_token}}"
     return request;


### PR DESCRIPTION
Een paar kleine verbeteringen aan swagger.

* In het authorisatie scherm wordt na een succesvolle login de jwt token getoond zodat deze makkelijk gekopieerd kan worden.
* persistAuthorisation staat aan zodat de token in browser cache bewaard blijft.
* tryitout knop staat standaard aan, dat scheelt klikken als je een endpoint wil proberen.
