### PR TITLE
Hotfix to repair external GetAlleStratenAmsterdam call

### DIFF
--- a/src/dso_api/dynamic_api/serializers/base.py
+++ b/src/dso_api/dynamic_api/serializers/base.py
@@ -204,7 +204,7 @@ class DynamicListSerializer(DSOModelListSerializer):
 class FieldAccessMixin(serializers.ModelSerializer):
     """Mixin for serializers to remove fields the user doesn't have access to."""
 
-    fields_always_included = set()
+    fields_always_included = {"_links"}
 
     @cached_property
     def _request(self):


### PR DESCRIPTION
The _links field was missing in calls such as: https://api.data.amsterdam.nl/v1/bag/openbareruimtes/?_fields=naam&_pageSize=&_sort=naam&ligtInWoonplaats.identificatie=3594

This happens due to the `?_fields=..` stripping the `_links` block as well. Previously, `DSOSerializer.fields_always_included` prevented this, but `FieldAccessMixin` redefined this variable with a new default as of 1e81980c9c331a77ca633c0565de471ed5c83624.