### PR TITLE
Fix test schema's and code that uses DatasetSchema internal representation.

### DIFF
--- a/schemas/data/datasets/bag/bag.json
+++ b/schemas/data/datasets/bag/bag.json
@@ -9,6 +9,7 @@
     {
       "id": "bouwblok",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -59,6 +60,7 @@
     {
       "id": "bron",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -89,6 +91,7 @@
     {
       "id": "buurt",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -166,6 +169,7 @@
     {
       "id": "buurtcombinatie",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -231,6 +235,7 @@
     {
       "id": "gebiedsgerichtwerken",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -274,6 +279,7 @@
     {
       "id": "gebiedsgerichtwerkenpraktijkgebieden",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -308,6 +314,7 @@
     {
       "id": "gemeente",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -357,6 +364,7 @@
     {
       "id": "grootstedelijkgebied",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -394,6 +402,7 @@
     {
       "id": "indicatieadresseerbaarobject",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -424,6 +433,7 @@
     {
       "id": "ligplaats",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -493,6 +503,7 @@
     {
       "id": "nummeraanduiding",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -585,6 +596,7 @@
     {
       "id": "openbareruimte",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -663,6 +675,7 @@
     {
       "id": "pand",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -743,6 +756,7 @@
     {
       "id": "stadsdeel",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -808,6 +822,7 @@
     {
       "id": "standplaats",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -877,6 +892,7 @@
     {
       "id": "unesco",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -911,6 +927,7 @@
     {
       "id": "verblijfsobject",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -1028,6 +1045,7 @@
     {
       "id": "verblijfsobjectpandrelatie",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -1065,6 +1083,7 @@
     {
       "id": "woonplaats",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,10 +9,10 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 3.0.0
+amsterdam-schema-tools[django] == 3.1.2
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
-jsonschema == 3.2.0
+jsonschema == 4.2.1
 lru_dict == 1.1.7
 more-ds == 0.0.4
 more-itertools == 8.8.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==3.0.0
+amsterdam-schema-tools[django]==3.1.2
     # via -r requirements.in
 asgiref==3.3.4
     # via django
@@ -137,7 +137,7 @@ jsonpath-rw==1.4.0
     # via amsterdam-schema-tools
 jsonref==0.2
     # via mappyfile
-jsonschema==3.2.0
+jsonschema==4.2.1
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
@@ -301,7 +301,6 @@ six==1.15.0
     #   isodate
     #   json-encoder
     #   jsonpath-rw
-    #   jsonschema
     #   protobuf
     #   python-dateutil
     #   python-owasp-zap-v2.4

--- a/src/tests/files/afval.json
+++ b/src/tests/files/afval.json
@@ -10,6 +10,7 @@
     {
       "id": "containers",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -57,6 +58,7 @@
     {
       "id": "clusters",
       "type": "table",
+      "version": "1.0.0",
       "auth": ["BAG/R"],
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -81,6 +83,7 @@
     {
       "id": "adresLoopafstand",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -10,6 +10,7 @@
     {
       "id": "panden",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -86,6 +87,7 @@
     {
       "id": "dossiers",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/dossiers.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -111,6 +113,7 @@
     {
       "id": "verblijfsobjecten",
       "type": "table",
+     "version": "1.0.0",
       "version": "1.1.0",
       "temporal": {
         "identifier": "volgnummer",
@@ -445,6 +448,7 @@
     {
       "id": "nummeraanduidingen",
       "type": "table",
+     "version": "1.0.0",
       "version": "1.1.0",
       "temporal": {
         "identifier": "volgnummer",

--- a/src/tests/files/bommen.json
+++ b/src/tests/files/bommen.json
@@ -9,6 +9,7 @@
     {
       "id": "bommen",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/bommen@2.0.0.json
+++ b/src/tests/files/bommen@2.0.0.json
@@ -9,6 +9,7 @@
     {
       "id": "bommen",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/brp.json
+++ b/src/tests/files/brp.json
@@ -11,6 +11,7 @@
     {
       "id": "ingeschrevenpersonen",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/download-url.json
+++ b/src/tests/files/download-url.json
@@ -9,6 +9,7 @@
     {
       "id": "dossiers",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/ligplaatsen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/tests/files/explosieven.json
+++ b/src/tests/files/explosieven.json
@@ -17,6 +17,7 @@
       "id": "verdachtgebied",
       "title": "Verdachtgebied",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/fietspaaltjes.json
+++ b/src/tests/files/fietspaaltjes.json
@@ -9,6 +9,7 @@
       {
         "id": "fietspaaltjes",
         "type": "table",
+        "version": "1.0.0",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "type": "object",
@@ -114,4 +115,3 @@
       }
     ]
   }
-  

--- a/src/tests/files/fietspaaltjes_no_display.json
+++ b/src/tests/files/fietspaaltjes_no_display.json
@@ -9,11 +9,12 @@
       {
         "id": "fietspaaltjesnodisplay",
         "type": "table",
+        "version": "1.0.0",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",          
+          "type": "object",
           "additionalProperties": false,
-          "required": ["schema", "id"],          
+          "required": ["schema", "id"],
           "properties": {
             "schema": {
               "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
@@ -113,4 +114,3 @@
       }
     ]
   }
-  

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -10,6 +10,7 @@
     {
       "id": "bouwblokken",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -79,6 +80,7 @@
     {
       "id": "buurten",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -147,6 +149,7 @@
     {
       "id": "wijken",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -218,6 +221,7 @@
     {
       "id": "ggwgebieden",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -290,6 +294,7 @@
     {
       "id": "ggpgebieden",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {
@@ -373,6 +378,7 @@
     {
       "id": "stadsdelen",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "volgnummer",
         "dimensions": {

--- a/src/tests/files/geometry_auth.json
+++ b/src/tests/files/geometry_auth.json
@@ -8,6 +8,7 @@
     {
       "id": "things",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/geometry_authdataset.json
+++ b/src/tests/files/geometry_authdataset.json
@@ -9,6 +9,7 @@
     {
       "id": "things",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/geometry_zoom.json
+++ b/src/tests/files/geometry_zoom.json
@@ -8,6 +8,7 @@
     {
       "id": "things",
       "type": "table",
+      "version": "1.0.0",
       "zoom": {
         "min": 3,
         "max": "max_zoom"

--- a/src/tests/files/haalcentraalbrk/schema.json
+++ b/src/tests/files/haalcentraalbrk/schema.json
@@ -10,6 +10,7 @@
     {
       "id": "kadastraalonroerendezaken",
       "type": "table",
+     "version": "1.0.0",
       "version": "0.0.1",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -181,6 +182,7 @@
     {
       "id": "kadasternatuurlijkpersonen",
       "type": "table",
+     "version": "1.0.0",
       "version": "0.0.1",
       "auth": [
         "BRK/RS",

--- a/src/tests/files/indirect-self-ref.json
+++ b/src/tests/files/indirect-self-ref.json
@@ -9,6 +9,7 @@
     {
       "id": "nummeraanduidingen",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/nummeraanduidingen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -42,6 +43,7 @@
     {
       "id": "ligplaatsen",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/bag/ligplaatsen.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/tests/files/meldingen.json
+++ b/src/tests/files/meldingen.json
@@ -10,6 +10,7 @@
     {
       "id": "statistieken",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/parkeervakken.json
+++ b/src/tests/files/parkeervakken.json
@@ -8,6 +8,7 @@
     {
       "id": "parkeervakken",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/temporal_auth.json
+++ b/src/tests/files/temporal_auth.json
@@ -9,6 +9,7 @@
     {
       "id": "things",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "seqno",
         "dimensions": {

--- a/src/tests/files/unconventional_temporal.json
+++ b/src/tests/files/unconventional_temporal.json
@@ -9,6 +9,7 @@
     {
       "id": "unconventionaltemporaltable",
       "type": "table",
+      "version": "1.0.0",
       "temporal": {
         "identifier": "UnconventionalTemporalId",
         "dimensions": {

--- a/src/tests/files/vestiging.json
+++ b/src/tests/files/vestiging.json
@@ -9,6 +9,7 @@
     {
       "id": "adres",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
@@ -59,6 +60,7 @@
     {
       "id": "vestiging",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",

--- a/src/tests/files/woningbouwplannen.json
+++ b/src/tests/files/woningbouwplannen.json
@@ -9,6 +9,7 @@
     {
       "id": "woningbouwplan",
       "type": "table",
+      "version": "1.0.0",
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/woningbouwplannen/woningbouwplan.json",
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -31,8 +31,8 @@ def patch_table_auth(schema: DatasetSchema, table_id, *, auth: list[str]):
     # This updates the low-level dict data so all high-level objects get it.
     schema.get_table_by_id(table_id)  # checks errors
 
-    raw_table = next(t for t in schema["tables"] if t["id"] == table_id)
-    raw_table["auth"] = auth
+    raw_table = next(t for t in schema["tables"] if t.default["id"] == table_id)
+    raw_table.default["auth"] = auth
 
     # Also patch the active model, as that's already loaded and has a copy of the table schema
     model = apps.get_model(schema.id, table_id)
@@ -44,9 +44,9 @@ def patch_field_auth(schema: DatasetSchema, table_id, field_id, *subfields, auth
     # This updates the low-level dict data so all high-level objects get it.
     schema.get_table_by_id(table_id).get_field_by_id(field_id)  # check existence
 
-    raw_table = next(t for t in schema["tables"] if t["id"] == table_id)
+    raw_table = next(t for t in schema["tables"] if t.default["id"] == table_id)
     raw_field = next(
-        f for f_id, f in raw_table["schema"]["properties"].items() if f_id == field_id
+        f for f_id, f in raw_table.default["schema"]["properties"].items() if f_id == field_id
     )
 
     # Allow to resolve sub fields too


### PR DESCRIPTION
New version of `schema-tools` keeps track of active table versions. This is entirely transparant to all code that only uses `DatasetSchema`'s public API (methods and properties). Code that uses the underlying `dict` representation of `DatasetSchema`, however, will be affected. This PR has the necessary changes for those pieces of code.