### PR TITLE
Guido/23896 psql schema per dataset

### DIFF
--- a/src/dso_api/dynamic_api/remote/serializers.py
+++ b/src/dso_api/dynamic_api/remote/serializers.py
@@ -90,7 +90,7 @@ class RemoteSerializer(DSOSerializer, _AuthMixin):
     @extend_schema_field(OpenApiTypes.URI)
     def get_schema(self, instance):
         """The schema field is exposed with every record"""
-        name = self.table_schema._parent_schema.id
+        name = self.table_schema.parent_schema.id
         table = self.table_schema.id
         dataset_path = Dataset.objects.get(name=name).path
         return f"https://schemas.data.amsterdam.nl/datasets/{dataset_path}/dataset#{table}"
@@ -117,7 +117,7 @@ class RemoteFieldSerializer(DSOSerializer, _AuthMixin):
 
 def remote_serializer_factory(table_schema: DatasetTableSchema):
     """Generate the DRF serializer class for a specific dataset model."""
-    dataset = table_schema._parent_schema
+    dataset = table_schema.parent_schema
     serializer_name = (f"{dataset.id.title()}{table_schema.id.title()}Serializer").replace(
         " ", "_"
     )

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 3.1.4
+amsterdam-schema-tools[django] == 3.2.0
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
 jsonschema == 4.2.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==3.1.4
+amsterdam-schema-tools[django]==3.2.0
     # via -r requirements.in
 arrow==1.2.1
     # via isoduration
@@ -53,20 +53,6 @@ defusedxml==0.7.1
     # via django-gisserver
 deprecated==1.2.13
     # via amsterdam-schema-tools
-django==3.1.14
-    # via
-    #   -r requirements.in
-    #   amsterdam-schema-tools
-    #   datapunt-authorization-django
-    #   django-cors-headers
-    #   django-filter
-    #   django-gisserver
-    #   django-healthchecks
-    #   django-postgres-unlimited-varchar
-    #   django-vectortiles
-    #   djangorestframework
-    #   drf-spectacular
-    #   opencensus-ext-django
 django-cors-headers==3.7.0
     # via -r requirements.in
 django-environ==0.4.5
@@ -87,24 +73,32 @@ django-postgres-unlimited-varchar==1.1.0
     #   amsterdam-schema-tools
 django-vectortiles==0.1.0
     # via -r requirements.in
+django==3.1.14
+    # via
+    #   -r requirements.in
+    #   amsterdam-schema-tools
+    #   datapunt-authorization-django
+    #   django-cors-headers
+    #   django-filter
+    #   django-gisserver
+    #   django-healthchecks
+    #   django-postgres-unlimited-varchar
+    #   django-vectortiles
+    #   djangorestframework
+    #   drf-spectacular
+    #   opencensus-ext-django
+djangorestframework-csv==2.1.1
+    # via -r requirements.in
+djangorestframework-gis==0.17
+    # via -r requirements.in
 djangorestframework==3.12.4
     # via
     #   -r requirements.in
     #   djangorestframework-csv
     #   djangorestframework-gis
     #   drf-spectacular
-djangorestframework-csv==2.1.1
-    # via -r requirements.in
-djangorestframework-gis==0.17
-    # via -r requirements.in
 drf-spectacular==0.15.0
     # via -r requirements.in
-flake8==3.9.2
-    # via
-    #   -r requirements.in
-    #   flake8-colors
-    #   flake8-debugger
-    #   flake8-raise
 flake8-blind-except==0.2.0
     # via -r requirements.in
 flake8-colors==0.1.9
@@ -113,6 +107,12 @@ flake8-debugger==4.0.0
     # via -r requirements.in
 flake8-raise==0.0.5
     # via -r requirements.in
+flake8==3.9.2
+    # via
+    #   -r requirements.in
+    #   flake8-colors
+    #   flake8-debugger
+    #   flake8-raise
 fqdn==1.5.1
     # via jsonschema
 future==0.18.2
@@ -187,11 +187,6 @@ ndjson==0.3.1
     # via amsterdam-schema-tools
 oauthlib==3.1.0
     # via requests-oauthlib
-opencensus==0.7.12
-    # via
-    #   opencensus-ext-azure
-    #   opencensus-ext-django
-    #   opencensus-ext-logging
 opencensus-context==0.1.2
     # via opencensus
 opencensus-ext-azure==1.0.7
@@ -200,6 +195,11 @@ opencensus-ext-django==0.7.4
     # via -r requirements.in
 opencensus-ext-logging==0.1.0
     # via -r requirements.in
+opencensus==0.7.12
+    # via
+    #   opencensus-ext-azure
+    #   opencensus-ext-django
+    #   opencensus-ext-logging
 ordered-set==4.0.2
     # via deepdiff
 orjson==3.5.3
@@ -223,18 +223,18 @@ protobuf==3.15.7
     #   mapbox-vector-tile
 psutil==5.8.0
     # via opencensus-ext-azure
-psycopg2==2.8.6
-    # via amsterdam-schema-tools
 psycopg2-binary==2.8.6
     # via -r requirements.in
+psycopg2==2.8.6
+    # via amsterdam-schema-tools
 py==1.10.0
     # via pytest
+pyasn1-modules==0.2.8
+    # via google-auth
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.2.8
-    # via google-auth
 pyclipper==1.2.1
     # via mapbox-vector-tile
 pycodestyle==2.7.0
@@ -249,15 +249,15 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.17.3
     # via jsonschema
+pytest-cov==2.12.1
+    # via -r requirements.in
+pytest-django==4.1.0
+    # via -r requirements.in
 pytest==6.2.4
     # via
     #   -r requirements.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==2.12.1
-    # via -r requirements.in
-pytest-django==4.1.0
-    # via -r requirements.in
 python-dateutil==2.8.1
     # via
     #   amsterdam-schema-tools
@@ -276,6 +276,8 @@ pyyaml==5.4.1
     # via drf-spectacular
 readerwriterlock==1.0.9
     # via -r requirements.in
+requests-oauthlib==1.3.0
+    # via msrest
 requests==2.25.1
     # via
     #   -r requirements.in
@@ -288,8 +290,6 @@ requests==2.25.1
     #   opencensus-ext-azure
     #   python-owasp-zap-v2.4
     #   requests-oauthlib
-requests-oauthlib==1.3.0
-    # via msrest
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
@@ -341,13 +341,13 @@ uri-template==1.1.0
     # via jsonschema
 uritemplate==3.0.1
     # via drf-spectacular
+urllib3-mock==0.3.3
+    # via -r requirements.in
 urllib3==1.26.5
     # via
     #   -r requirements.in
     #   requests
     #   sentry-sdk
-urllib3-mock==0.3.3
-    # via -r requirements.in
 webcolors==1.11.1
     # via jsonschema
 wirerope==0.4.2

--- a/src/tests/test_dynamic_api/remote/test_views.py
+++ b/src/tests/test_dynamic_api/remote/test_views.py
@@ -8,7 +8,13 @@ import urllib3
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 from schematools.contrib.django import models
-from schematools.types import DatasetTableSchema, ProfileSchema
+from schematools.types import (
+    DatasetSchema,
+    DatasetTableSchema,
+    ProfileSchema,
+    SemVer,
+    TableVersions,
+)
 from urllib3_mock import Responses
 
 from dso_api.dynamic_api.remote.clients import RemoteClient
@@ -765,14 +771,29 @@ def test_hcbrk_listing_by_bsn(api_client, fetch_auth_token, router, hcbrk_datase
     assert response.status_code == 403, data
 
 
-REMOTE_SCHEMA = DatasetTableSchema.from_dict(
-    {
-        "id": "mytable",
-        "type": "table",
-        "schema": {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-        },
-    }
+V1 = SemVer("1.0.0")
+TABLE_SCHEMA = {
+    "id": "mytable",
+    "type": "table",
+    "version": str(V1),
+    "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    },
+}
+REMOTE_SCHEMA = DatasetTableSchema(
+    TABLE_SCHEMA,
+    parent_schema=DatasetSchema(
+        {
+            "id": "adhoc",
+            "tables": [
+                TableVersions(
+                    id=TABLE_SCHEMA["id"],
+                    default_version_number=V1,
+                    active=dict(V1=TABLE_SCHEMA),
+                )
+            ],
+        }
+    ),
 )
 
 


### PR DESCRIPTION
`schematools` is about to have a number of changes (https://github.com/Amsterdam/schema-tools/pull/233/) that affect DSO-API. This PR will bring DSO-API back into sync with that version of `schema-tools`

As that version of `schematools` does not yet have a specific version number, this DSO-API PR does not yet have an update `requirements.in`. So once the above `schematools` PR has been merged, update DSO-API's `requirements.in` with whatever version number `schematools` has gotten.