### PR TITLE
Don't default to test JWKS (AB#38587)

### DIFF
--- a/dev-docs/source/auth.rst
+++ b/dev-docs/source/auth.rst
@@ -142,12 +142,17 @@ Testing
 -------
 
 When testing datasets with authorization from the command line
-you can use the `maketoken` management command, that generates 
+you can use the `maketoken` management command, which generates
 a test token for the provided scope(s).
 
 This requires DSO-API to be installed in the current virtualenv
-(``cd src && pip install -e .``).
-You can now issue a curl command such as
+(``cd src && pip install -e .``) and the test JWKS to be in the environment.
+After setting the latter with
+::
+
+    export PUB_JWKS="$(cat jwks_test.json)"  # in src/
+
+you can issue a curl command such as
 ::
 
     curl http://localhost:8000/v1/haalcentraal/brk/kadastraalonroerendezaken/${id}/ \

--- a/dev-docs/source/auth.rst
+++ b/dev-docs/source/auth.rst
@@ -158,3 +158,6 @@ you can issue a curl command such as
 
     curl http://localhost:8000/v1/haalcentraal/brk/kadastraalonroerendezaken/${id}/ \
         --header "Authorization: Bearer ${token}"
+
+The test token expires after half an hour by default.
+Run ``python manage.py maketoken --help`` to see how to change that.

--- a/dev-docs/source/auth.rst
+++ b/dev-docs/source/auth.rst
@@ -147,13 +147,14 @@ a test token for the provided scope(s).
 
 This requires DSO-API to be installed in the current virtualenv
 (``cd src && pip install -e .``) and the test JWKS to be in the environment.
-After setting the latter with
+After setting the latter and getting a token with
 ::
 
     export PUB_JWKS="$(cat jwks_test.json)"  # in src/
+    token=$(python manage.py maketoken BRK/RSN)
 
 you can issue a curl command such as
 ::
 
     curl http://localhost:8000/v1/haalcentraal/brk/kadastraalonroerendezaken/${id}/ \
-        --header "Authorization: Bearer $(python manage.py maketoken BRK/RSN)"
+        --header "Authorization: Bearer ${token}"

--- a/dev-docs/source/howto/install.rst
+++ b/dev-docs/source/howto/install.rst
@@ -103,7 +103,8 @@ To address the error we need to mark that dataset as a proxy to another URL::
 Run the server
 --------------
 
-The server needs a JSON Web Key Set (JWKS) to do authorization.
+The server needs a JSON Web Key Set (JWKS) to perform authorization,
+even when authorized endpoints aren't used; it refuses to start without one.
 For testing and development, use the one in ``jwks_test.json``:
 
 ::

--- a/dev-docs/source/howto/install.rst
+++ b/dev-docs/source/howto/install.rst
@@ -103,8 +103,16 @@ To address the error we need to mark that dataset as a proxy to another URL::
 Run the server
 --------------
 
+The server needs a JSON Web Key Set (JWKS) to do authorization.
+For testing and development, use the one in ``jwks_test.json``:
+
+::
+    export PUB_JWKS="$(cat jwks_test.json)"
+
+Then start DSO-API:
+
 ::
 
     ./manage.py runserver localhost:8000
 
-The API can now be accessed at: http://localhost:8000
+The API can now be accessed at: http://localhost:8000.

--- a/src/dso_api/dynamic_api/management/commands/maketoken.py
+++ b/src/dso_api/dynamic_api/management/commands/maketoken.py
@@ -11,7 +11,7 @@ from jwcrypto.jwt import JWT
 
 
 class Command(BaseCommand):
-    """Generate a JWT test token."""
+    """maketoken command: generates a JWT test token."""
 
     help = """Generate a JWT test token to test endpoints that are protected by an auth scope.
         See for usage: https://dso-api.readthedocs.io/en/latest/auth.html#testing
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
         It creates a JWT test token with the provided scopes and validity.
         """
-        key = JWK(**json.loads(settings.JWKS_TEST_KEY)["keys"][0])
+        key = JWK(**json.loads(settings.DATAPUNT_AUTHZ["JWKS"])["keys"][0])
         scopes = list(set(args))
         now = int(time.time())
         claims = {

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -362,29 +362,8 @@ These are located at:
 
 # -- Amsterdam oauth settings
 
-# The following JWKS data was obtained in the authz project :  jwkgen -create -alg ES256
-# This is a test public/private key def and added for testing .
-JWKS_TEST_KEY = """
-    {
-        "keys": [
-            {
-                "kty": "EC",
-                "key_ops": [
-                    "verify",
-                    "sign"
-                ],
-                "kid": "2aedafba-8170-4064-b704-ce92b7c89cc6",
-                "crv": "P-256",
-                "x": "6r8PYwqfZbq_QzoMA4tzJJsYUIIXdeyPA27qTgEJCDw=",
-                "y": "Cf2clfAfFuuCB06NMfIat9ultkMyrMQO9Hd2H7O9ZVE=",
-                "d": "N1vu0UQUp0vLfaNeM0EDbl4quvvL6m_ltjoAXXzkI3U="
-            }
-        ]
-    }
-"""
-
 DATAPUNT_AUTHZ = {
-    "JWKS": os.getenv("PUB_JWKS", JWKS_TEST_KEY),
+    "JWKS": os.getenv("PUB_JWKS"),
     "JWKS_URL": os.getenv("OAUTH_JWKS_URL"),
     # "ALWAYS_OK": True if DEBUG else False,
     "ALWAYS_OK": False,

--- a/src/jwks_test.json
+++ b/src/jwks_test.json
@@ -1,0 +1,16 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "key_ops": [
+        "verify",
+        "sign"
+      ],
+      "kid": "2aedafba-8170-4064-b704-ce92b7c89cc6",
+      "crv": "P-256",
+      "x": "6r8PYwqfZbq_QzoMA4tzJJsYUIIXdeyPA27qTgEJCDw=",
+      "y": "Cf2clfAfFuuCB06NMfIat9ultkMyrMQO9Hd2H7O9ZVE=",
+      "d": "N1vu0UQUp0vLfaNeM0EDbl4quvvL6m_ltjoAXXzkI3U="
+    }
+  ]
+}

--- a/src/tests/settings.py
+++ b/src/tests/settings.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from dso_api.settings import *
 
 # The reason the settings are defined here, is to make them independent
@@ -24,6 +26,16 @@ CACHES = {
 
 CSRF_COOKIE_SECURE = False
 SESSION_COOKIE_SECURE = False
+
+# Load public/private test key pair.
+# This was obtained in the authz project with: jwkgen -create -alg ES256
+jwks_key = Path(__file__).parent.parent.joinpath("jwks_test.json").read_text()
+
+DATAPUNT_AUTHZ = {
+    "JWKS": jwks_key,
+    "ALWAYS_OK": False,
+    "MIN_INTERVAL_KEYSET_UPDATE": 30 * 60,  # 30 minutes
+}
 
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 


### PR DESCRIPTION
The test key belongs in src/tests/settings.py, not the main settings.py. It also needs to be set when developing on the command line, or DSO-API fails to start with an AuthzConfigurationError. This is inconvenient, but much safer than the old setup.