### PR TITLE
Implemented reverse-relation support in the new filter engine

### DIFF
--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -21,7 +21,7 @@ from rest_framework.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from schematools.types import DatasetTableSchema
 from urllib3 import HTTPResponse
 
-from dso_api.dynamic_api.permissions import FilterSyntaxError, parse_filter
+from dso_api.dynamic_api.permissions import parse_filter
 from rest_framework_dso.crs import CRS
 from rest_framework_dso.exceptions import (
     BadGateway,
@@ -294,7 +294,7 @@ class HaalCentraalClient(RemoteClient):
 
             try:
                 p, op = parse_filter(p)
-            except FilterSyntaxError as e:
+            except ValueError as e:
                 raise ValidationError(str(e)) from e
             if op != "exact":
                 raise ValidationError(f"filter operator {op!r} not supported")

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -18,12 +18,9 @@ from django.db import models
 from django.http import Http404, JsonResponse
 from django.utils.translation import gettext as _
 from rest_framework import viewsets
-from rest_framework.exceptions import ValidationError
 from schematools.contrib.django.models import DynamicModel
-from schematools.exceptions import SchemaObjectNotFound
 
 from dso_api.dynamic_api import filters, locking, permissions, serializers
-from dso_api.dynamic_api.permissions import FilterSyntaxError
 from dso_api.dynamic_api.temporal import TemporalTableQuery
 from rest_framework_dso.views import DSOViewMixin
 
@@ -96,13 +93,12 @@ class DynamicApiViewSet(locking.ReadLockMixin, DSOViewMixin, viewsets.ReadOnlyMo
     def initial(self, request, *args, **kwargs):
         super().initial(request, *args, **kwargs)
         table_schema = self.model.table_schema()
-        try:
-            permissions.validate_request(request, table_schema, self._NON_FILTER_PARAMS)
-        except FilterSyntaxError as e:
-            raise ValidationError(str(e)) from e
-        except SchemaObjectNotFound as e:
-            raise ValidationError(str(e)) from e
-        self.temporal = TemporalTableQuery(request, table_schema)
+
+        if request.method == "OPTIONS":
+            # No permission checks for metadata inquiry
+            self.temporal = None
+        else:
+            self.temporal = TemporalTableQuery(request, table_schema)
 
     @cached_property
     def lookup_field(self):

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 3.6.3
+amsterdam-schema-tools[django] == 3.6.4
 datapunt-authorization-django==1.3.2
 drf-spectacular == 0.15.0
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==3.6.3
+amsterdam-schema-tools[django]==3.6.4
     # via -r requirements.in
 asgiref==3.3.4
     # via django

--- a/src/tests/files/movies.json
+++ b/src/tests/files/movies.json
@@ -55,6 +55,14 @@
         "identifier": "id",
         "required": ["name"],
         "display": "name",
+        "additionalRelations": {
+          "movies": {
+            "table": "movie",
+            "field": "actors",
+            "format": "expanded",
+            "$comment": "Reverse M2M back to movies"
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.2#/definitions/schema"
@@ -78,6 +86,14 @@
         "identifier": "id",
         "required": ["name"],
         "display": "name",
+        "additionalRelations": {
+          "movies": {
+            "table": "movie",
+            "field": "category",
+            "format": "expanded",
+            "$comment": "Reverse FK back to movies"
+          }
+        },
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.2#/definitions/schema"


### PR DESCRIPTION
This replaces some functions to use a FilterPathPart that will handle
both a DatasetFieldSchema and AdditionalRelationSchema object. These
objects differ tremendously in their API and usage.

The early requests permissions check are removed, as the filters already do this.
This also avoids double-parsing the request, and double bookkeeping
when new features are added to the filter engine.