### PR TITLE
AB#24404 Fix filter auth on relations

### DIFF
--- a/src/tests/files/relationauth.json
+++ b/src/tests/files/relationauth.json
@@ -1,0 +1,88 @@
+{
+  "id": "relationauth",
+  "type": "dataset",
+  "description": "Test filter authorization on relations within a dataset",
+  "license": "public",
+  "status": "beschikbaar",
+  "version": "1.2.3",
+  "publisher": "us",
+  "owner": "us",
+  "authorizationGrantor": "us",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "base",
+      "type": "table",
+      "title": "Base",
+      "auth": [
+        "BASE"
+      ],
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+          "id"
+        ],
+        "required": [
+          "schema",
+          "id"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "auth": [
+              "BASE/ID"
+            ],
+            "type": "integer",
+            "description": "Unieke aanduiding van het record."
+          }
+        }
+      }
+    },
+    {
+      "id": "refers",
+      "type": "table",
+      "title": "Refers",
+      "auth": [
+        "REFERS"
+      ],
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "name",
+          "base"
+        ],
+        "display": "name",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "name": {
+            "description": "Name",
+            "type": "string",
+            "auth": [
+              "REFERS/NAME"
+            ]
+          },
+          "base": {
+            "description": "Reference to base",
+            "type": "integer",
+            "auth": [
+              "REFERS/BASE"
+            ],
+            "relation": "relationauth:base"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_filter_auth.py
+++ b/src/tests/test_dynamic_api/test_filter_auth.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+from schematools.permissions import UserScopes
+from schematools.utils import dataset_schema_from_path
+
+from dso_api.dynamic_api.permissions import _filter_ok
+
+SCHEMA = dataset_schema_from_path(Path(__file__).parent.parent / "files" / "relationauth.json")
+
+
+@pytest.mark.parametrize(
+    ["field_name", "scopes", "expect"],
+    [
+        ("name", "REFERS REFERS/NAME", True),
+        ("base", "REFERS REFERS/NAME", False),
+        ("base", "REFERS REFERS/BASE", False),
+        ("base", "REFERS REFERS/BASE BASE", False),
+        ("base", "REFERS REFERS/BASE BASE/ID", False),
+        ("base", "REFERS BASE BASE/ID", False),
+        ("base", "REFERS/BASE BASE BASE/ID", False),
+        ("base", "REFERS REFERS/BASE BASE BASE/ID", True),
+    ],
+)
+def test_filter_ok(field_name: str, scopes: str, expect: bool):
+    schema = SCHEMA.get_table_by_id("refers")
+
+    scopes = UserScopes(query_params={}, request_scopes=scopes.split())
+    assert _filter_ok(field_name, scopes, schema) == expect


### PR DESCRIPTION
Should work for all relation types, though the test only covers one-to-many within a dataset. The implementation isn't very efficient since it traverses the dataset collection for every single field. The caches in schema-tools should help a bit, though.