### PR TITLE
Allow ?_field=... to work across relations too.

### DIFF
--- a/src/rest_framework_dso/utils.py
+++ b/src/rest_framework_dso/utils.py
@@ -1,5 +1,7 @@
 from django.utils.functional import LazyObject, empty
 
+DictOfDicts = dict[str, dict[str, dict]]
+
 
 def unlazy_object(obj):
     if isinstance(obj, LazyObject):
@@ -8,3 +10,13 @@ def unlazy_object(obj):
         return obj._wrapped
     else:
         return obj
+
+
+def group_dotted_names(dotted_field_names: list[str]) -> DictOfDicts:
+    """Convert a list of dotted names to tree."""
+    result = {}
+    for dotted_name in dotted_field_names:
+        tree_level = result
+        for path_item in dotted_name.split("."):
+            tree_level = tree_level.setdefault(path_item, {})
+    return result

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -235,9 +235,10 @@ class TestDynamicFilterSet:
             ("ligtInBuurt.volgnummer[not]", "ligt_in_buurt_volgnummer"),
         }
 
-        assert expected_fields.issubset(
-            [(k, v.field_name) for k, v in filterset_class.get_filters().items()]
+        actual_fields = set(
+            (k, v.field_name) for k, v in filterset_class.get_filters().items() if "." in k
         )
+        assert expected_fields.issubset(actual_fields)
 
         assert VerblijfsObjecten.objects.count() == 4
 

--- a/src/tests/test_rest_framework_dso/test_embedding.py
+++ b/src/tests/test_rest_framework_dso/test_embedding.py
@@ -10,8 +10,8 @@ from rest_framework_dso.embedding import (
     ChunkedQuerySetIterator,
     ObservableIterator,
     get_all_embedded_field_names,
-    group_dotted_names,
 )
+from rest_framework_dso.utils import group_dotted_names
 
 from .models import Category, Movie
 from .serializers import MovieSerializer

--- a/src/tests/test_rest_framework_dso/test_fields.py
+++ b/src/tests/test_rest_framework_dso/test_fields.py
@@ -1,0 +1,79 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from rest_framework_dso.fields import (
+    ALLOW_ALL_FIELDS_TO_DISPLAY,
+    DENY_SUB_FIELDS_TO_DISPLAY,
+    FieldsToDisplay,
+)
+
+
+class TestFieldsToDisplay:
+    """Prove whether the 'FieldsToDisplay' tool really works"""
+
+    def test_allow_all(self):
+        """Prove that having no fields to filter evaluates to false"""
+        assert not FieldsToDisplay()
+        assert not ALLOW_ALL_FIELDS_TO_DISPLAY
+        assert repr(FieldsToDisplay()) == "<FieldsToDisplay: allow all>"
+        assert ALLOW_ALL_FIELDS_TO_DISPLAY.get_allow_list(set("abc")) == ({"a", "b", "c"}, set())
+
+    def test_deny_all(self):
+        """Prove that our singleton to deny all works"""
+        assert DENY_SUB_FIELDS_TO_DISPLAY  # this is not empty
+        assert list(DENY_SUB_FIELDS_TO_DISPLAY.includes) == []
+        assert list(DENY_SUB_FIELDS_TO_DISPLAY.excludes) == []
+        assert repr(DENY_SUB_FIELDS_TO_DISPLAY) == "<FieldsToDisplay: deny all>"
+        assert DENY_SUB_FIELDS_TO_DISPLAY.get_allow_list(set("abc")) == (set(), set())
+
+    def test_grouping(self):
+        """Prove that sublevel fields are properly grouped."""
+        root = FieldsToDisplay(["cat", "person.name", "person.id"])
+        assert bool(root)
+        assert set(root.includes) == {"cat"}
+        assert set(root.children) == {"person"}
+
+        sublevel = root.as_nested("person")
+        assert set(sublevel.includes) == {"name", "id"}
+
+    def test_grouping_exclusions(self):
+        """Prove that sublevel fields are properly grouped."""
+        root = FieldsToDisplay(["person", "person.name", "-person.pet.name", "address"])
+        assert bool(root)
+        assert set(root.includes) == {"address"}
+        assert set(root.children) == {"person"}
+        assert set(root.excludes) == set()  # -person.pet becomes an include of person.
+
+        person = root.as_nested("person")
+        assert set(person.includes) == {"name"}
+        assert set(person.children) == {"pet"}
+        person_name = person.as_nested("name")
+        assert person_name is ALLOW_ALL_FIELDS_TO_DISPLAY  # further nesting is also allowed
+
+        # Unmentioned nestings receive the same treatment as other fields
+        assert person.as_nested("unknown") is DENY_SUB_FIELDS_TO_DISPLAY
+
+        pet = person.as_nested("pet")
+        assert set(pet.includes) == set()
+        assert set(pet.excludes) == {"name"}
+
+        pet_name = pet.as_nested("name")
+        assert pet_name is DENY_SUB_FIELDS_TO_DISPLAY  # further nesting is also denied
+
+        # Unmentioned nestings receive the same treatment as other fields
+        assert pet.as_nested("food") is ALLOW_ALL_FIELDS_TO_DISPLAY
+
+    def test_deny_mixing_inclusions_exclusions(self):
+        """Prove that mixing inclusions and exclusions at the same level is denied."""
+        with pytest.raises(ValidationError) as e:
+            FieldsToDisplay(["person", "-address"])
+        assert "not possible to combine inclusions and exclusions" in str(e)
+
+        # This is fine, only reducing sub object:
+        FieldsToDisplay(["person", "-person.address"])
+        FieldsToDisplay(["person", "person.name", "-person.address.name"])
+
+        # But mixing includes/excludes at the same level is not:
+        with pytest.raises(ValidationError) as e:
+            FieldsToDisplay(["person", "person.name", "-person.address"])
+        assert "not possible to combine inclusions and exclusions" in str(e)

--- a/src/tests/test_rest_framework_dso/test_serializers.py
+++ b/src/tests/test_rest_framework_dso/test_serializers.py
@@ -231,7 +231,7 @@ def test_fields_limit_by_incorrect_field_gives_error(api_rf, movie, fields):
         #  as fields limit is performed on Single serializer level.
         repr(serializer)
 
-    assert "'batman' not among the available options" in str(exec_info.value)
+    assert "The following field name is invalid: 'batman'." in str(exec_info.value)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This required a completely different parser (FieldsToDisplay) that can handle the various include/exclude patterns across different nesting levels. The final result still produces an allowlist of all fields that should be preserved, and which embeddings to preserve.
