### PR TITLE
Authorization on filters

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -1,9 +1,13 @@
 import logging
+from typing import cast
 
 from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest
 from rest_framework import permissions
 from rest_framework.viewsets import ViewSetMixin
+from schematools.exceptions import SchemaObjectNotFound
 from schematools.permissions import UserScopes
+from schematools.types import DatasetTableSchema, Permission
 
 from rest_framework_dso.embedding import EmbeddedFieldMatch
 from rest_framework_dso.serializers import ExpandableSerializer
@@ -80,7 +84,11 @@ class HasOAuth2Scopes(permissions.BasePermission):
             # This affects the mandatoryFilterSets matching on profile objects.
             request.user_scopes.add_query_params(view.table_schema.identifier)
 
-        access = request.user_scopes.has_table_access(model.table_schema())
+        schema = model.table_schema()
+        access = request.user_scopes.has_table_access(schema)
+        if access:
+            if not self._filters_ok(request, schema):
+                access = Permission.none
 
         log_access(request, access)
         return access
@@ -110,6 +118,85 @@ class HasOAuth2Scopes(permissions.BasePermission):
 
         log_access(request, access)
         return access
+
+    def _filters_ok(self, request, schema: DatasetTableSchema) -> bool:  # noqa: C901
+        """Check field authorization for requested filters."""
+        # Type hack: DRF requests have a __getattr__ that delegates to an HttpRequest.
+        request = cast(HttpRequest, request)
+
+        # And then we and authorization_django monkey-patch the scopes onto the request.
+        scopes = cast(UserScopes, request.user_scopes)
+
+        # Collect mandatory filters. We need to make an exception for these to handle cases
+        # where the field they reference isn't otherwise accessible.
+        # The actual check for whether the filter sets are provided lives elsewhere.
+        mandatory = set()
+        for profile in scopes.get_active_profile_tables(schema.dataset.id, schema.id):
+            for f in profile.mandatory_filtersets:
+                mandatory.update(f)
+
+        for key, values in request.GET.lists():
+            if key in ["fields", "sorteer"] or key.startswith("_"):
+                continue
+
+            # Everything else is a filter.
+            field_name, op = _parse_filter(key)
+
+            # mandatoryFilters may contain either the complete filter (with lookup operation)
+            # or just the field name.
+            if key in mandatory or field_name in mandatory:
+                continue
+
+            temporal = schema.temporal.dimensions if schema.temporal is not None else {}
+
+            if fields := temporal.get(field_name):
+                if not self._filter_ok(fields.start, scopes, schema):
+                    return False
+                if not self._filter_ok(fields.end, scopes, schema):
+                    return False
+
+            elif not self._filter_ok(field_name, scopes, schema):
+                return False
+
+        return True
+
+    def _filter_ok(self, field_name: str, scopes: UserScopes, schema: DatasetTableSchema) -> bool:
+        schema_part = schema
+        parts = field_name.split(".")  # Handle subfields.
+        for i, part in enumerate(parts):
+            try:
+                schema_part = schema_part.get_field_by_id(part)
+            except SchemaObjectNotFound as e:
+                # TODO: this should be a ValidationError,
+                # but that exception isn't handled properly from here.
+                # Raise PermissionDenied to at least get the exception message to the client.
+                raise PermissionDenied(f"{field_name} not found in schema") from e
+            if not scopes.has_field_access(schema_part):
+                return False
+
+        return True
+
+
+def _parse_filter(v: str) -> tuple[str, str]:
+    """Given a filter query parameter, returns the field name and operator.
+
+    Does not validate the operator.
+
+    E.g.,
+        parse_filter("foo") == ("foo", "exact")
+        parse_filter("foo[contains]") == ("foo", "contains")
+    """
+    bracket = v.find("[")
+    if bracket == -1:
+        field_name = v
+        op = "exact"
+    elif not v.endswith("]"):
+        raise ValueError(f"missing closing bracket (]) in {v!r}")
+    else:
+        field_name = v[:bracket]
+        op = v[bracket + 1 : -1]
+
+    return field_name, op
 
 
 class CheckPermissionsMixin:

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -147,11 +147,13 @@ class HasOAuth2Scopes(permissions.BasePermission):
             if key in mandatory or field_name in mandatory:
                 continue
 
-            if schema.temporal is not None and fields := schema.temporal.dimensions.get(field_name):
-                if not self._filter_ok(fields.start, scopes, schema):
-                    return False
-                if not self._filter_ok(fields.end, scopes, schema):
-                    return False
+            if schema.temporal is not None:
+                if fields := schema.temporal.dimensions.get(field_name):
+                    if any(
+                        not self._filter_ok(field, scopes, schema)
+                        for field in (fields.start, fields.end)
+                    ):
+                        return False
 
             elif not self._filter_ok(field_name, scopes, schema):
                 return False

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -983,6 +983,27 @@ def woningbouwplan_model(woningbouwplannen_dataset, dynamic_models):
 
 
 @pytest.fixture()
+def temporal_auth_schema_json() -> dict:
+    path = HERE / "files/temporal_auth.json"
+    return json.loads(path.read_text())
+
+
+@pytest.fixture()
+def temporal_auth_dataset(temporal_auth_schema_json):
+    schema_path = HERE / "files/temporal_auth.json"
+    return Dataset.objects.create(
+        name="temporalauth",
+        path="temporalauth",
+        schema_data=schema_path.read_text(),
+    )
+
+
+@pytest.fixture()
+def temporal_auth_model(temporal_auth_dataset, dynamic_models):
+    return dynamic_models["temporalauth"]["things"]
+
+
+@pytest.fixture()
 def statistieken_data(statistieken_model, buurten_data):
     return statistieken_model.objects.create(
         id=1,

--- a/src/tests/files/temporal_auth.json
+++ b/src/tests/files/temporal_auth.json
@@ -1,0 +1,47 @@
+{
+  "type": "dataset",
+  "id": "temporalauth",
+  "title": "Dataset with authorization on temporal dimensions",
+  "status": "beschikbaar",
+  "version": "0.0.0",
+  "identifier": "id",
+  "tables": [
+    {
+      "id": "things",
+      "type": "table",
+      "temporal": {
+        "identifier": "seqno",
+        "dimensions": {
+          "valid": ["start", "stop"]
+        }
+      },
+      "schema": {
+        "$id": "https://example.com/schema/temporal_auth.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["id", "seqno"],
+        "required": ["schema", "id", "seqno"],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {"type": "string", "description": ""},
+          "seqno": {"type": "integer", "description": ""},
+          "start": {
+            "type": "string",
+            "format": "date",
+            "description": ""
+          },
+          "stop": {
+            "type": "string",
+            "format": "date",
+            "auth": "SCOPE/HAMMERTIME",
+            "description": "U can't touch this."
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Some things to note:

1. The new code is in the wrong place. I'm still looking for the right place to put this. Ideally, we would validate the request much earlier in the process. That should fix the issue that invalid filters give 403 instead of 400.
2. `_parse_filter` is more general than necessary, in preparation for reimplementation of the filters.