### PR TITLE
Disable deployment of dso-api-docs on ACC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,7 @@ if (BRANCH == "master") {
                     [$class: 'StringParameterValue', name: 'PLAYBOOKPARAMS', value: "-e cmdb_id=app_dso-api"]
                 ]
             }
+            /* Commented out to work around an issue with deployment of dso-api-docs on ACC.
             tryStep "deployment", {
                 build job: 'Subtask_Openstack_Playbook',
                 parameters: [
@@ -103,6 +104,7 @@ if (BRANCH == "master") {
                     [$class: 'StringParameterValue', name: 'PLAYBOOKPARAMS', value: "-e cmdb_id=app_dso-api-docs"]
                 ]
             }
+            */
         }
     }
    


### PR DESCRIPTION
To work around the recent issues. The docs image is still deployed on PROD. Quasi-permanent version of #487 so the deployment issue does not become an impediment.