### PR TITLE
Cleanups for stuff during PR work

### DIFF
--- a/src/dso_api/dynamic_api/serializers/factories.py
+++ b/src/dso_api/dynamic_api/serializers/factories.py
@@ -390,7 +390,7 @@ def _loose_link_serializer_factory(
     At runtime, a loose relationship does not receive an object but a
     str, since LooseRelationField inherits from CharField.
 
-    The primary id of the relation is used to contruct the href, title and id field.
+    The primary id of the relation is used to construct the href, title and id field.
     """
     table_schema = related_model.table_schema()
     serializer_part = SerializerAssemblyLine(
@@ -403,6 +403,7 @@ def _loose_link_serializer_factory(
         _build_href_field(related_model, field_cls=fields.HALLooseRelationUrlField),
     )
     if related_model.has_display_field():
+        # Using source="*" because the source is already a str.
         serializer_part.add_field("title", serializers.CharField(source="*"))
 
     # Add the primary identifier, whose names depend on the schema

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -130,9 +130,9 @@ def get_serializer_source_fields(  # noqa: C901
 
 def get_source_model_fields(
     serializer: serializers.ModelSerializer, field_name: str, field: serializers.Field
-) -> list[models.Field]:
+) -> list[models.Field | models.ForeignObjectRel]:
     """Find the model fields that the serializer field points to.
-    Typically this is only one field, but `field.source` could be set to a dotted path.
+    This is typically just one field, but `field.source` could be set to a dotted path.
     """
     if field.source == "*":
         # These fields are special: they receive the entire model instead of a attribute value.


### PR DESCRIPTION
This fixes some spelling errors, and makes sure that derived queryset classes still work on DSO-API
(I almost needed that one, finally didn't, but this fix needs to be there for it)