### PR TITLE
Fix JSON rendering optimization

### DIFF
--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -207,7 +207,7 @@ class HALJSONRenderer(RendererMixin, renderers.JSONRenderer):
             yield b"{"
             sep = b"\n  "
             for key, value in data.items():
-                if hasattr(data, "__iter__") and not isinstance(data, str):
+                if hasattr(value, "__iter__") and not isinstance(value, str):
                     # Recurse streaming for actual complex values.
                     yield b"%b%b:" % (sep, orjson.dumps(key))
                     yield from self._render_json(value, level=level + 1)


### PR DESCRIPTION
HALJSONRenderer._render_json was looking at the wrong value to determine whether to call itself recursively: it only did so for
`isinstance(data, str)`, after first checking that `isinstance(data, dict)`.

With this patch, the optimization actually works and shows a small improvement on the data for the first 10000 `openbareverlichting` items. Before:

```
>>> r = renderers.HALJSONRenderer()
>>> %timeit all(r.render(data))
9.32 ms ± 542 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

After:

```
9.12 ms ± 10.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```