### PR TITLE
AB#24404 Whitelist "page_size" in filter auth

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -136,7 +136,7 @@ class HasOAuth2Scopes(permissions.BasePermission):
                 mandatory.update(f)
 
         for key, values in request.GET.lists():
-            if key in ("fields", "format", "sorteer") or key.startswith("_"):
+            if key in ("fields", "format", "page_size", "sorteer") or key.startswith("_"):
                 continue
 
             # Everything else is a filter.

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -688,7 +688,8 @@ class TestExceptionHandler:
 
 @pytest.mark.django_db
 class TestListCount:
-    def test_list_count_included(self, api_client):
+    @pytest.mark.parametrize("page_size_param", ["_pageSize", "page_size"])
+    def test_list_count_included(self, page_size_param, api_client):
         Movie.objects.create(name="foo123")
         Movie.objects.create(name="test")
 
@@ -702,9 +703,9 @@ class TestListCount:
 
         Movie.objects.create(name="bla")
 
-        response = api_client.get("/v1/movies", data={"_count": "true", "_pageSize": 2})
-        data = read_response_json(response)
+        response = api_client.get("/v1/movies", data={"_count": "true", page_size_param: 2})
         assert response.status_code == 200
+        data = read_response_json(response)
         assert response["X-Total-Count"] == "3"
         assert data["page"]["totalElements"] == 3
         assert response["X-Pagination-Count"] == "2"


### PR DESCRIPTION
I forgot to whitelist this parameter. Of the tests, the one in `test_rest_framework_dso` doesn't actually trigger the bug, but I included it for completeness. The one in `test_dynamic_api` does, but it triggers a different bug, [AB#24678](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/24678).