### PR TITLE
Get fresh network names on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,11 +108,15 @@ if (BRANCH == "master") {
    
     node {
         stage('OWASP vulnerability scan') {
+            // Get a fresh project name to prevent conflicts between concurrent builds.
+            gitHash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+            project = 'owasp_check_' + gitHash
+
             tryStep "owasp vulnerability check", {
-                sh  "docker-compose -p owasp_check -f src/.jenkins/owasp_vulnerability_scan/docker-compose.yml build --pull && " +
-                    "docker-compose -p owasp_check -f src/.jenkins/owasp_vulnerability_scan/docker-compose.yml run -u root --rm test"
+                sh  "docker-compose -p ${project} -f src/.jenkins/owasp_vulnerability_scan/docker-compose.yml build --pull && " +
+                    "docker-compose -p ${project} -f src/.jenkins/owasp_vulnerability_scan/docker-compose.yml run -u root --rm test"
             }, {
-                sh  "docker-compose -p owasp_check -f src/.jenkins/owasp_vulnerability_scan/docker-compose.yml down"
+                sh  "docker-compose -p ${project} -f src/.jenkins/owasp_vulnerability_scan/docker-compose.yml down"
             }
         }
     }


### PR DESCRIPTION
Add a docker-compose project name with git hash to create a unique
network in the OWASP step. This prevents the step to break because
a lingering network from a previous run with a non-unique name exists.

> Don't forget about...
> * Tests
> * Documentation in `docs/`, `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
