### PR TITLE
Restore mandatoryFilters handling, fix test

### DIFF
--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -274,12 +274,12 @@ class TestSort:
             "instance": "http://testserver/v1/movies/movie/?_sort=category",
             "invalid-params": [
                 {
-                    "type": "urn:apiexception:invalid:order-by",
-                    "name": "order-by",
-                    "reason": "Invalid sort fields: category",
+                    "type": "urn:apiexception:invalid:invalid",
+                    "name": "invalid",
+                    "reason": "'category' does not refer to a field",
                 }
             ],
-            "x-validation-errors": ["Invalid sort fields: category"],
+            "x-validation-errors": ["'category' does not refer to a field"],
         }
 
 


### PR DESCRIPTION
The main part of this PR is a partial revert of 8609348380047381e14c14c31ad498814ca7eb54. I removed too much of the `mandatoryFilters` handling, breaking a test.

The issue here is that when a filter is mandatory, it must also be allowed, regardless of whether the field being used to filter is accessible. This may be something that we need to rethink, but for now, this test needs to pass.