### PR TITLE
MVT should pick main geometry

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -436,7 +436,7 @@ def geometry_auth_thing(geometry_auth_model):
     return geometry_auth_model.objects.create(
         id=1,
         metadata="secret",
-        geometry=Point(10, 10),
+        geometry_with_auth=Point(10, 10),
     )
 
 

--- a/src/tests/files/geometry_auth.json
+++ b/src/tests/files/geometry_auth.json
@@ -13,6 +13,7 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "required": ["id", "schema"],
+        "mainGeometry": "geometryWithAuth",
         "properties": {
           "id": {
             "type": "integer",
@@ -26,7 +27,7 @@
             "auth": "TEST/META",
             "description": ""
           },
-          "geometry": {
+          "geometryWithAuth": {
             "$ref": "https://geojson.org/schema/Point.json",
             "auth": "TEST/GEO",
             "description": "Geometrie"

--- a/src/tests/test_dynamic_api/test_views_wfs.py
+++ b/src/tests/test_dynamic_api/test_views_wfs.py
@@ -265,7 +265,7 @@ class TestDatasetWFSViewAuth:
         "scopes,expect",
         [
             ([], {"boundedBy": None, "id": "1"}),
-            (["TEST/GEO"], {"boundedBy": None, "id": "1", "geometry": None}),
+            (["TEST/GEO"], {"boundedBy": None, "id": "1", "geometry_with_auth": None}),
             (["TEST/META"], {"boundedBy": None, "id": "1", "metadata": "secret"}),
         ],
     )


### PR DESCRIPTION
It used to pick the first geometry it could find, which can fail when there are multiple geo fields.

For [AB#30007](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/30007).