### PR TITLE
Run sphinx-build with parallel workers

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -15,7 +15,7 @@ COPY . /docs/
 # Added arg here, so build step is invalidated each time
 ARG BUILD_NUMBER=unknown
 RUN mkdir -p /docs/_static \
- && make html
+ && SPHINXOPTS="-j $(nproc)" make html
 
 # Static serving runtime
 FROM nginx


### PR DESCRIPTION
Generating the docs is one of the slower parts of our builds.

With this patch, on a 16-core laptop, I see

    docker build --build-arg BUILD_NUMBER=x .

(w/ fresh x) speed up by about a factor 4. The sequential part is writing the generated files out to disk.