### PR TITLE
Use em4w admin token when running as task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ ENV/
 # Docs
 /docs/source/datasets/
 /docs/source/wfs-datasets/
+
+# Docker
+docker-compose.override.y*ml

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -147,7 +147,7 @@ if _USE_SECRET_STORE or CLOUD_ENV.startswith("azure"):
     except FileNotFoundError:
         # When running as a task container.
         # In this case PGPASSWORD refers to a token from Azure IMDS
-        pgpassword = env["PGPASSWORD"]
+        pgpassword = env.str("PGPASSWORD")
 
     DATABASES = {
         "default": {

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -145,7 +145,8 @@ if _USE_SECRET_STORE or CLOUD_ENV.startswith("azure"):
         # Normal operation
         pgpassword = Path("/mnt/secrets-store/mdbdataservices-read").read_text()
     except FileNotFoundError:
-        # When running as a task container
+        # When running as a task container.
+        # In this case PGPASSWORD refers to a token from Azure IMDS
         pgpassword = env["PGPASSWORD"]
 
     DATABASES = {

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -142,9 +142,11 @@ if _USE_SECRET_STORE or CLOUD_ENV.startswith("azure"):
     # On Azure, passwords are NOT passed via environment variables,
     # because the container environment can be inspected, and those vars export to subprocesses.
     try:
+        # Normal operation
         pgpassword = Path("/mnt/secrets-store/mdbdataservices-read").read_text()
     except FileNotFoundError:
-        pgpassword = Path("/mnt/secrets-store/mdbdataservices-owner").read_text()
+        # When running as a task container
+        pgpassword = env["PGPASSWORD"]
 
     DATABASES = {
         "default": {


### PR DESCRIPTION
When running the dso-api as a task, we use the em4w admin group through the AKS mid with time-limited token-based authentication

fixes [AB#55947](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/55947)