### PR TITLE
Add unit test to prevent a regression in _links when using ?_fields=...

### DIFF
--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -107,29 +107,6 @@ def test_list_dynamic_view_unregister(api_client, api_rf, bommen_dataset, filled
 
 
 @pytest.mark.django_db
-def test_filter_no_such_field(api_client, afval_dataset, filled_router):
-    url = reverse("dynamic_api:afvalwegingen-containers-list")
-
-    # Non-existing field.
-    response = api_client.get(url, data={"nietbestaand": ""})
-    assert response.status_code == HTTP_400_BAD_REQUEST, response.data
-    reason = response.data["invalid-params"][0]["reason"]
-    assert reason == "Field 'nietbestaand' does not exist"
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize("param", ["buurtcode[", "buurtcode[exact", "buurtcodeexact]"])
-def test_filter_syntax_error(param, api_client, afval_dataset, filled_router):
-    """Existing field, but syntax error in the filter parameter."""
-    url = reverse("dynamic_api:afvalwegingen-containers-list")
-
-    response = api_client.get(url, data={param: ""})
-    assert response.status_code == HTTP_400_BAD_REQUEST, response.data
-    reason = response.data["invalid-params"][0]["reason"]
-    assert param in reason
-
-
-@pytest.mark.django_db
 class TestDSOViewMixin:
     """Prove that the DSO view mixin logic is used within the dynamic API."""
 
@@ -175,6 +152,27 @@ class TestDSOViewMixin:
 @pytest.mark.django_db
 class TestListFilters:
     """Prove that filtering works as expected."""
+
+    @staticmethod
+    def test_filter_no_such_field(api_client, afval_dataset, filled_router):
+        url = reverse("dynamic_api:afvalwegingen-containers-list")
+
+        # Non-existing field.
+        response = api_client.get(url, data={"nietbestaand": ""})
+        assert response.status_code == HTTP_400_BAD_REQUEST, response.data
+        reason = response.data["invalid-params"][0]["reason"]
+        assert reason == "Field 'nietbestaand' does not exist"
+
+    @staticmethod
+    @pytest.mark.parametrize("param", ["buurtcode[", "buurtcode[exact", "buurtcodeexact]"])
+    def test_filter_syntax_error(param, api_client, afval_dataset, filled_router):
+        """Existing field, but syntax error in the filter parameter."""
+        url = reverse("dynamic_api:afvalwegingen-containers-list")
+
+        response = api_client.get(url, data={param: ""})
+        assert response.status_code == HTTP_400_BAD_REQUEST, response.data
+        reason = response.data["invalid-params"][0]["reason"]
+        assert param in reason
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -227,6 +227,35 @@ class TestListFilters:
 
 
 @pytest.mark.django_db
+class TestLimitFields:
+    """Test how the ?_fields=... parameter works with all extra serializer weight."""
+
+    @staticmethod
+    def test_fields(api_client, afval_dataset, afval_container, filled_router):
+        url = reverse("dynamic_api:afvalwegingen-containers-list")
+        response = api_client.get(url, data={"_fields": "id,serienummer"})
+        assert response.status_code == HTTP_200_OK, response.data
+        data = read_response_json(response)
+        assert data["_embedded"] == {
+            "containers": [
+                {
+                    "_links": {
+                        # _links block still exists with self link:
+                        "self": {
+                            "href": "http://testserver/v1/afvalwegingen/containers/1/",
+                            "id": 1,
+                            "title": "1",
+                        },
+                        "schema": "https://schemas.data.amsterdam.nl/datasets/afvalwegingen/dataset#containers",  # noqa: E501
+                    },
+                    "id": 1,
+                    "serienummer": "foobar-123",
+                }
+            ]
+        }
+
+
+@pytest.mark.django_db
 class TestSort:
     """Prove that the ordering works as expected."""
 


### PR DESCRIPTION
This amends the hotfix of 8c8b0214dd58f4b533d6a068170775e61c0735a6