### PR TITLE
AB#24579 fix to_snake_case bug in router

### DIFF
--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -243,7 +243,7 @@ class DynamicRouter(routers.DefaultRouter):
                     # Do not create separate viewsets for nested tables.
                     continue
 
-                dataset_id = model.get_dataset_id()
+                dataset_id = to_snake_case(model.get_dataset_id())
 
                 # Determine the URL prefix for the model
                 url_prefix = self.make_url(model.get_dataset_path(), model.get_table_id())


### PR DESCRIPTION
_build_db_viewsets was registering views without calling to_snake_case
on the dataset id. This caused beheerkaart_basis and beheerkaart_cbs grid to give a 500.
