### PR TITLE
Revert "Upgrade OWASP ZAP (#545)"

### DIFF
--- a/src/.jenkins/owasp_vulnerability_scan/docker-compose.yml
+++ b/src/.jenkins/owasp_vulnerability_scan/docker-compose.yml
@@ -2,7 +2,8 @@
 version: "3.0"
 services:
   owasp:
-    image: owasp/zap2docker-stable:2.11.1
+    # Using version 2.9.0 as version 2.10.0 has issues with Selenium.
+    image: owasp/zap2docker-stable:2.9.0
     ports:      
       - "8090:8090"
     networks:


### PR DESCRIPTION
The new version gets stuck on 90% progress in the scan without an
indication of what is going wrong. We should fix this more thoroughly
and improve the logging, but for now we'll stick to a version that has
worked in the past.

This reverts commit 9bfc9d58c48a6024e4a49c98506bef34b40a16b4.