### PR TITLE
Test isnull filter on a relation field

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1337,3 +1337,14 @@ def verblijfsobjecten_data(verblijfsobjecten_model, buurten_data, nummeraanduidi
         heeft_hoofdadres_identificatie="nm3",
         heeft_hoofdadres_volgnummer=5,
     )
+    verblijfsobjecten_model.objects.create(
+        id="e",
+        identificatie="vo5",
+        volgnummer=1,
+        ligt_in_buurt_id=None,
+        ligt_in_buurt_identificatie=None,
+        ligt_in_buurt_volgnummer=None,
+        heeft_hoofdadres_id="nm2.1",
+        heeft_hoofdadres_identificatie="nm3",
+        heeft_hoofdadres_volgnummer=6,
+    )

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -326,10 +326,10 @@ class TestFilterEngine:
     @pytest.mark.parametrize(
         "query,expect",
         [
-            ("", 4),
+            ("", 5),
             ("heeftHoofdadres.volgnummer=1", 2),
             ("heeftHoofdadres.identificatie=nm2", 1),
-            ("ligtInBuurt.identificatie[isnull]=1", 0),
+            ("ligtInBuurt.identificatie[isnull]=1", 1),
             ("ligtInBuurt.volgnummer[gte]=2", 3),
             ("ligtInBuurt.identificatie[like]=X*X", 1),
         ],


### PR DESCRIPTION
Inspired by a case reported on Slack where this doesn't work. Won't fix the issue, but makes it easier to spot regressions.