### PR TITLE
Bump Django to v3.2.15

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-Django == 3.2.14
+Django == 3.2.15
 django-environ == 0.4.5
 django-cors-headers == 3.7.0
 django-healthchecks == 1.4.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -53,7 +53,7 @@ defusedxml==0.7.1
     # via django-gisserver
 deprecated==1.2.13
     # via amsterdam-schema-tools
-django==3.2.14
+django==3.2.15
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools


### PR DESCRIPTION
Bump Django to version 3.2.15: https://docs.djangoproject.com/en/dev/releases/3.2.15/