### PR TITLE
Port permissions.parse_filter to new filter parser

### DIFF
--- a/src/dso_api/dynamic_api/filters/__init__.py
+++ b/src/dso_api/dynamic_api/filters/__init__.py
@@ -4,4 +4,5 @@ from .backends import DynamicFilterBackend, DynamicOrderingFilter
 __all__ = (
     "DynamicFilterBackend",
     "DynamicOrderingFilter",
+    "FilterInput",
 )

--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -101,7 +101,7 @@ class FilterInput:
             path = key
             lookup = None
         elif not key.endswith("]"):
-            raise ValidationError(f"missing closing bracket (]) in {key!r}")
+            raise ValidationError(f"last character of {key!r} must be closing bracket (])")
         elif bracket == 0:
             raise ValidationError(f"empty field path in {key!r}")
         else:

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -125,31 +125,6 @@ class HasOAuth2Scopes(permissions.BasePermission):
         return access
 
 
-def parse_filter(v: str) -> tuple[str, str]:
-    """Given a filter query parameter, returns the field name and operator.
-
-    Does not validate the operator.
-
-    E.g.,
-        parse_filter("foo") == ("foo", "exact")
-        parse_filter("foo[contains]") == ("foo", "contains")
-    """
-    bracket = v.find("[")
-    if bracket == -1:
-        if "]" in v:
-            # Close bracket but no open bracket. Brackets don't occur in field names.
-            raise ValueError(f"missing open bracket ([) in {v!r}")
-        field_name = v
-        op = "exact"
-    elif not v.endswith("]"):
-        raise ValueError(f"missing closing bracket (]) in {v!r}")
-    else:
-        field_name = v[:bracket]
-        op = v[bracket + 1 : -1]
-
-    return field_name, op
-
-
 class CheckPermissionsMixin:
     """Mixin that adds a ``check_permissions()`` function to the view,
     which supports the DRF-plugins for permission checks on a non-DRF view (e.g. WFS/MVT).

--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -21,7 +21,7 @@ from rest_framework.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from schematools.types import DatasetTableSchema
 from urllib3 import HTTPResponse
 
-from dso_api.dynamic_api.permissions import parse_filter
+from dso_api.dynamic_api.filters import FilterInput
 from rest_framework_dso.crs import CRS
 from rest_framework_dso.exceptions import (
     BadGateway,
@@ -289,13 +289,11 @@ class HaalCentraalClient(RemoteClient):
                 raise ValidationError(f"unknown filter {p!r}")
 
             try:
-                p, op = parse_filter(p)
-            except ValueError as e:
-                raise ValidationError(str(e)) from e
-            if op != "exact":
-                raise ValidationError(f"filter operator {op!r} not supported")
+                filt = FilterInput.from_parameter(p, [])
+            if filt.lookup not in [None, "exact"]:
+                raise ValidationError(f"filter operator {filt.lookup!r} not supported")
 
-            remote_params[p] = v
+            remote_params[filt.path] = v
 
         return super()._make_url(path, remote_params)
 


### PR DESCRIPTION
And use it in the remote filters, so we no longer have two implementations.