### PR TITLE
settings: replace os.getenv() with env.str() so proper error messages are given.

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -374,8 +374,8 @@ These are located at:
 # -- Amsterdam oauth settings
 
 DATAPUNT_AUTHZ = {
-    "JWKS": os.getenv("PUB_JWKS"),
-    "JWKS_URL": os.getenv("OAUTH_JWKS_URL"),
+    "JWKS": env.str("PUB_JWKS"),
+    "JWKS_URL": env.url("OAUTH_JWKS_URL"),
     # "ALWAYS_OK": True if DEBUG else False,
     "ALWAYS_OK": False,
     "MIN_INTERVAL_KEYSET_UPDATE": 30 * 60,  # 30 minutes


### PR DESCRIPTION
The settings `PUB_JWKS` and `OAUTH_JWKS_URL` are required in DSO-API.

If these are none, the error message will show a missing `JWKS` and `JWKS_URL` variable from authorization_django, which are not the correct setting names.