### PR TITLE
Remove "api" from formats in browsable API dropdown

### DIFF
--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -111,6 +111,10 @@ class BrowsableAPIRenderer(RendererMixin, renderers.BrowsableAPIRenderer):
     def get_context(self, data, accepted_media_type, renderer_context):
         context = super().get_context(data, accepted_media_type, renderer_context)
 
+        formats = context["available_formats"]
+        if "api" in formats:
+            formats.remove("api")
+
         # Maintain compatibility with other types of ViewSets
         context["authorization_grantor"] = getattr(context["view"], "authorization_grantor", None)
 


### PR DESCRIPTION
_format=api puts HTTP headers + HTML response inside the div that shows the response. I can't imagine this is useful and it has given error 406 in the past. Fixes AB#28405.