### PR TITLE
Show all relation values in the _links, even if they are null (reverts AB#7538)

### DIFF
--- a/src/dso_api/dynamic_api/serializers.py
+++ b/src/dso_api/dynamic_api/serializers.py
@@ -536,11 +536,6 @@ class DynamicLinksSerializer(DynamicSerializer):
         """
         return False
 
-    def to_representation(self, validated_data):
-        """Hide "None" and empty list [] values in the _links section."""
-        data = super().to_representation(validated_data)
-        return {field: value for field, value in data.items() if value}
-
 
 def get_view_name(model: type[DynamicModel], suffix: str):
     """Return the URL pattern for a dynamically generated model.

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -197,6 +197,7 @@ class TestDynamicSerializer:
                     "title": "3",
                     "id": 3,
                 },
+                "cluster": None,
             },
             "id": 3,
             "clusterId": None,
@@ -235,6 +236,7 @@ class TestDynamicSerializer:
                     "id": 4,
                 },
                 "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#containers",  # noqa: E501
+                "cluster": None,
             },
             "id": 4,
             "clusterId": 99,
@@ -447,6 +449,7 @@ class TestDynamicSerializer:
                     "title": "3",
                     "id": 3,
                 },
+                "vestigingenBezoek": [],
                 "vestigingenPost": [
                     {
                         "href": "http://testserver/v1/vestiging/vestiging/1/",

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -932,6 +932,7 @@ class TestEmbedTemporalTables:
                     "title": "03630012052035.1",
                     "volgnummer": 1,
                 },
+                "onderdeelVanGGWGebieden": [],
                 "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
                 "self": {
                     "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2",
@@ -1196,6 +1197,7 @@ class TestEmbedTemporalTables:
                                         "title": "03630012052035.1",
                                         "volgnummer": 1,
                                     },
+                                    "onderdeelVanGGWGebieden": [],
                                 },
                                 "id": "03630000000078.2",
                                 "naam": None,
@@ -1311,6 +1313,7 @@ class TestEmbedTemporalTables:
                     "title": "03630012052035.1",
                     "volgnummer": 1,
                 },
+                "onderdeelVanGGWGebieden": [],
                 "schema": "https://schemas.data.amsterdam.nl/datasets/gebieden/dataset#buurten",
                 "self": {
                     "href": "http://testserver/v1/gebieden/buurten/03630000000078/?volgnummer=2",
@@ -1368,6 +1371,7 @@ class TestEmbedTemporalTables:
                                 "title": "03630012052035.1",
                                 "volgnummer": 1,
                             },
+                            "onderdeelVanGGWGebieden": [],
                         },
                         "id": "03630000000078.2",
                         "code": None,
@@ -1504,6 +1508,7 @@ class TestEmbedTemporalTables:
                             "title": "03630000000078.2",
                             "volgnummer": 2,
                         },
+                        "ligtInWijk": None,
                     },
                     "beginGeldigheid": "2021-06-11",
                     "code": None,
@@ -1570,6 +1575,7 @@ class TestEmbedTemporalTables:
                             "volgnummer": 2,
                             "identificatie": "03630000000078",
                         },
+                        "ligtInWijk": None,
                     },
                     "id": "03630000000078.2",
                     "naam": None,
@@ -1613,6 +1619,7 @@ class TestEmbedTemporalTables:
                             "title": "03630000000078.2",
                             "volgnummer": 2,
                         },
+                        "ligtInWijk": None,
                         "onderdeelVanGGWGebieden": [
                             {
                                 "href": "http://testserver/v1/gebieden/ggwgebieden/03630950000000/?volgnummer=1",  # noqa: E501
@@ -1769,6 +1776,8 @@ class TestEmbedTemporalTables:
                             "volgnummer": 2,
                             "identificatie": "03630000000078",
                         },
+                        "ligtInWijk": None,
+                        "onderdeelVanGGWGebieden": [],
                     },
                     "code": None,
                     "naam": None,


### PR DESCRIPTION
While it may "look" nicer to avoid null values, this makes browsable discovery of relations much harder, and we found this raises more questions on what is possible.

---

To discuss: we talked about this option because of received `feedback`, but I can't find the ticket number for this anymore..