### PR TITLE
Fix accessing /v1/wfs/beheerkaart/basis/ due to camel-case dataset name

### DIFF
--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -221,7 +221,7 @@ class DynamicRouter(routers.DefaultRouter):
             dataset.schema
 
         for dataset in db_datasets:  # type: Dataset
-            dataset_id = dataset.schema.id  # not dataset.name!
+            dataset_id = dataset.schema.id  # not dataset.name which is mangled.
             new_models = {}
 
             for model in dataset.create_models(base_app_name="dso_api.dynamic_api"):
@@ -310,12 +310,13 @@ class DynamicRouter(routers.DefaultRouter):
         """Build the mvt views per dataset"""
         results = []
         for dataset in datasets:
+            dataset_id = dataset.schema.id  # not dataset.name which is mangled.
             results.append(
                 path(
                     "mvt/" + dataset.path + "/",
                     DatasetMVTSingleView.as_view(),
                     name="mvt-single-dataset",
-                    kwargs={"dataset_name": dataset.name},
+                    kwargs={"dataset_name": dataset_id},
                 )
             )
             results.append(
@@ -323,7 +324,7 @@ class DynamicRouter(routers.DefaultRouter):
                     "mvt/" + dataset.path + "/<table_name>/<int:z>/<int:x>/<int:y>.pbf",
                     DatasetMVTView.as_view(),
                     name="mvt-pbf",
-                    kwargs={"dataset_name": dataset.name},
+                    kwargs={"dataset_name": dataset_id},
                 )
             )
         return results
@@ -332,12 +333,13 @@ class DynamicRouter(routers.DefaultRouter):
         """Build the wfs views per dataset"""
         results = []
         for dataset in datasets:
+            dataset_id = dataset.schema.id  # not dataset.name which is mangled.
             results.append(
                 path(
                     "wfs/" + dataset.path + "/",
                     DatasetWFSView.as_view(),
                     name="wfs",
-                    kwargs={"dataset_name": dataset.name},
+                    kwargs={"dataset_name": dataset_id},
                 )
             )
         return results

--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -38,7 +38,7 @@ from django.utils.functional import cached_property
 from gisserver.exceptions import InvalidParameterValue
 from gisserver.features import ComplexFeatureField, FeatureField, FeatureType, ServiceDescription
 from gisserver.views import WFSView
-from schematools.contrib.django.models import Dataset, get_field_schema
+from schematools.contrib.django.models import Dataset, DynamicModel, get_field_schema
 
 from dso_api.dynamic_api.datasets import get_active_datasets
 from dso_api.dynamic_api.permissions import CheckPermissionsMixin
@@ -179,11 +179,11 @@ class DatasetWFSView(CheckPermissionsMixin, WFSView):
         return context
 
     def get_service_description(self, service: str) -> ServiceDescription:
-        dataset_name = self.kwargs["dataset_name"]
-        schema = Dataset.objects.get(name=dataset_name).schema
+        some_model: DynamicModel = next(iter(self.models.values()))
+        schema = some_model.get_dataset_schema()
 
         return ServiceDescription(
-            title=schema.title or dataset_name.title(),
+            title=schema.title or self.kwargs["dataset_name"].title(),
             abstract=schema.description,
             keywords=["wfs", "amsterdam", "datapunt"],
             provider_name="Gemeente Amsterdam",


### PR DESCRIPTION
The `beheerkaartBasis` dataset id was converted into `beheerkaart_basis` when it was accessed via the `Dataset.name` attribute.  This change also reduces the need for an extra query to get the description.