### PR TITLE
Bugfix browsable API works with all endpoints

### DIFF
--- a/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
+++ b/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
@@ -238,3 +238,6 @@ input:invalid {
 .param-info.hidden {
   visibility: hidden;
 }
+#authorize-btn.disabled {
+  visibility: hidden;
+}


### PR DESCRIPTION
browsable api can now match Open API paths with parameters like
'/v1/dataset/table/{id}'
