### PR TITLE
Add field enums to openapi parameters

### DIFF
--- a/src/dso_api/dynamic_api/filters/openapi.py
+++ b/src/dso_api/dynamic_api/filters/openapi.py
@@ -141,6 +141,9 @@ def _get_field_openapi_params(field: DatasetFieldSchema, prefix="") -> list[dict
                 param["explode"] = False
                 param["style"] = "form"
 
+        if enum := field.get("enum"):
+            param["schema"]["enum"] = enum
+
         openapi_params.append(param)
 
     return openapi_params


### PR DESCRIPTION
Enums uit amsterdam schema werden niet meegenomen in de openapi spec. Door deze pr wel. Zo komen ze ook in de suggesties van de browsable api
