### PR TITLE
Update DSO-API with new schematools release changes

### DIFF
--- a/docs/source/datasets.py
+++ b/docs/source/datasets.py
@@ -253,7 +253,7 @@ def _get_fields(table_fields) -> List[DatasetFieldSchema]:
     """Flatten a nested listing of fields."""
     result_fields = []
     for field in table_fields:
-        if field.name == "schema":
+        if field.id == "schema":
             continue
 
         result_fields.append(field)

--- a/src/dso_api/dynamic_api/filters/openapi.py
+++ b/src/dso_api/dynamic_api/filters/openapi.py
@@ -86,12 +86,9 @@ def get_table_filter_params(table_schema: DatasetTableSchema) -> list[dict]:  # 
         elif field.relation:
             # Relation: promote filtering with dot-notation instead of the old "fieldnameId"
             # This works both for temporal relations, regular relations as loose relations.
-            rel_table = field.related_table
-            identifiers = field.related_field_ids
-            for identifier in identifiers:
-                sub_field = rel_table.get_field_by_id(identifier)
+            for related_id_field in field.related_fields:
                 openapi_params.extend(
-                    _get_field_openapi_params(sub_field, prefix=f"{field.name}.")
+                    _get_field_openapi_params(related_id_field, prefix=f"{field.name}.")
                 )
         else:
             # Flat direct field

--- a/src/dso_api/dynamic_api/management/commands/dump_serializers.py
+++ b/src/dso_api/dynamic_api/management/commands/dump_serializers.py
@@ -9,9 +9,9 @@ from django.db import models
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
+from schematools.naming import to_snake_case
 from schematools.permissions import UserScopes
 from schematools.types import DatasetTableSchema
-from schematools.utils import to_snake_case
 
 from dso_api.dynamic_api.serializers import DynamicSerializer
 from dso_api.dynamic_api.urls import router
@@ -122,9 +122,7 @@ class Command(BaseCommand):
             )
         else:
             # Remote serializer:
-            self.stdout.write(
-                f"# {serializer.table_schema.dataset.id}.{serializer.table_schema.id}\n\n\n"
-            )
+            self.stdout.write(f"# {serializer.table_schema.qualified_id}\n\n\n")
 
     def write_sub_serializers(self, serializer: DSOSerializer):
         """Write the dependant serializers"""

--- a/src/dso_api/dynamic_api/management/commands/implement_constraint.py
+++ b/src/dso_api/dynamic_api/management/commands/implement_constraint.py
@@ -18,13 +18,13 @@ class Command(BaseCommand):
                     continue
 
                 schema = model.table_schema()
-                pk = schema.get_field_by_id(schema.identifier[0])
+                pk = schema.identifier_fields[0]
 
                 if len(schema.identifier) == 1 and pk.type == "string":
-                    if model.objects.filter(**{f"{pk.db_name()}__contains": "/"}).exists():
+                    if model.objects.filter(**{f"{pk.python_name}__contains": "/"}).exists():
                         self.stdout.write(
                             self.style.WARNING(
-                                f"Data in {schema.db_name()} does not satisfy constraint.\
+                                f"Data in {schema.db_name} does not satisfy constraint.\
                                     Skipping this model...\n"
                             )
                         )
@@ -34,17 +34,17 @@ class Command(BaseCommand):
                         curs.execute(
                             sql.SQL(
                                 "ALTER TABLE {table} DROP CONSTRAINT IF EXISTS id_not_contains_slash;"  # noqa E501
-                            ).format(table=sql.Identifier(schema.db_name()))
+                            ).format(table=sql.Identifier(schema.db_name))
                         )
                         curs.execute(
                             sql.SQL(
                                 "ALTER TABLE {table} ADD CONSTRAINT id_not_contains_slash CHECK (NOT {field} LIKE '%%/%%');"  # noqa E501
                             ).format(
-                                table=sql.Identifier(schema.db_name()),
-                                field=sql.Identifier(pk.db_name()),
+                                table=sql.Identifier(schema.db_name),
+                                field=sql.Identifier(pk.db_name),
                             )
                         )
 
                     self.stdout.write(
-                        self.style.SUCCESS(f"Applied constraint on {schema.db_name()}")
+                        self.style.SUCCESS(f"Applied constraint on {schema.db_name}")
                     )

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -36,8 +36,8 @@ def check_filter_field_access(field_name: str, field: DatasetFieldSchema, user_s
 
     if field.related_field_ids is not None:
         # Check if related ID fields are accessible.
-        for id_name in field.related_field_ids:
-            if not user_scopes.has_field_access(field.related_table.get_field_by_id(id_name)):
+        for related_id_field in field.related_fields:
+            if not user_scopes.has_field_access(related_id_field):
                 raise PermissionDenied(f"Access denied to filter on: {field_name}")
 
 

--- a/src/dso_api/dynamic_api/remote/views.py
+++ b/src/dso_api/dynamic_api/remote/views.py
@@ -179,16 +179,20 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
         )
 
 
+def _get_viewset_api_docs(table_schema: DatasetTableSchema) -> str:
+    return table_schema.description or "Forwarding proxy"
+
+
 def remote_viewset_factory(
     endpoint_url, serializer_class, table_schema: DatasetTableSchema
 ) -> type[RemoteViewSet]:
     """Construct the viewset class that handles the remote serializer."""
 
     return type(
-        f"{serializer_class.__name__}Viewset",
+        f"{table_schema.python_name}ViewSet",
         (RemoteViewSet,),
         {
-            "__doc__": "Forwarding proxy serializer",
+            "__doc__": _get_viewset_api_docs(table_schema),
             "client": clients.make_client(endpoint_url, table_schema),
             "serializer_class": serializer_class,
             "dataset_id": table_schema.dataset.id,

--- a/src/dso_api/dynamic_api/remote/views.py
+++ b/src/dso_api/dynamic_api/remote/views.py
@@ -11,6 +11,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import ViewSet
+from schematools.naming import toCamelCase
 from schematools.types import DatasetTableSchema
 
 from rest_framework_dso.exceptions import RemoteAPIException
@@ -117,7 +118,7 @@ class RemoteViewSet(DSOViewMixin, ViewSet):
 
         data = {
             "_embedded": {
-                self.table_schema.name: data,
+                toCamelCase(self.table_schema.id): data,
             },
             "_links": {
                 "self": {

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -35,9 +35,9 @@ from django.urls import NoReverseMatch, URLPattern, path, reverse
 from rest_framework import routers
 from schematools.contrib.django.factories import remove_dynamic_models
 from schematools.contrib.django.models import Dataset
-from schematools.utils import to_snake_case
+from schematools.naming import to_snake_case
 
-from ..dynamic_api.datasets import get_active_datasets
+from .datasets import get_active_datasets
 from .models import SealedDynamicModel
 from .openapi import get_openapi_json_view
 from .remote import remote_serializer_factory, remote_viewset_factory
@@ -120,7 +120,7 @@ class DynamicRouter(routers.DefaultRouter):
 
     def __init__(self):
         super().__init__(trailing_slash=True)
-        self.all_models = {}
+        self.all_models: dict[str, dict[str, type[DynamicModel]]] = {}
         self.static_routes = []
         self._openapi_urls = []
         self._index_urls = []

--- a/src/dso_api/dynamic_api/serializers/fields.py
+++ b/src/dso_api/dynamic_api/serializers/fields.py
@@ -8,6 +8,8 @@ by ``to_representation()``, the field also needs to define the OpenAPI details o
 what the field would return. Hence, other fields (e.g. in ``_links``) that return
 more variable fields are constructed as a serializer instead.
 """
+from urllib.parse import urlencode
+
 from django.db import models
 from drf_spectacular.utils import extend_schema_field, inline_serializer
 from more_ds.network.url import URL
@@ -15,9 +17,8 @@ from rest_framework import serializers
 from rest_framework.relations import HyperlinkedRelatedField
 from rest_framework.reverse import reverse
 from rest_framework.serializers import Field
+from schematools.naming import toCamelCase
 from schematools.types import DatasetTableSchema
-from schematools.utils import toCamelCase
-from urllib.parse import urlencode
 
 from dso_api.dynamic_api.temporal import TemporalTableQuery
 from dso_api.dynamic_api.utils import get_view_name, split_on_separator

--- a/src/dso_api/dynamic_api/utils.py
+++ b/src/dso_api/dynamic_api/utils.py
@@ -10,7 +10,7 @@ from django.db.models.fields.reverse_related import ForeignObjectRel
 from rest_framework import serializers
 from schematools.contrib.django.models import DynamicModel
 from schematools.contrib.django.signals import dynamic_models_removed
-from schematools.utils import to_snake_case
+from schematools.naming import to_snake_case
 
 from rest_framework_dso.fields import GeoJSONIdentifierField
 
@@ -98,10 +98,12 @@ def get_serializer_source_fields(  # noqa: C901
                 # A CharField(source="*") that either receives a str from its parent
                 # (e.g. _loose_link_serializer_factory() receives a str as data),
                 # or it's reading DynamicModel.__str__().
-                if isinstance(serializer, serializers.ModelSerializer) and (
-                    display_field := serializer.Meta.model.table_schema().display_field
+                if (
+                    isinstance(serializer, serializers.ModelSerializer)
+                    and (display_field := serializer.Meta.model.table_schema().display_field)
+                    is not None
                 ):
-                    lookups.append(f"{prefix}{display_field}")
+                    lookups.append(f"{prefix}{display_field.python_name}")
                 continue
             else:
                 raise NotImplementedError(

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -125,7 +125,6 @@ class DynamicApiViewSet(DSOViewMixin, viewsets.ReadOnlyModelViewSet):
 
 def _get_viewset_api_docs(model: type[DynamicModel]) -> str:
     """Generate the API documentation header for the viewset."""
-    # NOTE: currently not using model.get_dataset_path() as the docs don't do either.
     description = model.table_schema().description
     docs_path = f"datasets/{model.get_dataset_path()}.html#{model.get_table_id()}"
     return (
@@ -156,6 +155,7 @@ def viewset_factory(model: type[DynamicModel]) -> type[DynamicApiViewSet]:
     function is called to generate those classes.
     """
     serializer_class = serializers.serializer_factory(model)
+    table_schema = model.table_schema()
 
     attrs = {
         "__doc__": _get_viewset_api_docs(model),
@@ -166,4 +166,4 @@ def viewset_factory(model: type[DynamicModel]) -> type[DynamicApiViewSet]:
         "table_id": model.table_schema()["id"],
         "authorization_grantor": model.get_dataset_schema().get("authorizationGrantor"),
     }
-    return type(f"{model.__name__}ViewSet", (DynamicApiViewSet,), attrs)
+    return type(f"{table_schema.python_name}ViewSet", (DynamicApiViewSet,), attrs)

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-vectortiles == 0.2.0
 djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 1.0
-amsterdam-schema-tools[django] == 4.3.0
+amsterdam-schema-tools[django] == 5.0
 datapunt-authorization-django==1.3.2
 drf-spectacular == 0.24.2
 jsonschema == 4.16.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==4.3.0
+amsterdam-schema-tools[django]==5.0
     # via -r requirements.in
 arrow==1.2.3
     # via isoduration
@@ -207,9 +207,7 @@ more-ds==0.0.6
     #   -r requirements.in
     #   amsterdam-schema-tools
 more-itertools==9.0.0
-    # via
-    #   -r requirements.in
-    #   amsterdam-schema-tools
+    # via -r requirements.in
 msal==1.20.0
     # via
     #   azure-identity
@@ -340,7 +338,7 @@ rsa==4.9
     # via google-auth
 sentry-sdk==1.10.1
     # via -r requirements.in
-shapely==1.8.5.post1
+shapely==1.8.0
     # via
     #   amsterdam-schema-tools
     #   mapbox-vector-tile

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -10,6 +10,7 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
 from rest_framework.serializers import ListSerializer
 from rest_framework.utils import formatting
+from rest_framework.views import APIView
 from rest_framework.views import exception_handler as drf_exception_handler
 from schematools.types import DatasetTableSchema
 
@@ -21,15 +22,17 @@ from rest_framework_dso.response import StreamingResponse
 W3HTMLREF = "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.5.1"
 
 
-def get_view_name(view):
+def get_view_name(view: APIView):
     """
     Given a view instance, return a textual name to represent the view.
     This name is used in the browsable API, and in OPTIONS responses.
 
-    This function replaces the Rest Framework default.
+    This function replaces the Rest Framework default,
+    configured in settings using: ``REST_FRAMEWORK['VIEW_NAME_FUNCTION']``
     """
     name = getattr(view, "name", None)
     if name is not None:
+        # This attribute is used by DRF routing internally.
         return name
 
     name = view.__class__.__name__

--- a/src/tests/files/fietspaaltjes.json
+++ b/src/tests/files/fietspaaltjes.json
@@ -15,7 +15,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["schema", "id"],
-          "display": "scoreCurrent",
+          "display": "score_current",
           "properties": {
             "schema": {
               "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"


### PR DESCRIPTION
This fixes the shortnames appearing in the API.

The cause of this bug happened deep inside schematools, where the `field.name` would return the database `shortname`. Thus, model fields, and even API serializer fields received that shortname. This PR brings DSO-API in line with the changes in schematools.