### PR TITLE
Get better diagnostics for missing API keys in remotes

### DIFF
--- a/src/dso_api/dynamic_api/remote/clients.py
+++ b/src/dso_api/dynamic_api/remote/clients.py
@@ -335,7 +335,8 @@ class HCBAGClient(HaalCentraalClient):
     def _get_headers(self, request):
         headers = super()._get_headers(request)
 
-        headers["X-Api-Key"] = settings.HAAL_CENTRAAL_BAG_API_KEY
+        if (apikey := settings.HAAL_CENTRAAL_BAG_API_KEY) is not None:
+            headers["X-Api-Key"] = apikey
         headers["accept"] = "application/hal+json"
 
         return headers
@@ -363,7 +364,8 @@ class HCBRKClient(HaalCentraalClient):
     def _get_headers(self, request):
         headers = super()._get_headers(request)
 
-        headers["X-Api-Key"] = settings.HAAL_CENTRAAL_API_KEY
+        if (apikey := settings.HAAL_CENTRAAL_API_KEY) is not None:
+            headers["X-Api-Key"] = apikey
         headers["accept"] = "application/hal+json"
         # Currently for kadaster HaalCentraal only RD (epsg:28992) is supported
         headers["Accept-Crs"] = "epsg:28992"

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -403,8 +403,8 @@ if _USE_SECRET_STORE or CLOUD_ENV.startswith("azure"):
     HAAL_CENTRAAL_API_KEY = Path("/mnt/secrets-store/haalcentraal-api-key").read_text()
     HAAL_CENTRAAL_BAG_API_KEY = Path("/mnt/secrets-store/haalcentraal-bag-api-key").read_text()
 else:
-    HAAL_CENTRAAL_API_KEY = os.getenv("HAAL_CENTRAAL_API_KEY", "UNKNOWN")
-    HAAL_CENTRAAL_BAG_API_KEY = os.getenv("HAAL_CENTRAAL_BAG_API_KEY", "UNKNOWN")
+    HAAL_CENTRAAL_API_KEY = os.getenv("HAAL_CENTRAAL_API_KEY")
+    HAAL_CENTRAAL_BAG_API_KEY = os.getenv("HAAL_CENTRAAL_BAG_API_KEY")
 
 HAAL_CENTRAAL_KEYFILE = os.getenv("HC_KEYFILE")
 HAAL_CENTRAAL_CERTFILE = os.getenv("HC_CERTFILE")


### PR DESCRIPTION
We want "Missing API Key" from the remote, not "Invalid API Key",
when we can't send the key.