### PR TITLE
Rename FieldsToDisplay.__bool__ to FieldsToDisplay.reduced

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -403,11 +403,11 @@ class DynamicBodySerializer(DynamicSerializer):
         # itself as that creates a cross-dependency between the parent/child.fields property.
         links_field = fields.get("_links")
         if links_field is not None and isinstance(links_field, DynamicLinksSerializer):
-            if fields_to_display := self.fields_to_display:  # checks __bool__ for allow_all
+            if self.fields_to_display.reduced():
                 # The 'invalid_fields' is not checked against here, as that already happened
                 # for the top-level fields reduction.
                 main_and_links_fields = self.get_valid_field_names(fields)
-                fields_to_keep, _ = fields_to_display.get_allow_list(main_and_links_fields)
+                fields_to_keep, _ = self.fields_to_display.get_allow_list(main_and_links_fields)
                 fields_to_keep.update(links_field.fields_always_included)
                 links_field.fields = {
                     name: field

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -71,7 +71,7 @@ class FieldsToDisplay:
         else:
             return "<FieldsToDisplay: deny all>"
 
-    def __bool__(self):
+    def reduced(self):
         """Whether the returned fields need to be reduced.
         Note that this returns false when there are child nodes that need to be reduced.
         These are found with :meth:`allow_nested`, :meth:`as_nested` and :attr:`children`.

--- a/src/tests/test_rest_framework_dso/test_fields.py
+++ b/src/tests/test_rest_framework_dso/test_fields.py
@@ -12,9 +12,9 @@ class TestFieldsToDisplay:
     """Prove whether the 'FieldsToDisplay' tool really works"""
 
     def test_allow_all(self):
-        """Prove that having no fields to filter evaluates to false"""
-        assert not FieldsToDisplay()
-        assert not ALLOW_ALL_FIELDS_TO_DISPLAY
+        """Prove that having no fields to filter is handled correctly."""
+        assert not FieldsToDisplay().reduced()
+        assert not ALLOW_ALL_FIELDS_TO_DISPLAY.reduced()
         assert repr(FieldsToDisplay()) == "<FieldsToDisplay: allow all>"
         assert ALLOW_ALL_FIELDS_TO_DISPLAY.get_allow_list(set("abc")) == ({"a", "b", "c"}, set())
 


### PR DESCRIPTION
Explicit is better than implicit: this way, the method has a name indicating what it does, and we no longer need a reminder at the call site that we overloaded `__bool__` with a meaning that is not obvious. Also, PyCharm can find the method's call site, which it can't for `__bool__` without extensive type annotations.