### PR TITLE
Update docs for maketoken

### DIFF
--- a/dev-docs/source/auth.rst
+++ b/dev-docs/source/auth.rst
@@ -158,6 +158,3 @@ you can issue a curl command such as
 
     curl http://localhost:8000/v1/haalcentraal/brk/kadastraalonroerendezaken/${id}/ \
         --header "Authorization: Bearer ${token}"
-
-The test token expires after half an hour by default.
-Run ``python manage.py maketoken --help`` to see how to change that.


### PR DESCRIPTION
Just don't mention the expiry. Power users will run --help.