### PR TITLE
Fix auth check on composite relation fields

### DIFF
--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -203,18 +203,28 @@ def _check_field_access(  # noqa: C901
             raise
 
         # First check the field, then check whether it's a relation,
-        # so we can auth-check the relation and the thing it points to.
+        # so we can auth-check the relation and the thing(s) it points to.
         if not scopes.has_field_access(schema):
             raise PermissionDenied(f"access denied to field {schema.id} with scopes {scopes}")
 
         if rel := schema.related_table:
             rel = cast(DatasetTableSchema, rel)
-            (ident,) = schema.related_field_ids  # Must be a single identifier.
-            schema = rel.get_field_by_id(ident)
+            idents = schema.related_field_ids
+            for ident in idents:
+                schema = rel.get_field_by_id(ident)
+                # scopes.has_field_access also checks table and dataset access.
+                if not scopes.has_field_access(schema):
+                    raise PermissionDenied(
+                        f"access denied to field {schema.id} with scopes {scopes}"
+                    )
 
-            # scopes.has_field_access also checks table and dataset access.
-            if not scopes.has_field_access(schema):
-                raise PermissionDenied(f"access denied to field {schema.id} with scopes {scopes}")
+            if len(idents) > 1:
+                # Relations with composite keys use the table name as the last part of the filter
+                # and specify the field values as "id1.id2.id3".
+                if field_name != "":
+                    raise FilterSyntaxError("")
+                return
+
             schema = rel
 
     # If we're still, or again, at a DatasetTableSchema, then either field_name was empty

--- a/src/tests/files/relationauthcomposite.json
+++ b/src/tests/files/relationauthcomposite.json
@@ -1,0 +1,96 @@
+{
+  "id": "relationauthcomposite",
+  "type": "dataset",
+  "description": "Test filter authorization on relations within a dataset",
+  "license": "public",
+  "status": "beschikbaar",
+  "version": "1.2.3",
+  "publisher": "us",
+  "owner": "us",
+  "authorizationGrantor": "us",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "base",
+      "type": "table",
+      "title": "Base",
+      "auth": [
+        "BASE"
+      ],
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": [
+          "id",
+          "volgnr"
+        ],
+        "required": [
+          "schema",
+          "id"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "auth": [
+              "BASE/ID"
+            ],
+            "type": "integer",
+            "description": "Unieke aanduiding van het record."
+          },
+          "volgnr": {
+            "auth": [
+              "BASE/VOLGNR"
+            ],
+            "type": "integer",
+            "description": "Volgnummer"
+          }
+        }
+      }
+    },
+    {
+      "id": "refers",
+      "type": "table",
+      "title": "Refers",
+      "auth": [
+        "REFERS"
+      ],
+      "version": "1.2.4",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "name",
+          "base"
+        ],
+        "display": "name",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "name": {
+            "description": "Name",
+            "type": "string",
+            "auth": [
+              "REFERS/NAME"
+            ]
+          },
+          "base": {
+            "description": "Reference to base",
+            "type": "integer",
+            "auth": [
+              "REFERS/BASE"
+            ],
+            "relation": "relationauthcomposite:base"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Relations with composite keys would error out with 500 because the auth/validation check assumed `DatasetFieldSchema.related_field_ids` would return a single value. That is obviously not true for such fields.