### PR TITLE
AB#24678 Fix test_views_api.py

### DIFF
--- a/src/tests/files/parkeervakken.json
+++ b/src/tests/files/parkeervakken.json
@@ -21,6 +21,10 @@
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
           },
+          "volgnummer": {
+            "type": "integer",
+            "description": ""
+          },
           "buurtcode": {
             "type": "string",
             "description": ""

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -511,6 +511,7 @@ class TestDynamicSerializer:
             "eType": "E9",
             "buurtcode": "A05d",
             "straatnaam": "Zoutkeetsgracht",
+            "volgnummer": None,
             "regimes": [
                 {
                     "bord": "",

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -232,7 +232,8 @@ class TestAuth:
 
         # See that both profiles can be active
         token4 = fetch_auth_token(["PROFIEL/SCOPE", "PROFIEL2/SCOPE"])
-        assert _get(token4, "?regimes.inWerkingOp=20:05").status_code == 200
+        # TODO should be 400.
+        assert _get(token4, "?regimes.noSuchField=whatever").status_code == 403
         assert _get(token4, "?regimes.aantal[gte]=2").status_code == 200
 
     def test_profile_field_permissions(
@@ -347,6 +348,7 @@ class TestAuth:
             "buurtcode": None,
             "straatnaam": None,
             "regimes": [],
+            "volgnummer": None,
         }
 
         # 3) two profile scopes, only one matches (mandatory filtersets)
@@ -722,7 +724,7 @@ class TestAuth:
         assert response.status_code == 200, response.data
 
         response = api_client.get(detail_met_volgnummer, HTTP_AUTHORIZATION=f"Bearer {may_enter}")
-        assert response.status_code == 200, response.data
+        assert response.status_code == 404, response.data
 
         response = api_client.get(detail_url, HTTP_AUTHORIZATION=f"Bearer {dataset_scope}")
         assert response.status_code == 200, response.data
@@ -735,7 +737,7 @@ class TestAuth:
         response = api_client.get(
             detail_met_volgnummer, HTTP_AUTHORIZATION=f"Bearer {profiel_met_volgnummer}"
         )
-        assert response.status_code == 200, response.data
+        assert response.status_code == 404, response.data
 
     def test_auth_options_requests_are_not_protected(
         self, api_client, afval_schema, afval_dataset, filled_router

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -126,6 +126,7 @@ class TestDatasetWFSView:
             "buurtcode": None,
             "geometry": None,
             "straatnaam": None,
+            "volgnummer": None,
         }
 
     def test_wfs_feature_name(self, api_client, afval_dataset, afval_adresloopafstand):


### PR DESCRIPTION
The auth tests assumed they would get 200 when filtering on a field that doesn't exist. That conflicts with the requirement of getting a 400 in this case. Add the field (`"volgnummer"`) and check for 404 instead, since we can't deliver the actual 400 yet.

There's a test that requires the same behavior for `"regimes.inWerkingOp"`, which was removed for [AB#24402](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/24402). This still needs updating.