### PR TITLE
[AB#30003] Use camelcase in test schemas and test against snake case

### DIFF
--- a/src/tests/files/afval.json
+++ b/src/tests/files/afval.json
@@ -34,16 +34,16 @@
             "type": "string",
             "description": "Serienummer van container"
           },
-          "eigenaar_naam": {
+          "eigenaarNaam": {
             "type": "string",
             "description": "Naam van eigenaar"
           },
-          "datum_creatie": {
+          "datumCreatie": {
             "type": "string",
             "format": "date",
             "description": "Datum aangemaakt"
           },
-          "datum_leegmaken": {
+          "datumLeegmaken": {
             "type": "string",
             "format": "date-time",
             "description": "Datum leeggemaakt"

--- a/src/tests/files/parkeervakken.json
+++ b/src/tests/files/parkeervakken.json
@@ -42,7 +42,7 @@
             "type": "string",
             "description": ""
           },
-          "e_type": {
+          "eType": {
             "type": "string",
             "description": ""
           },
@@ -62,7 +62,7 @@
                   "type": "string",
                   "description": ""
                 },
-                "e_type": {
+                "eType": {
                   "type": "string",
                   "description": ""
                 },

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -4,6 +4,7 @@ import pytest
 from django.apps import apps
 from django.contrib.gis.geos import GEOSGeometry
 from rest_framework.exceptions import ValidationError
+from rest_framework.status import HTTP_400_BAD_REQUEST
 from rest_framework.test import APIClient
 
 from dso_api.dynamic_api.filterset import filterset_factory
@@ -199,6 +200,14 @@ class TestDynamicFilterSet:
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 1
         assert data["_embedded"]["parkeervakken"][0]["id"] == "121138489006"
+
+    @staticmethod
+    @pytest.mark.parametrize("params", [{"e_type": "whatever"}, {"_sort": "e_type"}])
+    def test_snake_case_400(params, parkeervakken_parkeervak_model):
+        """Filter names match property names in the schema.
+        We no longer accept snake-cased property names."""
+        response = APIClient().get("/v1/parkeervakken/parkeervakken/", data=params)
+        assert response.status_code == HTTP_400_BAD_REQUEST
 
     @staticmethod
     def test_subobject_filters(verblijfsobjecten_model, verblijfsobjecten_data):

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -518,7 +518,7 @@ class TestAuth:
     ):
         """Prove that protected fields are shown
         with an auth scope and there is a valid token"""
-        patch_field_auth(afval_schema, "containers", "eigenaar_naam", auth=["BAG/R"])
+        patch_field_auth(afval_schema, "containers", "eigenaarNaam", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         token = fetch_auth_token(["BAG/R"])
         response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
@@ -533,7 +533,7 @@ class TestAuth:
     ):
         """Prove that protected fields are shown
         with an auth scope connected to Profile that gives access to specific field."""
-        patch_field_auth(afval_schema, "containers", "eigenaar_naam", auth=["BAG/R"])
+        patch_field_auth(afval_schema, "containers", "eigenaarNaam", auth=["BAG/R"])
         models.Profile.create_for_schema(
             ProfileSchema.from_dict(
                 {
@@ -544,7 +544,7 @@ class TestAuth:
                             "tables": {
                                 "containers": {
                                     "fields": {
-                                        "eigenaar_naam": "read",
+                                        "eigenaarNaam": "read",
                                     }
                                 }
                             }
@@ -567,7 +567,7 @@ class TestAuth:
     ):
         """Prove that protected fields are *not* shown
         with an auth scope and there is not a valid token"""
-        patch_field_auth(afval_schema, "containers", "eigenaar_naam", auth=["BAG/R"])
+        patch_field_auth(afval_schema, "containers", "eigenaarNaam", auth=["BAG/R"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         response = api_client.get(url)
         data = read_response_json(response)
@@ -774,12 +774,12 @@ class TestAuth:
         assert response.status_code == 200, response.data
 
     def test_sort_auth(self, api_client, afval_schema, afval_container, filled_router):
-        patch_field_auth(afval_schema, "containers", "datum_creatie", auth=["SEE/CREATION"])
+        patch_field_auth(afval_schema, "containers", "datumCreatie", auth=["SEE/CREATION"])
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        response = api_client.get(f"{url}?_sort=datum_creatie")
+        response = api_client.get(f"{url}?_sort=datumCreatie")
         data = read_response_json(response)
         assert response.status_code == 403, data
-        assert "access denied to field datum_creatie" in data["title"]
+        assert "access denied to field datumCreatie" in data["title"]
 
     def test_sort_by_not_accepting_db_column_names(
         self, api_client, afval_container, filled_router

--- a/src/tests/test_dynamic_api/test_views_mvt.py
+++ b/src/tests/test_dynamic_api/test_views_mvt.py
@@ -122,6 +122,9 @@ def test_mvt_content(api_client, afval_container, filled_router):
                 {
                     "geometry": {"type": "Point", "coordinates": [4171, 1247]},
                     "properties": {
+                        # TODO These are snake-cased database field names.
+                        # We should return schema field names instead.
+                        # Also, what happens in the case of relations?
                         "id": 1,
                         "cluster_id": "c1",
                         "serienummer": "foobar-123",


### PR DESCRIPTION
Snake case shouldn't occur anymore. The code already didn't handle it when the schema properties were properly cased.

MVT gets the property names wrong (AB#30028). Added a TODO comment to remind of us that fact.

This shows that many of the case conversions are already doing nothing. They'll get removed in follow-up PRs.