### PR TITLE
Fix M2M relations in REST API

### DIFF
--- a/src/dso_api/dynamic_api/remote/serializers.py
+++ b/src/dso_api/dynamic_api/remote/serializers.py
@@ -90,7 +90,7 @@ class RemoteSerializer(DSOSerializer, _AuthMixin):
     @extend_schema_field(OpenApiTypes.URI)
     def get_schema(self, instance):
         """The schema field is exposed with every record"""
-        name = self.table_schema.parent_schema.id
+        name = self.table_schema.dataset.id
         table = self.table_schema.id
         dataset_path = Dataset.objects.get(name=name).path
         return f"https://schemas.data.amsterdam.nl/datasets/{dataset_path}/dataset#{table}"
@@ -117,7 +117,7 @@ class RemoteFieldSerializer(DSOSerializer, _AuthMixin):
 
 def remote_serializer_factory(table_schema: DatasetTableSchema):
     """Generate the DRF serializer class for a specific dataset model."""
-    dataset = table_schema.parent_schema
+    dataset = table_schema.dataset
     serializer_name = (f"{dataset.id.title()}{table_schema.id.title()}Serializer").replace(
         " ", "_"
     )

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -1157,7 +1157,6 @@ def _build_serializer_reverse_fk_field(
     if format1 == "embedded":
         # Shows the identifiers of each item inline.
         target_model: type[DynamicModel] = model_field.related_model
-        field_kwargs = {"read_only": True, "many": True}
         if target_model.is_temporal():
             # Since the "identificatie" / "volgnummer" fields are dynamic, there is no good
             # way to generate an OpenAPI definition from this unless the whole result
@@ -1166,7 +1165,7 @@ def _build_serializer_reverse_fk_field(
         else:
             field_class = _nontemporal_link_serializer_factory(target_model)
 
-        serializer_part.add_field(name, field_class(**field_kwargs))
+        serializer_part.add_field(name, field_class(read_only=True, many=True))
     elif format1 == "summary":
         # Only shows a count and href to the (potentially large) list of items.
         serializer_part.add_field(name, RelatedSummaryField())

--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -1066,12 +1066,11 @@ def _build_m2m_serializer_field(
     unnecessary queries joining both the through and target table.
     """
     camel_name = toCamelCase(m2m_field.name)
-    through_model = m2m_field.remote_field.through
     serializer_class = _through_serializer_factory(m2m_field)
 
     # Add the field to the serializer, but let it navigate to the through model
     # by using the reverse_name of it's first foreign key:
-    source = to_snake_case(f"{through_model._meta.object_name}_through_{model.get_table_id()}")
+    source = m2m_field.get_path_info()[0].join_field.name
     serializer_part.add_field(camel_name, serializer_class(source=source, many=True))
 
 

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -64,7 +64,7 @@ def get_source_model_fields(
     # unnecessary. However, most use-cases of this function involve inspecting model data earlier
     # in an override of serializer.get_fields(), which is before field.bind() is called.
     model = serializer.Meta.model
-    source_attrs = (field.source or field_name).split(".")
+    source_attrs = getattr(field, "source_attrs", None) or (field.source or field_name).split(".")
 
     for attr in source_attrs:
         model_field = model._meta.get_field(attr)

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 3.2.0
+amsterdam-schema-tools[django] == 3.3.1
 datapunt-authorization-django==1.3.1
 drf-spectacular == 0.15.0
 jsonschema == 4.2.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==3.2.0
+amsterdam-schema-tools[django]==3.3.1
     # via -r requirements.in
 arrow==1.2.1
     # via isoduration

--- a/src/rest_framework_dso/embedding.py
+++ b/src/rest_framework_dso/embedding.py
@@ -181,7 +181,8 @@ class EmbeddedFieldMatch:
         # Avoid long serializer repr which makes output unreadable.
         return (
             f"<{self.__class__.__name__}:"
-            f" {self.field!r}"
+            f" {self.serializer.__class__.__name__}"
+            f" field={self.field!r}"
             f" nested={self.nested_expand_scope!r}>"
         )
 

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -294,7 +294,11 @@ class AbstractEmbeddedField:
         self.parent_serializer_class = None
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}: {self.field_name}, {self.serializer_class.__name__}>"
+        parent_serializer = self.parent_serializer_class.__name__
+        return (
+            f"<{self.__class__.__name__}: {parent_serializer}.{self.field_name},"
+            f" {self.serializer_class.__name__}>"
+        )
 
     def __set_name__(self, owner, name):
         self.bind(owner, name)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1050,6 +1050,8 @@ def buurten_data(buurten_model) -> DynamicModel:
         begin_geldigheid=DATE_2021_FEB,
         eind_geldigheid=DATE_2021_JUNE,  # Historical record!
         ligt_in_wijk_id="03630012052035.1",
+        ligt_in_wijk_identificatie="03630012052035",
+        ligt_in_wijk_volgnummer="1",
     )
     return buurten_model.objects.create(
         id="03630000000078.2",
@@ -1057,6 +1059,8 @@ def buurten_data(buurten_model) -> DynamicModel:
         volgnummer=2,
         begin_geldigheid=DATE_2021_JUNE,
         ligt_in_wijk_id="03630012052035.1",
+        ligt_in_wijk_identificatie="03630012052035",
+        ligt_in_wijk_volgnummer="1",
     )
 
 
@@ -1068,6 +1072,8 @@ def bouwblokken_data(bouwblokken_model, buurten_data) -> DynamicModel:
         volgnummer=1,
         begin_geldigheid=DATE_2021_FEB,
         ligt_in_buurt_id="03630000000078.2",  # example (not actual)
+        ligt_in_buurt_identificatie="03630000000078",
+        ligt_in_buurt_volgnummer="2",
     )
 
 
@@ -1080,6 +1086,8 @@ def panden_data(panden_model, dossiers_model, bouwblokken_data):
         begin_geldigheid=DATE_2021_FEB,
         naam="Voorbeeldpand",
         ligt_in_bouwblok_id="03630012096483.1",
+        ligt_in_bouwblok_identificatie="03630012096483",
+        ligt_in_bouwblok_volgnummer="1",
         heeft_dossier_id="GV00000406",
     )
     dossiers_model.objects.create(dossier="GV00000406")
@@ -1095,6 +1103,8 @@ def wijken_data(wijken_model, stadsdelen_data) -> DynamicModel:
         naam="Burgwallen-Nieuwe Zijde",
         code="A01",
         ligt_in_stadsdeel=stadsdelen_data,
+        ligt_in_stadsdeel_identificatie=stadsdelen_data.identificatie,
+        ligt_in_stadsdeel_volgnummer=stadsdelen_data.volgnummer,
     )
 
 
@@ -1119,11 +1129,22 @@ def ggwgebieden_data(ggwgebieden_model, buurten_data):
         begin_geldigheid=DATE_2021_FEB,
     )
     ggwgebieden_model.bestaat_uit_buurten.through.objects.create(
-        id="22",
+        id=11,
         ggwgebieden_id="03630950000000.1",
+        ggwgebieden_identificatie="03630950000000",
+        ggwgebieden_volgnummer=1,
         bestaat_uit_buurten_id="03630000000078.1",
         bestaat_uit_buurten_identificatie="03630000000078",
         bestaat_uit_buurten_volgnummer=1,
+    )
+    ggwgebieden_model.bestaat_uit_buurten.through.objects.create(
+        id=22,
+        ggwgebieden_id="03630950000000.1",
+        ggwgebieden_identificatie="03630950000000",
+        ggwgebieden_volgnummer=1,
+        bestaat_uit_buurten_id="03630000000078.2",
+        bestaat_uit_buurten_identificatie="03630000000078",
+        bestaat_uit_buurten_volgnummer=2,
     )
 
 
@@ -1138,9 +1159,11 @@ def ggpgebieden_data(ggpgebieden_model, buurten_data):
     ggpgebieden_model.bestaat_uit_buurten.through.objects.create(
         id="33",
         ggpgebieden_id="03630950000000.1",
-        bestaat_uit_buurten_id="03630000000078.1",
+        ggpgebieden_identificatie="03630950000000",
+        ggpgebieden_volgnummer=1,
+        bestaat_uit_buurten_id="03630000000078.2",
         bestaat_uit_buurten_identificatie="03630000000078",
-        bestaat_uit_buurten_volgnummer=1,
+        bestaat_uit_buurten_volgnummer=2,
         begin_geldigheid="2021-03-04",
         eind_geldigheid=None,
     )
@@ -1153,7 +1176,7 @@ def woningbouwplannen_data(woningbouwplan_model, buurten_data, nontemporeel_mode
     woningbouwplan_model.buurten.through.objects.create(
         id=1000,
         woningbouwplan_id="1",
-        buurten_id=buurten_data.identificatie,
+        buurten_id=buurten_data.identificatie,  # NOTE: not a temporal reference!!
     )
     woningbouwplan_model.buurtenregular.through.objects.create(
         id=1000,

--- a/src/tests/files/bag.json
+++ b/src/tests/files/bag.json
@@ -113,7 +113,6 @@
     {
       "id": "verblijfsobjecten",
       "type": "table",
-     "version": "1.0.0",
       "version": "1.1.0",
       "temporal": {
         "identifier": "volgnummer",

--- a/src/tests/files/gebieden.json
+++ b/src/tests/files/gebieden.json
@@ -96,6 +96,14 @@
         "identifier": ["identificatie", "volgnummer"],
         "required": ["schema", "identificatie", "volgnummer"],
         "display": "id",
+        "additionalRelations": {
+          "onderdeelVanGGWGebieden": {
+            "table": "ggwgebieden",
+            "field": "bestaatUitBuurten",
+            "format": "embedded",
+            "$comment": "This is a fictional relation, added for testing purposes"
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -866,6 +866,7 @@ class TestEmbedTemporalTables:
             "ligtInWijkId": "03630012052035",
             "naam": None,
             "_embedded": {
+                "onderdeelVanGGWGebieden": [],  # reverse M2M relation, but no data in fixtures
                 "ligtInWijk": {
                     "_links": {
                         "schema": (
@@ -933,7 +934,7 @@ class TestEmbedTemporalTables:
                             "registratiedatum": None,
                         }
                     },
-                }
+                },
             },
         }
 
@@ -1349,6 +1350,7 @@ class TestEmbedTemporalTables:
                         },
                     }
                 ],
+                "onderdeelVanGGWGebieden": [],
             },
             "_links": {
                 "self": {
@@ -1592,6 +1594,7 @@ class TestEmbedTemporalTables:
                     "ligtInWijkId": "03630012052035",
                     "_embedded": {
                         "ligtInWijk": None,
+                        "onderdeelVanGGWGebieden": [],  # reverse m2m, but no fixture data given
                     },
                 }
             },

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1378,7 +1378,7 @@ class TestEmbedTemporalTables:
             "type": "urn:apiexception:parse_error",
         }
 
-    def test_detail_expand_true_for_nm_relation(
+    def test_detail_expand_true_for_m2m_relation(
         self, api_client, buurten_data, ggwgebieden_data, filled_router
     ):
         """Prove that bestaatUitBuurten shows up when expanded"""
@@ -1415,7 +1415,7 @@ class TestEmbedTemporalTables:
             }
         ]
 
-    def test_list_expand_true_for_nm_relation(
+    def test_list_expand_true_for_m2m_relation(
         self, api_client, buurten_data, ggwgebieden_data, woningbouwplannen_data, filled_router
     ):
         """Prove that buurt shows up when listview is expanded and uses the
@@ -1473,7 +1473,7 @@ class TestEmbedTemporalTables:
             "registratiedatum": None,
         }
 
-    def test_through_extra_fields_for_nm_relation(
+    def test_through_extra_fields_for_m2m_relation(
         self, api_client, buurten_data, ggpgebieden_data, filled_router
     ):
         """Prove that extra through fields are showing up


### PR DESCRIPTION
* Fixes reverse M2M walking
* Fixes 500 error for some datasets (without `many=True`, m2m was walked as a 1n relationship)
* Apply temporal filtering to have the proper results for the current date only.

(vereist nieuwe schematools release: https://github.com/Amsterdam/schema-tools/pull/239)