### PR TITLE
Properly resolve database source fields in temporal _links

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       args:
         PIP_REQUIREMENTS: requirements_dev.txt
     ports:
-      - "8000:8000"
+      - "8090:8000"
     links:
       - database
     environment:
@@ -40,9 +40,10 @@ services:
       AZURE_APPI_CONNECTION_STRING: "${AZURE_APPI_CONNECTION_STRING}"
       AZURE_APPI_AUDIT_CONNECTION_STRING: "${AZURE_APPI_AUDIT_CONNECTION_STRING}"
       OAUTH_CLIENT_ID: "${OAUTH_CLIENT_ID}"
-      OAUTH_JWKS_URL: ${OAUTH_JWKS_URL}""
-      OAUTH_URL:  ${OAUTH_URL}""
+      OAUTH_JWKS_URL: "${OAUTH_JWKS_URL}"
+      OAUTH_URL:  "${OAUTH_URL}"
       CLOUD_ENV: "${CLOUD_ENV}"
+      DATAPUNT_API_URL: "${DATAPUNT_API_URL}"
       DJANGO_DEBUG: 1
     volumes:
       - ./src:/app

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -413,5 +413,6 @@ HAAL_CENTRAAL_CERTFILE = os.getenv("HC_CERTFILE")
 SHELL_PLUS_POST_IMPORTS = (
     "from django.apps.registry import apps",
     "from dso_api.dynamic_api.filterset import filterset_factory",
+    "from dso_api.dynamic_api.serializers import serializer_factory",
     "from pprint import pprint",
 )

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -859,6 +859,21 @@ def _gebieden_dataset(gebieden_schema_json) -> Dataset:
 
 
 @pytest.fixture()
+def unconventional_temporal_dataset() -> dict:
+    path = HERE / "files/unconventional_temporal.json"
+    return Dataset.objects.create(
+        name="unconventionaltemporal",
+        path="unconventionaltemporal",
+        schema_data=json.dumps(json.loads(path.read_text())),  # validate
+    )
+
+
+@pytest.fixture()
+def unconventional_temporal_model(unconventional_temporal_dataset, dynamic_models) -> dict:
+    return dynamic_models["unconventionaltemporal"]["unconventionaltemporaltable"]
+
+
+@pytest.fixture()
 def gebieden_dataset(_gebieden_dataset, woningbouwplannen_dataset) -> Dataset:
     """Make sure gebieden + woningbouwplannen is always combined,
     because woningbouwplannen has a reverse dependency on 'gebieden'.

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -759,3 +759,22 @@ class TestDynamicSerializer:
             statistieken_serializer.data["_links"]["buurt"]["href"]
             == "http://testserver/v1/gebieden/buurten/03630000000078/"
         ), statistieken_serializer.data
+
+    @staticmethod
+    def test_unconventional_temporal_identifier(drf_request, unconventional_temporal_model):
+        """Prove that temporal ids with casing and shortnames are properly serialized"""
+        obj = unconventional_temporal_model.objects.create(
+            uncid=1, unc_tid="v1", start="2020-01-01", eind="2021-01-01"
+        )
+        serializer = serializer_factory(unconventional_temporal_model)(
+            obj, context={"request": drf_request}
+        )
+
+        fields = serializer.fields
+
+        assert fields["uncid"].source == "uncid"
+        assert fields["uncTid"].source == "unc_tid"
+        assert fields["eind"].source == "eind"
+        assert fields["start"].source == "start"
+        assert fields["_links"]["self"]["uncid"].source == "uncid"
+        assert fields["_links"]["self"]["uncTid"].source == "unc_tid"


### PR DESCRIPTION
Fixes [AB#24665](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/24665)

The temporal _links factory was directly using the camel-cased values from the schema identifier field to add serializer fields by name. This did not lead to an error as long as the fields in the identifier of temporal schemas were equal to the camel-cased name used as the eventual database field name (i.e.: within ams schema context: they did not use shortnames and did not use uppercase letters) . These are now properly resolved by using the snakecased `DatasetFieldSchema.name` as the source of the field.