### PR TITLE
AB#47079 Fix government_only field in index

### DIFF
--- a/src/dso_api/dynamic_api/views/index.py
+++ b/src/dso_api/dynamic_api/views/index.py
@@ -74,7 +74,7 @@ class APIIndexView(APIView):
                 "description": ds.schema.description or "",
                 "tags": ds.schema.get("theme", []),
                 "terms_of_use": {
-                    "government_only": "auth" in ds.schema,
+                    "government_only": "OPENBAAR" not in ds.schema.auth,
                     "pay_per_use": False,
                     "license": ds.schema.license,
                 },


### PR DESCRIPTION
The government_only field just checked whether a schema
contained an auth field. Now that this field is mandatory it should
check for "OPENBAAR" in the auth field.

> Don't forget about...
> * Tests
> * Documentation in `docs/`, `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
