### PR TITLE
Limit the requested database fields using .only()

### DIFF
--- a/src/dso_api/dynamic_api/models.py
+++ b/src/dso_api/dynamic_api/models.py
@@ -1,0 +1,26 @@
+from schematools.contrib.django.models import DynamicModel
+
+
+class SealedDynamicModel(DynamicModel):
+    """Extended DynamicModel from schematools, to block accessing deferred fields."""
+
+    class Meta:
+        abstract = True
+
+    def refresh_from_db(self, using=None, fields=None):
+        """Block accessing extra fields for a model.
+
+        This avoids getting a performance issue due to the use of .only(),
+        since Django will still query those fields when they are read.
+
+        Overriding this method is easier and more robust than implementing django-seal.
+        While django-seal offers similar functionality, this doesn't need overriding
+        the queryset/manager and queryset iterator.
+        """
+        if fields and fields[0] not in self.__dict__:
+            raise RuntimeError(
+                f"Deferred attribute access: field '{fields[0]}' "
+                f"was excluded by .only() but was still accessed."
+            )
+
+        return super().refresh_from_db(using=using, fields=fields)

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -38,6 +38,7 @@ from schematools.utils import to_snake_case
 
 from dso_api.dynamic_api.datasets import get_active_datasets
 from dso_api.dynamic_api.locking import lock_for_writing
+from dso_api.dynamic_api.models import SealedDynamicModel
 from dso_api.dynamic_api.openapi import get_openapi_json_view
 from dso_api.dynamic_api.remote import remote_serializer_factory, remote_viewset_factory
 from dso_api.dynamic_api.serializers import clear_serializer_factory_cache, get_view_name
@@ -236,7 +237,12 @@ class DynamicRouter(routers.DefaultRouter):
             dataset_id = dataset.schema.id  # not dataset.name which is mangled.
             new_models = {}
 
-            for model in dataset.create_models(base_app_name="dso_api.dynamic_api"):
+            models = dataset.create_models(
+                base_app_name="dso_api.dynamic_api",
+                base_model=SealedDynamicModel,
+            )
+
+            for model in models:
                 logger.debug("Created model %s.%s", dataset_id, model.__name__)
                 new_models[model._meta.model_name] = model
 

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from functools import lru_cache
 
@@ -8,6 +10,8 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from rest_framework import serializers
 from schematools.contrib.django.models import LooseRelationField
 from schematools.contrib.django.signals import dynamic_models_removed
+
+from rest_framework_dso.fields import GeoJSONIdentifierField
 
 PK_SPLIT = re.compile("[_.]")
 
@@ -23,16 +27,16 @@ dynamic_models_removed.connect(lambda **kwargs: resolve_model_lookup.cache_clear
 
 
 @lru_cache
-def resolve_model_lookup(model: type[Model], lookup: str) -> tuple[type[Model], bool]:
-    """Find which model a lookup points to.
-
-    :returns: The model that the relation points to,
-        and whether reading the relation could return multiple objects.
+def resolve_model_lookup(
+    model: type[Model], lookup: str
+) -> list[RelatedField | ForeignObjectRel | LooseRelationField]:
+    """Find which fields a lookup points to.
+    :returns: The model fields that the relation traverses.
     """
     if not lookup:
         raise ValueError("Empty lookup can't be resolved")
 
-    field = None
+    fields = []
     for field_name in lookup.split("__"):
         field = model._meta.get_field(field_name)
 
@@ -43,9 +47,73 @@ def resolve_model_lookup(model: type[Model], lookup: str) -> tuple[type[Model], 
         else:
             raise ValueError(f"Field '{field}' is not a relation in lookup '{lookup}'")
 
-    # As the x_to_y flags are set on all field types, they also work for the LooseRelationField,
-    # which is neither of these (it's technically a 'many_to_one' like ForeignKey).
-    return model, (field.many_to_many or field.one_to_many)
+        fields.append(field)
+
+    return fields
+
+
+def get_serializer_source_fields(  # noqa: C901
+    serializer: serializers.BaseSerializer, prefix=""
+) -> list[str]:
+    """Find which ORM fields a serializer instance would request.
+
+    It checks "serializer.fields", and analyzes each "field.source" to find
+    the model attributes that would be read.
+    This allows to prepare an ``only()`` call on the queryset.
+    """
+    # Unwrap the list serializer construct for the one-to-many relationships.
+    if isinstance(serializer, serializers.ListSerializer):
+        serializer = serializer.child
+
+    lookups = []
+
+    for field in serializer.fields.values():  # type: serializers.Field
+        if field.source == "*":
+            # Field takes the full object, only some cases are supported:
+            if isinstance(field, serializers.BaseSerializer):
+                # When a serializer receives the same data as the parent instance, it can be
+                # seen as being a part of the parent. The _links field is implemented this way.
+                lookups.extend(get_serializer_source_fields(field, prefix=prefix))
+            elif isinstance(field, serializers.HyperlinkedRelatedField):
+                # Links to an object e.g. TemporalHyperlinkedRelatedField
+                # When the lookup_field matches the identifier, there is no need
+                # to add the field because the parent name is already includes it.
+                if field.lookup_field != "pk":
+                    lookups.append(f"{prefix}{field.lookup_field}")
+            elif field.field_name == "schema" or isinstance(field, GeoJSONIdentifierField):
+                # Fields that do have "source=*", but don't read any additional fields.
+                # e.g. SerializerMethodField for schema, and GeoJSON ID field.
+                continue
+            elif isinstance(field, serializers.CharField):
+                # A CharField(source="*") that either receives a str from its parent
+                # (e.g. _loose_link_serializer_factory() receives a str as data),
+                # or it's reading DynamicModel.__str__().
+                if isinstance(serializer, serializers.ModelSerializer) and (
+                    display_field := serializer.Meta.model.table_schema().display_field
+                ):
+                    lookups.append(f"{prefix}{display_field}")
+                continue
+            else:
+                raise NotImplementedError(
+                    f"Can't determine .only() for {prefix}{field.field_name}"
+                    f" ({field.__class__.__name__})"
+                )
+        else:
+            # Check the field isn't a reverse field, this should not be mentioned at all
+            # because such field doesn't access a local field (besides the primary key).
+            model_fields = get_source_model_fields(serializer, field.field_name, field)
+            if isinstance(model_fields[0], models.ForeignObjectRel):
+                continue
+
+            # Regular field: add the source value to the list.
+            lookup = f"{prefix}{'__'.join(field.source_attrs)}"
+            lookups.append(lookup)
+
+            if isinstance(field, (serializers.ModelSerializer, serializers.ListSerializer)):
+                lookups.extend(get_serializer_source_fields(field, prefix=f"{lookup}__"))
+
+    # Deduplicate the final result, as embedded fields could overlap with _links.
+    return sorted(set(lookups)) if not prefix else lookups
 
 
 def get_source_model_fields(

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-vectortiles == 0.1.0
 djangorestframework == 3.12.4
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 3.6.4
+amsterdam-schema-tools[django] == 3.6.9
 datapunt-authorization-django==1.3.2
 drf-spectacular == 0.15.0
 jsonschema == 3.2.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==3.6.4
+amsterdam-schema-tools[django]==3.6.9
     # via -r requirements.in
 asgiref==3.3.4
     # via django

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -41,10 +41,10 @@ from rest_framework_dso.embedding import (
     EmbeddedResultSet,
     ExpandScope,
     ObservableIterator,
-    get_serializer_lookups,
 )
 from rest_framework_dso.exceptions import HumanReadableGDALException
 from rest_framework_dso.serializer_helpers import ReturnGenerator, peek_iterable
+from rest_framework_dso.utils import get_serializer_relation_lookups
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +260,7 @@ class DSOModelListSerializer(DSOListSerializer):
 
     def get_prefetch_lookups(self) -> list[Union[models.Prefetch, str]]:
         """Tell which fields should be included for a ``prefetch_related()``."""
-        return get_serializer_lookups(self)
+        return list(get_serializer_relation_lookups(self))
 
     def to_representation(self, data):
         """Improved list serialization.

--- a/src/rest_framework_dso/utils.py
+++ b/src/rest_framework_dso/utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from django.utils.functional import LazyObject, empty
+from rest_framework import serializers
 
 DictOfDicts = dict[str, dict[str, dict]]
 
@@ -20,3 +23,44 @@ def group_dotted_names(dotted_field_names: list[str]) -> DictOfDicts:
         for path_item in dotted_name.split("."):
             tree_level = tree_level.setdefault(path_item, {})
     return result
+
+
+def get_serializer_relation_lookups(
+    serializer: serializers.BaseSerializer, prefix=""
+) -> dict[str, serializers.Field]:
+    """Find all relations that a serializer instance would request.
+    This allows to prepare a ``prefetch_related()`` call on the queryset.
+    """
+    from rest_framework_dso.serializers import HALLooseLinkSerializer
+
+    # Unwrap the list serializer construct for the one-to-many relationships.
+    if isinstance(serializer, serializers.ListSerializer):
+        serializer = serializer.child
+
+    lookups: dict[str, serializers.Field] = {}
+
+    for field in serializer.fields.values():  # type: serializers.Field
+        if isinstance(field, HALLooseLinkSerializer):
+            # shortcircuit loose relations, which can not be passed to prefetch_related
+            # because they are regular CharFields
+            continue
+        elif field.source == "*":
+            if isinstance(field, serializers.BaseSerializer):
+                # When a serializer receives the same data as the parent instance, it can be
+                # seen as being a part of the parent. The _links field is implemented this way.
+                lookups.update(get_serializer_relation_lookups(field, prefix=prefix))
+        elif isinstance(
+            field,
+            (
+                serializers.BaseSerializer,  # also ListSerializer
+                serializers.RelatedField,
+                serializers.ManyRelatedField,
+            ),
+        ):
+            # Note this could overwrite a value, as embedded fields could overlap with _links.
+            lookup = f"{prefix}{'__'.join(field.source_attrs)}"
+            lookups[lookup] = field
+
+            if isinstance(field, serializers.BaseSerializer):
+                lookups.update(get_serializer_relation_lookups(field, prefix=f"{lookup}__"))
+    return lookups

--- a/src/tests/test_dynamic_api/test_utils.py
+++ b/src/tests/test_dynamic_api/test_utils.py
@@ -20,9 +20,13 @@ def test_split(instr, result):
 
 def _assert_lookup(start_model, lookup, expect):
     # Making repeated assertions easier.
-    result = resolve_model_lookup(start_model, lookup)
-    assert result == expect, f"Failed resolving {start_model.__name__}.{lookup.replace('__', '.')}"
-    assert result[0] is expect[0]  # Confirm object references too
+    expect_model, expect_is_many = expect
+    model_field = resolve_model_lookup(start_model, lookup)[-1]
+
+    msg = f"Failed resolving {start_model.__name__}.{lookup.replace('__', '.')}"
+    assert model_field.related_model == expect_model, msg
+    assert (model_field.one_to_many or model_field.many_to_many) == expect_is_many, msg
+    assert model_field.related_model is expect_model  # Confirm object references too
 
 
 def test_resolve_model_lookup():


### PR DESCRIPTION
This reorganizes the serializer `to_representation()` logic that optimizes the incoming querysets, and applies `.only()` on them. The prefetch-related logic is also updated.

Some existing code had to be reorganized/moved for reuse, which is stored in separate commits.