### PR TITLE
Generate docs on the fly

### DIFF
--- a/docs/source/_templates/datasets/dataset.rst.j2
+++ b/docs/source/_templates/datasets/dataset.rst.j2
@@ -18,7 +18,7 @@
 * **Uitgever:** {{ schema.publisher }}
 * **Bronhouder:** {{ schema.creator }}
 * **Versie:** {{ schema.version }}
-{% if datset_has_auth %}
+{% if dataset_has_auth %}
 
 Toegang kan worden aangevraagd bij de uitgever: {{ schema.publisher }}
 

--- a/src/dso_api/dynamic_api/urls.py
+++ b/src/dso_api/dynamic_api/urls.py
@@ -4,14 +4,15 @@ from importlib import import_module, reload
 from django.conf import settings
 from django.urls import clear_url_caches, get_urlconf, include, path
 
-from dso_api.dynamic_api.routers import DynamicRouter
-
 from . import views
+from .routers import DynamicRouter
+from .views.doc import DocsOverview
 
 
 def get_patterns(router_urls):
     """Generate the actual URL patterns for this file."""
     return [
+        path("docs/", DocsOverview.as_view()),
         path("mvt/", views.DatasetMVTIndexView.as_view(), name="mvt-index"),
         path("wfs/", views.DatasetWFSIndexView.as_view()),
         path("", include(router_urls)),

--- a/src/dso_api/dynamic_api/views/__init__.py
+++ b/src/dso_api/dynamic_api/views/__init__.py
@@ -1,5 +1,6 @@
 """All views for the dynamically generated API, split by protocol type."""
 from .api import DynamicApiViewSet, viewset_factory
+from .doc import DatasetDocView, DocsOverview
 from .index import APIIndexView
 from .mvt import DatasetMVTIndexView, DatasetMVTSingleView, DatasetMVTView
 from .oauth import oauth2_redirect
@@ -8,11 +9,13 @@ from .wfs import DatasetWFSIndexView, DatasetWFSView
 __all__ = (
     "DynamicApiViewSet",
     "APIIndexView",
+    "DatasetDocView",
     "DatasetMVTView",
     "DatasetMVTIndexView",
     "DatasetMVTSingleView",
     "DatasetWFSView",
     "DatasetWFSIndexView",
+    "DocsOverview",
     "oauth2_redirect",
     "viewset_factory",
 )

--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -1,0 +1,356 @@
+"""Dataset documentation views."""
+from typing import Any, List, FrozenSet, Optional, NamedTuple
+
+from django.shortcuts import get_object_or_404
+from django.views.generic import TemplateView
+from schematools.contrib.django.models import Dataset
+from schematools.types import DatasetTableSchema, DatasetFieldSchema, DatasetSchema
+from schematools.naming import to_snake_case
+
+
+class DocsOverview(TemplateView):
+    template_name = "dso_api/dynamic_api/docs/overview.html"
+
+    def get_context_data(self, **kwargs):
+        datasets = (ds.schema for ds in Dataset.objects.api_enabled().db_enabled().all())
+        context = super().get_context_data(**kwargs)
+        context["datasets"] = [
+            # TODO path
+            {"id": ds.id, "title": ds.title, "tables": [table.id for table in ds.tables]}
+            for ds in datasets
+        ]
+        return context
+
+
+class DatasetDocView(TemplateView):
+    template_name = "dso_api/dynamic_api/docs/dataset.html"
+
+    def get_context_data(self, **kwargs):
+        d: Dataset = get_object_or_404(
+            Dataset.objects.api_enabled().db_enabled(), name=kwargs["dataset_name"]
+        )
+        ds: DatasetSchema = d.schema
+        path = d.path
+
+        main_title = ds.title or ds.db_name.replace("_", " ").capitalize()
+        tables = [_table_context(t, path) for t in ds.tables]
+        if any(t.has_geometry_fields for t in ds.tables):
+            pass
+
+        context = super().get_context_data(**kwargs)
+        context.update(
+            dict(
+                schema=ds,
+                schema_name=ds.db_name,
+                schema_auth=ds.auth,
+                dataset_has_auth=bool(_fix_auth(ds.auth)),
+                main_title=main_title,
+                tables=tables,
+                swagger_url=f"{BASE_URL}/v1/{path}/",
+            )
+        )
+
+        return context
+
+
+class LookupContext(NamedTuple):
+    operator: str
+    value_example: Optional[str]
+    description: str
+
+
+# This should match ALLOWED_SCALAR_LOOKUPS in filters.parser (except for the "exact" lookup).
+_comparison_lookups = ["gt", "gte", "lt", "lte", "not", "in", "isnull"]
+_identifier_lookups = ["in", "not", "isnull"]
+_polygon_lookups = ["contains", "isnull", "not"]
+_string_lookups = ["in", "like", "not", "isnull", "isempty"]
+
+FORMAT_ALIASES = {
+    "date-time": "Datetime",
+}
+
+BASE_URL = "https://api.data.amsterdam.nl"
+
+VALUE_EXAMPLES = {
+    "string": ("Tekst", _string_lookups),
+    "boolean": ("``true`` | ``false``", []),
+    "integer": ("Geheel getal", _comparison_lookups),
+    "number": ("Getal", _comparison_lookups),
+    "time": ("``hh:mm[:ss[.ms]]``", _comparison_lookups),
+    "date": ("``yyyy-mm-dd``", _comparison_lookups),
+    "date-time": ("``yyyy-mm-dd`` of ``yyyy-mm-ddThh:mm[:ss[.ms]]``", _comparison_lookups),
+    "uri": ("https://....", _string_lookups),
+    "array": ("value,value", ["contains"]),  # comma separated list of strings
+    "https://geojson.org/schema/Geometry.json": ("geometry", _polygon_lookups),
+    "https://geojson.org/schema/Polygon.json": (
+        "GeoJSON of ``POLYGON(x y ...)``",
+        _polygon_lookups,
+    ),
+    "https://geojson.org/schema/MultiPolygon.json": (
+        "GeoJSON of ``MULTIPOLYGON(x y ...)``",
+        _polygon_lookups,
+    ),
+}
+
+LOOKUP_CONTEXT = {
+    lookup.operator: lookup
+    for lookup in [
+        LookupContext("gt", None, "Test op groter dan (``>``)."),
+        LookupContext("gte", None, "Test op groter dan of gelijk (``>=``)."),
+        LookupContext("lt", None, "Test op kleiner dan (``<``)."),
+        LookupContext("lte", None, "Test op kleiner dan of gelijk (``<=``)."),
+        LookupContext(
+            "like", "Tekst met jokertekens (``*`` en ``?``).", "Test op gedeelte van tekst."
+        ),
+        LookupContext(
+            "in",
+            "Lijst van waarden",
+            "Test of de waarde overeenkomst met 1 van de opties (``IN``).",
+        ),
+        LookupContext("not", None, "Test of waarde niet overeenkomt (``!=``)."),
+        LookupContext(
+            "contains", "Comma gescheiden lijst", "Test of er een intersectie is met de waarde."
+        ),
+        LookupContext(
+            "isnull",
+            "``true`` of ``false``",
+            "Test op ontbrekende waarden (``IS NULL`` / ``IS NOT NULL``).",
+        ),
+        LookupContext(
+            "isempty", "``true`` of ``false``", "Test of de waarde leeg is (``== ''`` / ``!= ''``)"
+        ),
+    ]
+}
+
+
+def _table_context(table: DatasetTableSchema, path: str):
+    """Collect all table data for the REST API spec."""
+    uri = _get_table_uri(table, path)
+    table_fields = table.fields
+    fields = _list_fields(table_fields)
+    filters = _get_filters(table_fields)
+
+    return {
+        "title": to_snake_case(table.id).replace("_", " ").capitalize(),
+        "doc_id": _make_link(table),
+        "uri": uri,
+        "rest_csv": f"{uri}?_format=csv",
+        "rest_geojson": f"{uri}?_format=geojson",
+        "description": table.get("description"),
+        "fields": [_get_field_context(field) for field in fields],
+        "filters": filters,
+        "auth": _fix_auth(table.auth | table.dataset.auth),
+        "expands": _make_table_expands(table),
+        "source": table,
+        "has_geometry": table.has_geometry_fields,
+    }
+
+
+def _make_link(to_table: DatasetTableSchema, id_separator=":") -> str:
+    path = get_object_or_404(
+        Dataset.objects.api_enabled().db_enabled(), name = to_table.dataset.id,
+    ).path
+    return _get_table_uri(to_table, path)
+
+
+def _get_table_uri(table: DatasetTableSchema, dataset_path: str) -> str:
+    """Tell where the endpoint of a table will be"""
+    snake_id = to_snake_case(table.id)
+    return f"{BASE_URL}/v1/{dataset_path}/{snake_id}/"
+
+
+def _make_table_expands(table: DatasetTableSchema, id_separator=":"):
+    """Return which relations can be expanded"""
+    expands = [
+        {
+            "id": field.id,
+            "camel_name": field.name,
+            "snake_name": field.python_name,
+            "relation_id": field["relation"].replace(":", id_separator),
+            "target_doc_id": _make_link(field.related_table, id_separator),
+            "related_table": field.related_table,
+        }
+        for field in table.fields
+        if field.get("relation") is not None
+    ]
+
+    # Reverse relations can also be expanded
+    for additional_relation in table.additional_relations:
+        expands.append(
+            {
+                "id": additional_relation.id,
+                "api_name": additional_relation.name,
+                "python_name": additional_relation.python_name,
+                "relation_id": additional_relation.relation.replace(":", id_separator),
+                "target_doc_id": _make_link(additional_relation.related_table, id_separator),
+                "related_table": additional_relation.related_table,
+            }
+        )
+
+    return sorted(expands, key=lambda item: item["id"])
+
+
+def _list_fields(table_fields) -> List[DatasetFieldSchema]:
+    """List fields and their subfields in a single flat list."""
+    result_fields = []
+    for field in table_fields:
+        if field.name == "schema":
+            continue
+
+        result_fields.append(field)
+        result_fields.extend(_list_fields(field.subfields))
+
+    return result_fields
+
+
+def _field_data(field: DatasetFieldSchema):
+    type = field.type
+    format = field.format
+    try:
+        value_example, lookups = VALUE_EXAMPLES[format or type]
+    except KeyError:
+        value_example = ""
+        lookups = []
+
+    if format:
+        # A string field with a format (e.g. date-time).
+        return FORMAT_ALIASES.get(format, format), value_example, lookups
+
+    # This closely mimics what the Django filter+serializer logic does
+    if type.startswith("https://geojson.org/schema/"):
+        # Catch-all for other geometry types
+        type = type[27:-5]
+        value_example = f"GeoJSON of ``{type.upper()}(x y ...)``"
+        lookups = []
+    elif field.relation or "://" in type:
+        lookups = _identifier_lookups
+        if field.type == "string":
+            lookups += [lookup for lookup in _string_lookups if lookup not in lookups]
+
+    return type, value_example, lookups
+
+
+def _get_field_context(field: DatasetFieldSchema) -> dict[str, Any]:
+    """Get context data for a field."""
+    python_name = _get_dotted_python_name(field)
+    api_name = _get_dotted_api_name(field)
+
+    type, value_example, _ = _field_data(field)
+    description = field.description
+    is_foreign_id = (
+        field.is_subfield and field.parent_field.relation and not field.is_temporal_range
+    )
+    if not description and is_foreign_id and field.id in field.parent_field.related_field_ids:
+        # First identifier gets parent field description.
+        description = field.parent_field.description
+
+    return {
+        "id": field.id,
+        "python_name": python_name,
+        "api_name": api_name,
+        "is_identifier": field.is_identifier_part,
+        "is_deprecated": False,
+        "is_relation": bool(field.relation),
+        "is_foreign_id": is_foreign_id,
+        "type": (type or "").capitalize(),
+        "description": description or "",
+        "source": field,
+        "auth": _fix_auth(field.auth | field.table.auth | field.table.dataset.auth),
+    }
+
+
+def _get_dotted_python_name(field: DatasetFieldSchema) -> str:
+    """Find the snake and camel names of a field"""
+    snake_name = to_snake_case(field.id)
+
+    parent_field = field.parent_field
+    while parent_field is not None:
+        parent_snake_name = to_snake_case(parent_field.id)
+        snake_name = f"{parent_snake_name}.{snake_name}"
+        parent_field = parent_field.parent_field
+
+    return snake_name
+
+
+def _get_dotted_api_name(field: DatasetFieldSchema) -> str:
+    """Find the snake and camel names of a field"""
+    camel_name = field.name
+    parent_field = field.parent_field
+    while parent_field is not None:
+        parent_camel_name = parent_field.name
+        camel_name = f"{parent_camel_name}.{camel_name}"
+        parent_field = parent_field.parent_field
+
+    return camel_name
+
+
+def _get_filters(table_fields: List[DatasetFieldSchema]) -> List[dict[str, Any]]:
+    filters = []
+    id_seen = False
+    for field in table_fields:
+        if field.id == "schema":
+            continue
+        # temporary patch until schematools is bumped to a version that
+        # does not duplicate the id field
+        if field.id == "id":
+            if id_seen:
+                continue
+            id_seen = True
+        filters.extend(_filter_context(field))
+    return filters
+
+
+def _filter_payload(
+        field: DatasetFieldSchema, *, prefix: str = "", name_suffix: str = "", is_deprecated=False
+):
+    name = prefix + _get_dotted_api_name(field) + name_suffix
+    type, value_example, lookups = _field_data(field)
+
+    return {
+        "name": name,
+        "type": type.capitalize(),
+        "is_deprecated": is_deprecated,
+        "value_example": value_example or "",
+        "lookups": [LOOKUP_CONTEXT[op] for op in lookups],
+        "auth": _fix_auth(field.auth | field.table.auth | field.table.dataset.auth),
+    }
+
+
+def _filter_context(field: DatasetFieldSchema) -> List[dict[str, Any]]:
+    """Return zero or more filter context(s) from the a field schema.
+
+    This function essentially reconstructs the output of the FilterSet
+    generation in the dynamic api directly from the underlying schema.
+    """
+    if field.relation:
+        if field.is_scalar:
+            # normal FKs, can now be parsed using dot-notation
+            prefix = _get_dotted_api_name(field) + "."
+            return [_filter_payload(id_field, prefix=prefix) for id_field in field.related_fields]
+        elif field.is_composite_key:
+            # composite key / temporal relation. Add those fields
+            return [
+                _filter_payload(sub_field)
+                for sub_field in field.subfields
+                if not sub_field.is_temporal_range
+            ]
+
+    elif field.is_nested_table:
+        return [_filter_payload(f) for f in field.subfields]
+    elif field.is_scalar or field.is_array_of_scalars:
+        # Regular filters
+        return [_filter_payload(field)]
+    elif field.nm_relation:
+        return [_filter_payload(field)]
+
+    # TODO: Field is an object but not a relation?
+
+    return []
+
+
+def _fix_auth(auth: FrozenSet[str]) -> FrozenSet[str]:
+    """Hide the OPENBAAR tag.
+    When the dataset is public, but table isn't,
+    this could even mix authorization levels.
+    """
+    return auth - {"OPENBAAR"}

--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -14,8 +14,8 @@ from schematools.naming import to_snake_case
 from schematools.types import DatasetTableSchema
 from vectortiles.postgis.views import MVTView
 
-from dso_api.dynamic_api.datasets import get_active_datasets
-from dso_api.dynamic_api.permissions import CheckPermissionsMixin
+from ..datasets import get_active_datasets
+from ..permissions import CheckPermissionsMixin
 
 from .index import APIIndexView
 

--- a/src/templates/dso_api/dynamic_api/docs/dataset.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset.html
@@ -1,0 +1,143 @@
+<!doctype html>{% load i18n %}
+<html>
+<head>
+  <title>{% if schema.title %}{{ schema.title }}{% else %}{{ name|title }}{% endif %} &mdash; Amsterdam Datapunt API Documentatie v1</title>
+  {% block extrahead %}{% endblock %}
+</head>
+<body>
+  <h1>{% if schema.title %}{{ schema.title }}{% else %}{{ name|title }}{% endif %} MVT</h1>
+  <p>{% if schema.description %}{{ schema.description }}{% endif %}</p>
+  <ul>
+    <li><strong>ID:</strong> {{ schema.id }}</li>
+    <li><strong>Versie:</strong> {{ schema.version }}</li>
+    <li><strong>Autorisatie:</strong> {{ schema.auth }}</li>
+    <li><strong>Licentie:</strong> {{ schema.license }}</li>
+    <li><strong>Eigenaar:</strong> {{ schema.owner }}</li>
+    <li><strong>Uitgever:</strong> {{ schema.publisher }}</li>
+    <li><strong>Bronhouder:</strong> {{ schema.creator }}</li>
+  </ul>
+
+  {% if dataset_has_auth %}
+    <p><Toegang kan worden aangevraagd bij de uitgever: {{ schema.publisher }}</p>
+  {% endif %}
+
+  <h1>Endpoints</h1>
+  <ul>
+    <li>Swagger UI: <a href="{{ swagger_url }}">{{ swagger_url }}</a></li>
+  </ul>
+
+  <h1>Tabellen</h1>
+  {% for table in tables %}
+    <h2>{{ table.title }}</h2>
+    {% if table.description %}<p>{{ table.description }}</p>{% endif %}
+
+    <ul>
+      <li>
+        <strong>Autorisatie:</strong>
+        {% if table.auth %}
+          {{ table.auth|join:", " }}
+        {% else %}
+          Geen, dit is openbare data.
+        {% endif %}
+      </li>
+      <li><strong>REST URI:</strong> <a href="{{ table.uri }}">{{ table.uri }}</a></li>
+    </ul>
+
+    <p>De volgende velden zijn beschikbaar:</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Veldnaam</th>
+          <th>Type</th>
+          <th>Omschrijving</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for field in table.fields %}
+        <tr>
+          <td>
+            {% if field.is_deprecated %}
+            <s>{{ field.name }}</s> <i>gaat vervallen</i>
+            {% else %}
+            {{ field.name }}
+            {% endif %}
+          </td>
+          <td>
+            {{ field.type|default:"" }}
+            {% if field.is_identifier %}<i>identificatie</i>{% endif %}
+            {% if field.is_relation or field.is_foreign_id %}<i>relatie</i>{% endif %}
+          </td>
+          <td>{{ field.description|default:"" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <p>De volgende query-parameters zijn te gebruiken:</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Parameter</th>
+          <th>Autorisatie</th>
+          <th>Mogelijke waarden</th>
+          <th>Werking</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for filter in table.filters %}
+        <tr>
+          <td>
+            {% if filter.is_deprecated %}
+              <s>{{ filter.name }}</s> <i>gaat vervallen</i>
+            {% else %}
+              {{ filter.name }}
+            {% endif %}
+          </td>
+          <td>{{ filter.auth|join:", " }}</td>
+          <td>{{ filter.value_example|default:"" }}</td>
+          <td>Test op exacte waarde (<code>==</code>)</td>
+        </tr>
+        {% for lookup in filter.lookups %}
+          <tr>
+            <td>
+              {% if filter.is_deprecated %}
+                <s>{{ filter.name }}[{{ lookup.operator }}]</s> <i>gaat vervallen</i>
+              {% else %}
+                {{ filter.name }}[{{ lookup.operator }}]
+              {% endif %}
+            </td>
+            <td>{{ filter.auth|join:", " }}</td>
+            <td>{{ lookup.value_example|default:"" }}</td>
+            <td>{{ lookup.description }}</td>
+          </tr>
+        {% endfor %}
+      {% endfor %}
+      </tbody>
+    </table>
+
+    {% if table.expands %}
+      <h3>Insluitbare relaties</h3>
+      <p>De volgende velden kunnen ingesloten worden met <code>?_expandScope=...</code>:</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Relatie</th>
+            <th>Tabel</th>
+            <th>Omschrijving</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for expand in table.expands %}
+            <tr>
+              <td>{{ expand.api_name }}</td>
+              <td><a href="{{ expand.target_doc_id }}">{{ expand.relation_id }}</a></td>
+              <td>{{ expand.related_table.description|default:"" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  {% endfor %}
+
+</body>
+</html>

--- a/src/templates/dso_api/dynamic_api/docs/overview.html
+++ b/src/templates/dso_api/dynamic_api/docs/overview.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Amsterdam DataPunt API Documentatie</title>
+</head>
+<body>
+
+<h1>Amsterdam DataPunt API Documentatie</h1>
+
+<p>
+  In deze pagina's geven we uitleg hoe de API diensten van Datapunt afgenomen worden.
+</p>
+<p class="note">
+  Naast de API's van DataPunt worden door andere partijen nog diverse API's aangeboden.
+  Deze vind je in de <a href="https://data.amsterdam.nl/datasets/zoek/?filters=distributionType%3Bapi">datasetcatalogus</a>.
+  Deze documentatie richt zich tot de API's van DataPunt, onderdeel van OIS (Onderzoek, Informatie en Statistiek)
+  van de Gemeente Amsterdam.
+</p>
+<p>
+  De gemeente Amsterdam biedt haar datasets onder andere aan via een REST API die voldoet aan de
+  <a href="https://forumstandaardisatie.nl/open-standaarden/rest-api-design-rules">NL API REST API Design Rules</a>.
+  Daarnaast is ook gekozen de strictere interpretatie van de
+  <a href="https://iplo.nl/digitaal-stelsel/aansluiten/standaarden/api-en-uri-strategie">DSO API Strategie 2.0</a>
+  te volgen, aangezien het de intentie van de DSO API Strategie is om een interoperabel
+  koppelvlak voor data-uitwisseling te ontwikkelen dat overeenkomt met de behoeftes
+  van de Gemeente Amsterdam.
+</p>
+<p>
+  Om zoveel mogelijk afnemers te kunnen bedienen, ondersteunen we diverse koppelingen.
+  Zo zal een mobiele-appontwikkelaar eerder een <a href="generic/rest.html">REST-API</a> gebruiken,
+  en een GIS-professional de <a href="generic/gis.html">WFS/MVT-koppelingen</a>.
+  Tot slot worden er ook volledige CSV en GeoJSON exports ondersteund.
+</p>
+
+<h2>Algemene uitleg</h2>
+<ul>
+  <li>TODO</li>
+</ul>
+
+<h2>Naslagwerk datasets</h2>
+<ul>
+  {% for ds in datasets %}
+  <li>
+    <a href="datasets/{{ ds.id }}">{{ ds.title|title }}</a>
+    <ul>
+    {% for table in ds.tables %}
+      <li><a href="datasets/{{ ds.id }}#{{ table }}">{{ table }}</a></li>
+    {% endfor %}
+    </ul>
+  </li>
+  {% endfor %}
+</ul>
+
+</body>
+</html>

--- a/src/templates/dso_api/dynamic_api/mvt_single.html
+++ b/src/templates/dso_api/dynamic_api/mvt_single.html
@@ -11,10 +11,9 @@
     <dl>
       <p>ID: {{ schema.id }}</p>
       <p>Status: {{ schema.status }}</p>
-      <p>Openbaar: {% if schema.auth %} Nee {% else %} Ja {% endif %}</p>
+      <p>Openbaar: {{ schema.auth }}</p>
       <p>Licentie: {{ schema.license }}</p>
     </dl> 
-  </p>
       <h2>Gebruik van deze dataset</h2>
         <p>Voeg de volgende urls toe aan uw GIS applicatie:</p>
       <ul>


### PR DESCRIPTION
This adds an endpoint /v1/docs/datasets/{dataset_id}.html that displays automatically generated HTML documentation for a dataset. The contents match those of the Sphinx documentation, which these docs must ultimately replace. There is also an overview of datasets at /v1/docs/.

The HTML isn't styled yet, but the functionality is there. For now, this will not display on api.data.amsterdam.nl/v1/docs/, which uses proxy rules to display docs from a separate Docker image instead.

For [AB#56614](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/56614).