### PR TITLE
Fix the API index page, various API's were not listed due to resolve() issues.

### DIFF
--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -41,29 +41,28 @@ class DatasetMVTIndexView(APIIndexView):
         ]
 
     def get_environments(self, ds: Dataset, base: str):
+        api_url = reverse("dynamic_api:mvt-single-dataset", kwargs={"dataset_name": ds.schema.id})
         return [
             {
                 "name": "production",
-                "api_url": base
-                + reverse("dynamic_api:mvt-single-dataset", kwargs={"dataset_name": ds.name}),
-                "specification_url": base
-                + reverse("dynamic_api:mvt-single-dataset", kwargs={"dataset_name": ds.name}),
+                "api_url": base + api_url,
+                "specification_url": base + api_url,
                 "documentation_url": f"{base}/v1/docs/generic/mvt.html",
             }
         ]
 
     def get_related_apis(self, ds: Dataset, base: str):
-        related_apis = [
+        dataset_id = ds.schema.id
+        return [
             {
                 "type": "rest_json",
-                "url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
+                "url": base + reverse(f"dynamic_api:openapi-{dataset_id}"),
             },
             {
                 "type": "WFS",
-                "url": base + reverse("dynamic_api:wfs", kwargs={"dataset_name": ds.name}),
+                "url": base + reverse("dynamic_api:wfs", kwargs={"dataset_name": dataset_id}),
             },
         ]
-        return related_apis
 
 
 class DatasetMVTSingleView(TemplateView):

--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -96,30 +96,25 @@ class DatasetWFSIndexView(APIIndexView):
         ]
 
     def get_environments(self, ds: Dataset, base: str):
+        dataset_id = ds.schema.id
+        wfs_url = reverse("dynamic_api:wfs", kwargs={"dataset_name": dataset_id})
         return [
             {
                 "name": "production",
-                "api_url": base + reverse("dynamic_api:wfs", kwargs={"dataset_name": ds.name}),
-                "specification_url": base
-                + reverse("dynamic_api:wfs", kwargs={"dataset_name": ds.name})
-                + "?SERVICE=WFS&REQUEST=GetCapabilities",
+                "api_url": base + wfs_url,
+                "specification_url": f"{base}{wfs_url}?SERVICE=WFS&REQUEST=GetCapabilities",
                 "documentation_url": f"{base}/v1/docs/wfs-datasets/{ds.path}.html",
             }
         ]
 
     def get_related_apis(self, ds: Dataset, base: str):
-        related_apis = [
-            {
-                "type": "rest_json",
-                "url": base + reverse(f"dynamic_api:openapi-{ds.schema.id}"),
-            },
-            {
-                "type": "MVT",
-                "url": base
-                + reverse("dynamic_api:mvt-single-dataset", kwargs={"dataset_name": ds.name}),
-            },
+        dataset_id = ds.schema.id
+        json_url = reverse(f"dynamic_api:openapi-{dataset_id}")
+        mvt_url = reverse("dynamic_api:mvt-single-dataset", kwargs={"dataset_name": dataset_id})
+        return [
+            {"type": "rest_json", "url": base + json_url},
+            {"type": "MVT", "url": base + mvt_url},
         ]
-        return related_apis
 
 
 class DatasetWFSView(CheckPermissionsMixin, WFSView):

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -210,6 +210,7 @@ LOGGING = {
     "loggers": {
         "opencensus": {"handlers": ["console"], "level": DJANGO_LOG_LEVEL, "propagate": False},
         "django": {"handlers": ["console"], "level": DJANGO_LOG_LEVEL, "propagate": False},
+        "django.utils.autoreload": {"handlers": ["console"], "level": "INFO", "propagate": False},
         "dso_api": {"handlers": ["console"], "level": DSO_API_LOG_LEVEL, "propagate": False},
         "dso_api.audit": {
             "handlers": ["audit_console"],

--- a/src/templates/dso_api/dynamic_api/api.html
+++ b/src/templates/dso_api/dynamic_api/api.html
@@ -352,13 +352,13 @@
     if(page) {
       setPageLinks(page);
     }
-    getData(PAGEURL).catch(exceptionHandler).then(parseData);
+    getData(PAGEURL).catch(parseException).then(parseData);
 
     // Override the default DRF behaviour of the OPTIONS button,
     // which does not work with our script.
     // We make the request and replace the page content with the options response.
     document.getElementById("options-button").onclick = e => {
-      getData(PAGEURL, "OPTIONS").catch(exceptionHandler).then(parseData);
+      getData(PAGEURL, "OPTIONS").catch(parseException).then(parseData);
       e.preventDefault();
     }
   }
@@ -435,15 +435,15 @@
       http.setRequestHeader("Accept", "application/hal+json");
       http.send();
       http.onreadystatechange = function () {
-        if (this.readyState == 2){
+        if (this.readyState === 2){
             parseHeaders(this);
         }
-        if (this.readyState == 4){
-          let result = JSON.parse(this.responseText);
-          try {   
+        if (this.readyState === 4){
+          try {
+            let result = JSON.parse(this.responseText);
             callback(result);
           } catch (error) {
-              err("Error: JSON corrupt");
+            err([error, this.responseText]);
           }
         }
       }; 
@@ -479,8 +479,12 @@
     }
   }
 
-  function exceptionHandler(e) {
-    console.error("Failed to retrieve API response from server.");
+  function parseException(err) {
+    let exception = err[0], responseText = err[1];  // promises only allow 1 argument.
+    console.error("Failed to retrieve API response from server:", exception);
+
+    let contentElement = document.getElementById("response-content");
+    contentElement.innerHTML = responseText;
   }
 
   function parseData(data) {


### PR DESCRIPTION
* Fixed Django `Dataset.name` usage (which can be `snake_case@version` identifier). Use `dataset.schema.id` instead.
* Instead of hiding the dataset, give an empty `environments` and `related_apis` section.
* Show responseText on browsable API for HTTP 500 error.