### PR TITLE
Update API documentation, hide shortname syntax in API view

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-Sphinx == 4.1.2
-sphinx-rtd-theme == 0.5.2
-Pillow == 9.0.1
+Sphinx == 5.3.0
+sphinx-rtd-theme == 1.0.0
+Pillow == 9.3.0
 python-string-utils == 1.0.0
-amsterdam-schema-tools == 3.0.0
+amsterdam-schema-tools == 5.0
 
 # Required by Sphinx too
-jinja2 >= 3.0.1
+jinja2 >= 3.1.2

--- a/docs/source/_templates/datasets/dataset.rst.j2
+++ b/docs/source/_templates/datasets/dataset.rst.j2
@@ -61,7 +61,7 @@ De volgende velden zijn beschikbaar:
      - Type
      - Omschrijving
 {%- for field in table.fields %}
-   * - {% if field.is_deprecated %}:deprecated:`{{ field.camel_name }}` *gaat vervallen*{% else %}``{{ field.camel_name }}``{% endif %}{% if field.auth %} (autorisatie: {{ field.auth|sort|join(', ') }}){% endif %}
+   * - {% if field.is_deprecated %}:deprecated:`{{ field.api_name }}` *gaat vervallen*{% else %}``{{ field.api_name }}``{% endif %}{% if field.auth %} (autorisatie: {{ field.auth|sort|join(', ') }}){% endif %}
      - {{ field.type|default('') }}{% if field.is_relation or field.is_foreign_id %} *relatie*{% elif field.is_identifier %} *identificatie*{% endif %}
      - {{ field.description|default('') }}
 {%- endfor %}
@@ -98,7 +98,7 @@ De volgende velden kunnen ingesloten worden met ``?_expandScope=...``:
      - Tabel
      - Omschrijving
 {%- for expand in table.expands: %}
-   * - ``{{ expand.camel_name }}``
+   * - ``{{ expand.api_name }}``
      - :ref:`{{ expand.relation_id }} <{{ expand.target_doc_id }}>`
      - {{ expand.related_table.description or '' }}
 {%- endfor %}

--- a/docs/source/_templates/wfs-datasets/dataset.rst.j2
+++ b/docs/source/_templates/wfs-datasets/dataset.rst.j2
@@ -44,7 +44,7 @@ Velden
      - Type
      - Omschrijving
 {%- for field in table.fields %}
-   * - ``{{ field.snake_name }}`` {% if field.auth %} (autorisatie: {{ field.auth|sort|join(', ') }}){% endif %}
+   * - ``{{ field.python_name }}`` {% if field.auth %} (autorisatie: {{ field.auth|sort|join(', ') }}){% endif %}
      - {{ field.type|default('') }}
      - {{ field.description|default('') }}
 {%- endfor %}
@@ -62,14 +62,14 @@ De volgende velden kunnen ingesloten worden met ``?embed=...`` en ``?expand=...`
      - Tabel
      - Omschrijving
 {%- for expand in table.expands: %}
-   * - ``{{ expand.snake_name }}``
+   * - ``{{ expand.python_name }}``
      - :ref:`{{ expand.relation_id }} <{{ expand.target_doc_id }}>`
      - {{ expand.related_table.description or '' }}
 {%- endfor %}
 
 {% if table.expands|length > 1 %}
 Je kan meerdere velden insluiten door te ze scheiden met een comma, bijvoorbeeld:
-``?embed={{ table.expands.0.snake_name }},{{ table.expands.1.snake_name }}``
+``?embed={{ table.expands.0.python_name }},{{ table.expands.1.python_name }}``
 {% endif %}
 
 {% endif %}

--- a/src/rest_framework_dso/openapi.py
+++ b/src/rest_framework_dso/openapi.py
@@ -262,6 +262,10 @@ class DSOAutoSchema(openapi.AutoSchema):
         return paginator
 
     def _map_model_field(self, model_field, direction):
+        """This method is called by DRF-spectacular when a serializer field
+        is only mentioned in "Meta.fields", but doesn't have a declared field yet
+        (e.g. added via ``SerializerAssemblyLine.add_field_name()``).
+        """
         schema = super()._map_model_field(model_field, direction=direction)
 
         if isinstance(model_field, gis_models.GeometryField):
@@ -273,8 +277,12 @@ class DSOAutoSchema(openapi.AutoSchema):
         return schema
 
     def _map_serializer_field(self, field, direction, bypass_extensions=False):
-        """Transform the serializer field into a OpenAPI definition.
-        This method is overwritten to fix some missing field types.
+        """This method is called by DRF-spectacular when a serializer field
+        is defined with a corresponding ``serializer.Field`` class
+        (e.g. added via ``SerializerAssemblyLine.add_field()``).
+
+        This method transforms the serializer field into a OpenAPI definition.
+        We've overwritten this to change the geometry field representation.
         """
         if not hasattr(field, "_spectacular_annotation"):
             # Fix support for missing field types:

--- a/src/tests/test_rest_framework_dso/models.py
+++ b/src/tests/test_rest_framework_dso/models.py
@@ -30,6 +30,7 @@ class Category(models.Model, NonTemporalMixin):
 
     class Meta:
         app_label = "test_rest_framework_dso"
+        ordering = ("name",)
 
 
 class Actor(models.Model, NonTemporalMixin):
@@ -40,6 +41,7 @@ class Actor(models.Model, NonTemporalMixin):
 
     class Meta:
         app_label = "test_rest_framework_dso"
+        ordering = ("name",)
 
 
 class Movie(models.Model, NonTemporalMixin):

--- a/src/tests/test_rest_framework_dso/test_serializers.py
+++ b/src/tests/test_rest_framework_dso/test_serializers.py
@@ -26,8 +26,8 @@ def test_serializer_single(drf_request, movie):
         "date_added": None,
         "_embedded": {
             "actors": [
-                {"name": "John Doe"},
                 {"name": "Jane Doe"},
+                {"name": "John Doe"},
             ],
             "category": {"name": "bar"},
         },
@@ -48,8 +48,8 @@ def test_serializer_many(drf_request, movie):
     assert data == {
         "movie": [{"name": "foo123", "category_id": movie.category_id, "date_added": None}],
         "actors": [
-            {"name": "John Doe"},
             {"name": "Jane Doe"},
+            {"name": "John Doe"},
         ],
         "category": [{"name": "bar"}],
     }
@@ -112,8 +112,8 @@ def test_pagination_many(drf_request, movie):
         "_embedded": {
             "movie": [{"name": "foo123", "category_id": movie.category_id, "date_added": None}],
             "actors": [
-                {"name": "John Doe"},
                 {"name": "Jane Doe"},
+                {"name": "John Doe"},
             ],
             "category": [{"name": "bar"}],
         },

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -78,12 +78,12 @@ class TestExpand:
             "_embedded": {
                 "actors": [
                     {
-                        "name": "John Doe",
-                        "_embedded": {"last_updated_by": None},
-                    },
-                    {
                         "name": "Jane Doe",
                         "_embedded": {"last_updated_by": {"name": "jane_updater"}},
+                    },
+                    {
+                        "name": "John Doe",
+                        "_embedded": {"last_updated_by": None},
                     },
                 ],
                 "category": {
@@ -113,8 +113,8 @@ class TestExpand:
             "date_added": None,
             "_embedded": {
                 "actors": [
-                    {"name": "John Doe"},
                     {"name": "Jane Doe"},
+                    {"name": "John Doe"},
                 ],
                 "category": {"name": "bar"},
             },
@@ -198,12 +198,12 @@ class TestExpand:
                 ],
                 "actors": [
                     {
-                        "name": "John Doe",
-                        "_embedded": {"last_updated_by": None},
-                    },
-                    {
                         "name": "Jane Doe",
                         "_embedded": {"last_updated_by": {"name": "jane_updater"}},
+                    },
+                    {
+                        "name": "John Doe",
+                        "_embedded": {"last_updated_by": None},
                     },
                 ],
                 "category": [
@@ -241,8 +241,8 @@ class TestExpand:
                     {"name": "foo123", "category_id": movie.category_id, "date_added": None}
                 ],
                 "actors": [
-                    {"name": "John Doe"},
                     {"name": "Jane Doe"},
+                    {"name": "John Doe"},
                 ],
                 "category": [{"name": "bar"}],
             },


### PR DESCRIPTION
Also mark old deprecated names that still appear in the OpenAPI view (no shortnames are shown there either)