### PR TITLE
Remove test for is_unfiltered (AB#24838)

### DIFF
--- a/src/tests/test_rest_framework_dso/test_filters.py
+++ b/src/tests/test_rest_framework_dso/test_filters.py
@@ -109,13 +109,3 @@ class TestDSOFilterSet:
         assert filterset.is_valid(), filterset.errors
         qs = filterset.filter_queryset(Movie.objects.all())
         assert {obj.name for obj in qs} == expect, str(qs.query)
-
-
-class TestDSOFilterBackend:
-    def test_is_unfiltered(self, api_rf):
-        """Prove that is_unfiltered() correctly detects non-standard fields"""
-        backend = DSOFilterBackend()
-        assert backend.is_unfiltered(api_rf.get("/", data={"_format": "csv", "_fields": "foo"}))
-        assert backend.is_unfiltered(api_rf.get("/", data={"_pageSize": "100", "_format": "csv"}))
-
-        assert not backend.is_unfiltered(api_rf.get("/", data={"field[in]": "foo"}))


### PR DESCRIPTION
Preliminary cleanup for [AB#24838](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/24838): this function is going to disappear and I'm porting all of these tests to use new filters (based on schemas instead of models). Removing this one first to make the final diff smaller.