### PR TITLE
WFS fixes

### DIFF
--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -35,7 +35,7 @@ from django.db import models
 from django.http import Http404
 from django.urls import reverse
 from django.utils.functional import cached_property
-from gisserver.exceptions import InvalidParameterValue
+from gisserver.exceptions import InvalidParameterValue, PermissionDenied
 from gisserver.features import ComplexFeatureField, FeatureField, FeatureType, ServiceDescription
 from gisserver.views import WFSView
 from schematools.contrib.django.models import Dataset, DynamicModel, get_field_schema
@@ -73,6 +73,11 @@ class AuthenticatedFeatureType(FeatureType):
                 models.append(related_model)
 
         self.wfs_view.check_permissions(request, models)
+
+        # If the main geometry is hidden behind an access scope,
+        # accessing the WFS feature is moot (and risks exposure through direct model access)
+        if not self.geometry_fields:
+            raise PermissionDenied("typeNames")
 
 
 class DatasetWFSIndexView(APIIndexView):

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -4,7 +4,7 @@ django-cors-headers == 3.7.0
 django-filter == 2.4.0
 django-healthchecks == 1.4.2
 django-postgres-unlimited-varchar == 1.1.0
-django-gisserver == 1.1.3
+django-gisserver == 1.2.1
 django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -59,7 +59,7 @@ django-environ==0.4.5
     #   amsterdam-schema-tools
 django-filter==2.4.0
     # via -r requirements.in
-django-gisserver==1.1.3
+django-gisserver==1.2.1
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
@@ -151,8 +151,10 @@ jwcrypto==0.8
     # via datapunt-authorization-django
 lark-parser==0.11.2
     # via mappyfile
-lru_dict==1.1.7
-    # via -r requirements.in
+lru-dict==1.1.7
+    # via
+    #   -r requirements.in
+    #   django-gisserver
 mapbox-vector-tile==1.2.1
     # via -r requirements.in
 mappyfile==0.9.1

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -117,7 +117,22 @@ def read_response_partial(response: HttpResponseBase) -> tuple[str, Optional[Exc
 
 def xml_element_to_dict(element: ET.Element) -> dict:
     """Convert an XML element to a Python dictionary."""
-    return {child.tag.split("}")[1]: child.text for child in element}
+    if not len(element):
+        # for recusion into children
+        local_name = element.tag.split("}")[1]
+        return {local_name: element.text}
+
+    result = {}
+    for child in element:
+        local_name = child.tag.split("}")[1]
+        if len(child) == 0:
+            result[local_name] = child.text
+        elif len(child) == 1:
+            result[local_name] = xml_element_to_dict(child)
+        else:
+            result[local_name] = [xml_element_to_dict(e) for e in child]
+
+    return result
 
 
 def normalize_data(data):


### PR DESCRIPTION
* Hide temporal records from WFS
* Hide parent/through tables in `?expand=..` summary.
* Give 403 forbidden when geometry field is not accessible, so no accidental exposure anymore
* Improve tests so see what sub-objects are returned (`boundedBy` / `geometry`)