### PR TITLE
Update base images to bullseye release

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-buster as builder
+FROM python:3.9-bullseye as builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python:3.9-buster AS builder
+FROM amsterdam/python:3.9-bullseye AS builder
 MAINTAINER datapunt@amsterdam.nl
 
 COPY requirements* ./
@@ -6,7 +6,7 @@ ARG PIP_REQUIREMENTS=requirements.txt
 RUN pip install --no-cache-dir -r $PIP_REQUIREMENTS
 
 # Start runtime image,
-FROM amsterdam/python:3.9-slim-buster
+FROM amsterdam/python:3.9-slim-bullseye
 RUN apt update && apt install --no-install-recommends -y curl
 
 # Copy python build artifacts from builder image


### PR DESCRIPTION
Update the base images to the bullseye release to fix the CVE's below:

- Debian Security Update for expat (DSA 5085-2)
- Debian Security Update for Open Secure Sockets Layer (OpenSSL) (DSA 5103-1)
- GNU Bash Privilege Escalation Vulnerability for Debian
- Debian Security Update for tiff (DSA 5108-1)
- Debian Security Update for zlib (DSA 5111-1)