### PR TITLE
AB#24404 Handle syntax errors in filter parameters

### DIFF
--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -23,6 +23,7 @@ from schematools.contrib.django.models import DynamicModel
 from schematools.exceptions import SchemaObjectNotFound
 
 from dso_api.dynamic_api import filterset, locking, permissions, serializers
+from dso_api.dynamic_api.permissions import FilterSyntaxError
 from dso_api.dynamic_api.temporal import TemporalTableQuery
 from rest_framework_dso import fields
 from rest_framework_dso.views import DSOViewMixin
@@ -97,6 +98,8 @@ class DynamicApiViewSet(locking.ReadLockMixin, DSOViewMixin, viewsets.ReadOnlyMo
         table_schema = self.model.table_schema()
         try:
             permissions.validate_request(request, table_schema, self._NON_FILTER_PARAMS)
+        except FilterSyntaxError as e:
+            raise ValidationError(str(e)) from e
         except SchemaObjectNotFound as e:
             raise ValidationError(str(e)) from e
         self.temporal = TemporalTableQuery(request, table_schema)


### PR DESCRIPTION
These would produce 500 instead of 400 due to a NameError.

It may seem overkill to introduce an exception class for this, but

* ValueError is too broad: it can be caused by a bug as well as a
  validation check.
* Django's ValidationError isn't handled by DRF, so it would require
  changes to the exception handler. I'm not willing to go there right
  now.
* DRF's ValidationError may cause problems with non-DRF views such as
  remotes. We want reusable validation/authorization code.

> Don't forget about...
> * Tests
> * Documentation in `docs/`, `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
