### PR TITLE
CRS cleanup

### DIFF
--- a/src/rest_framework_dso/crs.py
+++ b/src/rest_framework_dso/crs.py
@@ -11,8 +11,6 @@ __all__ = [
     "CRS",
     "WGS84",
     "RD_NEW",
-    "WEB_MERCATOR",
-    "ETRS89",
     "DEFAULT_CRS",
     "OTHER_CRS",
     "ALL_CRS",
@@ -36,4 +34,4 @@ DEFAULT_CRS = RD_NEW
 OTHER_CRS = [WGS84, WEB_MERCATOR, ETRS89]
 
 #: All coordinate reference systems exposed by this file.
-ALL_CRS = set([DEFAULT_CRS] + OTHER_CRS)
+ALL_CRS = frozenset([DEFAULT_CRS] + OTHER_CRS)

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -285,7 +285,7 @@ class DSOViewMixin:
     """
 
     #: The list of allowed coordinate reference systems for the request header
-    accept_crs = {crs.RD_NEW, crs.WEB_MERCATOR, crs.ETRS89, crs.WGS84}
+    accept_crs = crs.ALL_CRS
 
     #: Enforce parsing Content-Crs for POST requests:
     parser_classes = [parsers.DSOJsonParser]


### PR DESCRIPTION
ALL_CRS was never used. Instead, its value was repeated in views.py.

ETRS89 and WEB_MERCATOR no longer need to be exported.