### PR TITLE
Bump requirements for security, future maintenance and space for Django 4

### DIFF
--- a/src/dso_api/dynamic_api/filters/lookups.py
+++ b/src/dso_api/dynamic_api/filters/lookups.py
@@ -48,13 +48,13 @@ class NotEqual(lookups.Lookup):
             # Allow field__not=value to return NULL fields too.
             return (
                 f"({lhs} IS NULL OR {lhs} != {rhs})",
-                lhs_params + lhs_params + rhs_params,
+                list(lhs_params + lhs_params) + rhs_params,
             )
         elif rhs_params and rhs_params[0] is None:
             # Allow field__not=None to work.
             return f"{lhs} IS NOT NULL", lhs_params
         else:
-            return f"{lhs} != {rhs}", lhs_params + rhs_params
+            return f"{lhs} != {rhs}", list(lhs_params) + rhs_params
 
 
 @models.CharField.register_lookup

--- a/src/dso_api/dynamic_api/filters/values.py
+++ b/src/dso_api/dynamic_api/filters/values.py
@@ -36,19 +36,22 @@ def str2number(value: str) -> Decimal:
 def str2isodate(value: str) -> date | datetime | None:
     """Parse ISO date and datetime."""
 
-    # Try parsing full iso-8601 datetime.
+    # Try parsing ISO date without time.
+    # This is checked first, so the function can explicitly return a date object
+    # for something that has no time at inputs, allowing to check against a complete day
+    # instead of exactly midnight.
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        pass
+
+    # Try parsing full iso-8601 datetime (also works for date-only values in Django >= 4.x)
     try:
         result = parse_datetime(value)
         if result is not None:
             return result
     except ValueError:
         pass  # e.g. well formatted but invalid values
-
-    # Try parsing ISO date without time.
-    try:
-        return datetime.strptime(value, "%Y-%m-%d").date()
-    except ValueError:
-        pass
 
     raise ValidationError(_("Enter a valid ISO date-time, or single date."), code="invalid")
 

--- a/src/dso_api/dynamic_api/management/commands/maketoken.py
+++ b/src/dso_api/dynamic_api/management/commands/maketoken.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         See for usage: https://dso-api.readthedocs.io/en/latest/auth.html#testing
     """
 
-    requires_system_checks = False
+    requires_system_checks = []
 
     def add_arguments(self, parser: ArgumentParser) -> None:
         """Hook to add arguments."""

--- a/src/dso_api/middleware.py
+++ b/src/dso_api/middleware.py
@@ -22,7 +22,7 @@ class AuthMiddleware:
             # instead of is_authorized_for, to get more control over authorization
             # checks and to enable more precise logging.
             # get_token_scopes is a data attribute, not a method.
-            scopes = request.get_token_scopes
+            scopes = request.get_token_scopes or []
             request.user_scopes = UserScopes(request.GET, scopes, self._all_profiles)
 
         # The token subject contains the username/email address of the user (on Azure)

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -363,6 +363,7 @@ These are located at:
         "description": "API Usage Documentation",
         "url": "https://api.data.amsterdam.nl/v1/docs/",
     },
+    "GET_MOCK_REQUEST": "dso_api.dynamic_api.openapi.build_mock_request",
     "SCHEMA_PATH_PREFIX": r"^/v?\d+(\.\d+)?/",  # strip /v1/ from tags.
     "SWAGGER_UI_SETTINGS": {
         "oauth2RedirectUrl": f"{DATAPUNT_API_URL}v1/oauth2-redirect.html",

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,43 +1,45 @@
 Django == 3.2.16
-django-environ == 0.4.5
-django-cors-headers == 3.7.0
-django-healthchecks == 1.4.2
-django-postgres-unlimited-varchar == 1.1.1
+django-environ == 0.9.0
+django-cors-headers == 3.13.0
+django-healthchecks == 1.5.0
+django-postgres-unlimited-varchar == 1.1.2
 django-gisserver == 1.2.3
-django-vectortiles == 0.1.0
-djangorestframework == 3.12.4
+django-vectortiles == 0.2.0
+djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1
-djangorestframework-gis == 0.17
-amsterdam-schema-tools[django] == 4.2.0
+djangorestframework-gis == 1.0
+amsterdam-schema-tools[django] == 4.3.0
 datapunt-authorization-django==1.3.2
-drf-spectacular == 0.15.0
-jsonschema == 3.2.0
-lru_dict == 1.1.7
-more-ds == 0.0.4
-more-itertools == 8.8.0
-openapi-spec-validator == 0.4.0
-opencensus-ext-azure == 1.0.7
-opencensus-ext-django == 0.7.4
-opencensus-ext-logging == 0.1.0
-orjson == 3.5.3
+drf-spectacular == 0.24.2
+jsonschema == 4.16.0
+lru_dict == 1.1.8
+more-ds == 0.0.6
+more-itertools == 9.0.0
+openapi-spec-validator == 0.5.1
+opencensus-ext-azure == 1.1.7
+opencensus-ext-django == 0.8.0
+opencensus-ext-logging == 0.1.1
+orjson == 3.8.0
 python-string-utils == 1.0.0
-requests == 2.25.1
-sentry-sdk == 1.0.0
-urllib3 == 1.26.5
+requests == 2.28.1
+sentry-sdk == 1.10.1
+urllib3 == 1.26.12
 urllib3-mock == 0.3.3
 
 # When installed, it's used for API doc markup:
-markdown == 3.3.4
+markdown == 3.4.1
 
 # Testing
 bandit == 1.7.4
-flake8 == 3.9.2
-flake8-blind-except == 0.2.0
+flake8 == 5.0.4
+flake8-blind-except == 0.2.1
 flake8-colors == 0.1.9
-flake8-debugger == 4.0.0
+flake8-debugger == 4.1.2
 flake8-raise == 0.0.5
 mapbox-vector-tile == 1.2.1
-pytest == 6.2.4
-pytest-django == 4.1.0
-pytest-cov == 2.12.1
-python-owasp-zap-v2.4 == 0.0.18
+pytest == 7.1.3
+pytest-django == 4.5.2
+pytest-cov == 4.0.0
+python-owasp-zap-v2.4 == 0.0.20
+
+protobuf ~= 3.20.1  # for mapbox-vector-tile

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,43 +4,57 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==4.2.0
+amsterdam-schema-tools[django]==4.3.0
     # via -r requirements.in
-asgiref==3.3.4
+arrow==1.2.3
+    # via isoduration
+asgiref==3.5.2
     # via django
-attrs==20.3.0
+attrs==22.1.0
     # via
     #   jsonschema
+    #   openapi-schema-validator
     #   pg-grant
     #   pytest
+azure-core==1.26.0
+    # via
+    #   azure-identity
+    #   opencensus-ext-azure
+azure-identity==1.11.0
+    # via opencensus-ext-azure
 bandit==1.7.4
     # via -r requirements.in
-cachetools==4.2.2
+cachetools==5.2.0
     # via
     #   amsterdam-schema-tools
     #   google-auth
-certifi==2020.12.5
+certifi==2022.9.24
     # via
+    #   django-healthchecks
     #   requests
     #   sentry-sdk
-cffi==1.14.5
+cffi==1.15.1
     # via cryptography
-chardet==4.0.0
+charset-normalizer==2.1.1
     # via requests
-click==7.1.2
+click==8.1.3
     # via
     #   amsterdam-schema-tools
     #   mappyfile
     #   mercantile
-coverage==5.5
+coverage[toml]==6.5.0
     # via pytest-cov
-cryptography==3.4.7
-    # via jwcrypto
+cryptography==38.0.1
+    # via
+    #   azure-identity
+    #   jwcrypto
+    #   msal
+    #   pyjwt
 datapunt-authorization-django==1.3.2
     # via -r requirements.in
-decorator==5.0.5
+decorator==5.1.1
     # via jsonpath-rw
-deepdiff==5.2.3
+deepdiff==6.2.1
     # via amsterdam-schema-tools
 defusedxml==0.7.1
     # via django-gisserver
@@ -61,11 +75,11 @@ django==3.2.16
     #   djangorestframework
     #   drf-spectacular
     #   opencensus-ext-django
-django-cors-headers==3.7.0
+django-cors-headers==3.13.0
     # via -r requirements.in
 django-db-comments==0.4.1
     # via amsterdam-schema-tools
-django-environ==0.4.5
+django-environ==0.9.0
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
@@ -73,15 +87,15 @@ django-gisserver==1.2.3
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
-django-healthchecks==1.4.2
+django-healthchecks==1.5.0
     # via -r requirements.in
-django-postgres-unlimited-varchar==1.1.1
+django-postgres-unlimited-varchar==1.1.2
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
-django-vectortiles==0.1.0
+django-vectortiles==0.2.0
     # via -r requirements.in
-djangorestframework==3.12.4
+djangorestframework==3.14.0
     # via
     #   -r requirements.in
     #   djangorestframework-csv
@@ -89,145 +103,171 @@ djangorestframework==3.12.4
     #   drf-spectacular
 djangorestframework-csv==2.1.1
     # via -r requirements.in
-djangorestframework-gis==0.17
+djangorestframework-gis==1.0
     # via -r requirements.in
-drf-spectacular==0.15.0
+drf-spectacular==0.24.2
     # via -r requirements.in
 factory-boy==3.2.1
     # via amsterdam-schema-tools
-faker==13.15.1
+faker==15.1.1
     # via factory-boy
-flake8==3.9.2
+flake8==5.0.4
     # via
     #   -r requirements.in
     #   flake8-colors
     #   flake8-debugger
     #   flake8-raise
-flake8-blind-except==0.2.0
+flake8-blind-except==0.2.1
     # via -r requirements.in
 flake8-colors==0.1.9
     # via -r requirements.in
-flake8-debugger==4.0.0
+flake8-debugger==4.1.2
     # via -r requirements.in
 flake8-raise==0.0.5
     # via -r requirements.in
+fqdn==1.5.1
+    # via jsonschema
 future==0.18.2
     # via mapbox-vector-tile
-geoalchemy2==0.8.5
+geoalchemy2==0.12.5
     # via amsterdam-schema-tools
 gitdb==4.0.9
     # via gitpython
-gitpython==3.1.27
+gitpython==3.1.29
     # via bandit
-google-api-core==1.26.3
+google-api-core==2.10.2
     # via opencensus
-google-auth==1.28.1
+google-auth==2.13.0
     # via google-api-core
-googleapis-common-protos==1.53.0
+googleapis-common-protos==1.56.4
     # via google-api-core
-idna==2.10
+greenlet==1.1.3.post0
+    # via sqlalchemy
+idna==3.4
     # via
     #   jsonschema
     #   requests
+importlib-metadata==5.0.0
+    # via markdown
+importlib-resources==5.10.0
+    # via openapi-spec-validator
 inflection==0.5.1
     # via drf-spectacular
 iniconfig==1.1.1
     # via pytest
-jinja2==2.11.3
+isoduration==20.11.0
+    # via jsonschema
+jinja2==3.1.2
     # via amsterdam-schema-tools
 json-encoder==0.4.4
     # via amsterdam-schema-tools
 jsonpath-rw==1.4.0
     # via amsterdam-schema-tools
-jsonpointer==2.2
+jsonpointer==2.3
     # via jsonschema
 jsonref==0.2
     # via mappyfile
-jsonschema[format]==3.2.0
+jsonschema[format]==4.16.0
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
     #   drf-spectacular
+    #   jsonschema-spec
     #   mappyfile
     #   openapi-schema-validator
     #   openapi-spec-validator
-jwcrypto==1.4
+jsonschema-spec==0.1.2
+    # via openapi-spec-validator
+jwcrypto==1.4.2
     # via datapunt-authorization-django
-lark-parser==0.11.2
+lark-parser==0.12.0
     # via mappyfile
-lru-dict==1.1.7
+lazy-object-proxy==1.7.1
+    # via openapi-spec-validator
+lru-dict==1.1.8
     # via
     #   -r requirements.in
     #   django-gisserver
 mapbox-vector-tile==1.2.1
     # via -r requirements.in
-mappyfile==0.9.1
+mappyfile==0.9.7
     # via amsterdam-schema-tools
-markdown==3.3.4
+markdown==3.4.1
     # via -r requirements.in
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via jinja2
-mccabe==0.6.1
+mccabe==0.7.0
     # via flake8
-mercantile==1.1.6
+mercantile==1.2.1
     # via django-vectortiles
-methodtools==0.4.2
+methodtools==0.4.5
     # via amsterdam-schema-tools
-more-ds==0.0.4
+more-ds==0.0.6
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
-more-itertools==8.8.0
+more-itertools==9.0.0
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
+msal==1.20.0
+    # via
+    #   azure-identity
+    #   msal-extensions
+msal-extensions==1.0.0
+    # via azure-identity
 ndjson==0.3.1
     # via amsterdam-schema-tools
-openapi-schema-validator==0.2.3
+openapi-schema-validator==0.3.4
     # via openapi-spec-validator
-openapi-spec-validator==0.4.0
+openapi-spec-validator==0.5.1
     # via -r requirements.in
-opencensus==0.7.12
+opencensus==0.11.0
     # via
     #   opencensus-ext-azure
     #   opencensus-ext-django
     #   opencensus-ext-logging
-opencensus-context==0.1.2
+opencensus-context==0.1.3
     # via opencensus
-opencensus-ext-azure==1.0.7
+opencensus-ext-azure==1.1.7
     # via -r requirements.in
-opencensus-ext-django==0.7.4
+opencensus-ext-django==0.8.0
     # via -r requirements.in
-opencensus-ext-logging==0.1.0
+opencensus-ext-logging==0.1.1
     # via -r requirements.in
-ordered-set==4.0.2
+ordered-set==4.1.0
     # via deepdiff
-orjson==3.5.3
+orjson==3.8.0
     # via
     #   -r requirements.in
     #   django-gisserver
-packaging==20.9
+packaging==21.3
     # via
-    #   google-api-core
+    #   geoalchemy2
     #   pytest
-pbr==5.9.0
+pathable==0.4.3
+    # via jsonschema-spec
+pbr==5.11.0
     # via stevedore
 pg-grant==0.3.2
     # via amsterdam-schema-tools
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
 ply==3.11
     # via jsonpath-rw
-protobuf==3.18.3
+portalocker==2.6.0
+    # via msal-extensions
+protobuf==3.20.3
     # via
+    #   -r requirements.in
     #   google-api-core
     #   googleapis-common-protos
     #   mapbox-vector-tile
-psutil==5.8.0
+psutil==5.9.3
     # via opencensus-ext-azure
-psycopg2==2.8.6
+psycopg2==2.9.4
     # via amsterdam-schema-tools
-py==1.10.0
+py==1.11.0
     # via pytest
 pyasn1==0.4.8
     # via
@@ -235,118 +275,133 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pyclipper==1.2.1
+pyclipper==1.3.0.post3
     # via mapbox-vector-tile
-pycodestyle==2.7.0
+pycodestyle==2.9.1
     # via
     #   flake8
     #   flake8-debugger
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pyflakes==2.3.1
+pyflakes==2.5.0
     # via flake8
-pyparsing==2.4.7
+pyjwt[crypto]==2.6.0
+    # via msal
+pyparsing==3.0.9
     # via packaging
-pyrsistent==0.17.3
+pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.4
+pytest==7.1.3
     # via
     #   -r requirements.in
     #   pytest-cov
     #   pytest-django
-pytest-cov==2.12.1
+pytest-cov==4.0.0
     # via -r requirements.in
-pytest-django==4.1.0
+pytest-django==4.5.2
     # via -r requirements.in
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   amsterdam-schema-tools
+    #   arrow
     #   faker
-python-owasp-zap-v2-4==0.0.18
+python-owasp-zap-v2-4==0.0.20
     # via -r requirements.in
 python-string-utils==1.0.0
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
-pytz==2021.1
+pytz==2022.5
     # via
     #   django
-    #   google-api-core
-pyyaml==5.4.1
+    #   djangorestframework
+pyyaml==6.0
     # via
     #   bandit
     #   drf-spectacular
+    #   jsonschema-spec
     #   openapi-spec-validator
-requests==2.25.1
+requests==2.28.1
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
+    #   azure-core
     #   datapunt-authorization-django
     #   django-healthchecks
     #   google-api-core
+    #   msal
     #   opencensus-ext-azure
     #   python-owasp-zap-v2-4
+rfc3339-validator==0.1.4
+    # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
-rsa==4.7.2
+rsa==4.9
     # via google-auth
-sentry-sdk==1.0.0
+sentry-sdk==1.10.1
     # via -r requirements.in
-shapely==1.7.1
+shapely==1.8.5.post1
     # via
     #   amsterdam-schema-tools
     #   mapbox-vector-tile
-simple-singleton==1.1
+simple-singleton==1.5.1
     # via amsterdam-schema-tools
-singledispatch==3.6.1
+singledispatch==3.7.0
     # via json-encoder
-six==1.15.0
+six==1.16.0
     # via
-    #   django-healthchecks
+    #   azure-core
+    #   azure-identity
     #   djangorestframework-csv
-    #   flake8-debugger
-    #   google-api-core
     #   google-auth
     #   json-encoder
     #   jsonpath-rw
-    #   jsonschema
     #   python-dateutil
     #   python-owasp-zap-v2-4
+    #   rfc3339-validator
     #   singledispatch
     #   wirerope
 smmap==5.0.0
     # via gitdb
-sqlalchemy==1.3.24
+sqlalchemy==1.4.42
     # via
     #   amsterdam-schema-tools
     #   geoalchemy2
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via django
-stevedore==3.5.0
+stevedore==4.1.0
     # via bandit
-strict-rfc3339==0.7
-    # via jsonschema
-toml==0.10.2
+tomli==2.0.1
     # via
+    #   coverage
     #   pytest
-    #   pytest-cov
+typing-extensions==4.4.0
+    # via
+    #   azure-core
+    #   jsonschema-spec
 unicodecsv==0.14.1
     # via djangorestframework-csv
-uritemplate==3.0.1
+uri-template==1.2.0
+    # via jsonschema
+uritemplate==4.1.1
     # via drf-spectacular
-urllib3==1.26.5
+urllib3==1.26.12
     # via
     #   -r requirements.in
     #   requests
     #   sentry-sdk
 urllib3-mock==0.3.3
     # via -r requirements.in
-webcolors==1.11.1
+webcolors==1.12
     # via jsonschema
-wirerope==0.4.2
+wirerope==0.4.6
     # via methodtools
-wrapt==1.13.2
+wrapt==1.14.1
     # via deprecated
+zipp==3.10.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -2,16 +2,16 @@
 -r ./requirements.txt
 
 # Tools for maintaining requirements.txt:
-pip-tools == 6.1.0
-pur == 5.4.1
+pip-tools == 6.9.0
+pur == 7.0.0
 
 # Useful extra developer packages:
-black == 20.8b1
-isort == 5.8.0
-pytest-sugar == 0.9.4
-termcolor >= 1.1.0  # for pytest-sugar
-pre-commit == 2.13.0
+black == 22.10.0
+isort == 5.10.1
+pytest-sugar == 0.9.5
+termcolor >= 2.0.1  # for pytest-sugar
+pre-commit == 2.20.0
 
 # Debugging
-django-debug-toolbar == 3.2.1
-django-extensions == 3.1.3
+django-debug-toolbar == 3.7.0
+django-extensions == 3.2.1

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -12,7 +12,7 @@ from django.contrib.gis.geos import GEOSGeometry, Point
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import connection
 from django.utils.functional import SimpleLazyObject
-from django.utils.timezone import get_current_timezone, make_aware
+from django.utils.timezone import make_aware
 from jwcrypto.jwt import JWT
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
@@ -280,7 +280,7 @@ def afval_container(afval_container_model, afval_cluster):
         eigenaar_naam="Dataservices",
         # set to fixed dates to the CSV export can also check for desired formatting
         datum_creatie=date(2021, 1, 3),
-        datum_leegmaken=get_current_timezone().localize(datetime(2021, 1, 3, 12, 13, 14)),
+        datum_leegmaken=make_aware(datetime(2021, 1, 3, 12, 13, 14)),
         cluster=afval_cluster,
         geometry=Point(10, 10),  # no SRID on purpose, should use django model field.
     )


### PR DESCRIPTION
Bump all requirements for  security, future maintenance and to make room for future Django upgrades.

Django is kept at 3.2 for LTS support, but running this code on Django 4.0 works.

For Django 4.1 tests to pass, the ChunkedQuerysetIterator needs to be removed because Django 4.1 does the same internally.