### PR TITLE
[AB#24838, AB#30003] Fix types in parkeervakken test schema

### DIFF
--- a/src/tests/files/parkeervakken.json
+++ b/src/tests/files/parkeervakken.json
@@ -79,19 +79,23 @@
                   "description": ""
                 },
                 "begintijd": {
-                  "type": "time",
+                  "type": "string",
+                  "format": "time",
                   "description": ""
                 },
                 "eindtijd": {
-                  "type": "time",
+                  "type": "string",
+                  "format": "time",
                   "description": ""
                 },
                 "begindatum": {
-                  "type": "date",
+                  "type": "string",
+                  "format": "date",
                   "description": ""
                 },
                 "einddatum": {
-                  "type": "date",
+                  "type": "string",
+                  "format": "date",
                   "description": ""
                 },
                 "dagen": {


### PR DESCRIPTION
This schema breaks the new filters, which look at the types in the schema instead of in the DB.