### PR TITLE
Switch to modern (post-Django 1.10) middleware

### DIFF
--- a/src/dso_api/dynamic_api/middleware.py
+++ b/src/dso_api/dynamic_api/middleware.py
@@ -1,31 +1,26 @@
-from django.utils.deprecation import MiddlewareMixin
+from django.http import HttpRequest
 from schematools.contrib.django.models import Profile
 from schematools.permissions import UserScopes
 
 
-class AuthMiddleware(MiddlewareMixin):
+class AuthMiddleware:
     """
     Assigns `user_scopes` to request, for easy access.
     """
 
     def __init__(self, get_response):
-        super().__init__(get_response)
+        self._get_response = get_response
         # Load the profiles once on startup of the application (just like datasets are read once).
-        self.all_profiles = [p.schema for p in Profile.objects.all()]
+        self._all_profiles = [p.schema for p in Profile.objects.all()]
 
-    def process_request(self, request):
-        """
-        This method installs the `user_scopes` for the OAS views.
-        """
+    def __call__(self, request: HttpRequest):
+        # OPTIONS requests have no get_token_scopes, but don't need a UserScopes either.
+        if request.method != "OPTIONS":
+            # get_token_scopes should be set by authorization_django. We use it,
+            # instead of is_authorized_for, to get more control over authorization
+            # checks and to enable more precise logging.
+            # get_token_scopes is a data attribute, not a method.
+            scopes = request.get_token_scopes
+            request.user_scopes = UserScopes(request.GET, scopes, self._all_profiles)
 
-        # get_token_scopes should be set by authorization_django. We use it,
-        # instead of is_authorized_for, to get more control over authorization
-        # checks and to enable more precise logging.
-
-        if request.method == "OPTIONS":
-            # OPTIONS requests have no get_token_scopes, but don't need a UserScopes either.
-            return
-
-        # get_token_scopes is a data attribute, not a method.
-        scopes = request.get_token_scopes
-        request.user_scopes = UserScopes(request.GET, scopes, self.all_profiles)
+        return self._get_response(request)


### PR DESCRIPTION
This is a cosmetic change, in preparation for some validation middleware that I'm considering writing.

(It my remove some request latency, but don't expect miracles.)

There are no new tests because the existing ones cover this code: if I break it, existing tests fail.