### PR TITLE
Dataset docs: generate URLs using the router

### DIFF
--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -145,7 +145,7 @@ def _table_context(table: DatasetTableSchema, path: str):
     }
 
 
-def _make_link(to_table: DatasetTableSchema, id_separator=":") -> str:
+def _make_link(to_table: DatasetTableSchema) -> str:
     path = get_object_or_404(
         Dataset.objects.api_enabled().db_enabled(), name = to_table.dataset.id,
     ).path
@@ -166,7 +166,7 @@ def _make_table_expands(table: DatasetTableSchema, id_separator=":"):
             "camel_name": field.name,
             "snake_name": field.python_name,
             "relation_id": field["relation"].replace(":", id_separator),
-            "target_doc_id": _make_link(field.related_table, id_separator),
+            "target_doc_id": _make_link(field.related_table),
             "related_table": field.related_table,
         }
         for field in table.fields
@@ -181,7 +181,7 @@ def _make_table_expands(table: DatasetTableSchema, id_separator=":"):
                 "api_name": additional_relation.name,
                 "python_name": additional_relation.python_name,
                 "relation_id": additional_relation.relation.replace(":", id_separator),
-                "target_doc_id": _make_link(additional_relation.related_table, id_separator),
+                "target_doc_id": _make_link(additional_relation.related_table),
                 "related_table": additional_relation.related_table,
             }
         )

--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -3,12 +3,15 @@ from typing import Any, List, FrozenSet, Optional, NamedTuple
 
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.gzip import gzip_page
 from django.views.generic import TemplateView
 from schematools.contrib.django.models import Dataset
 from schematools.types import DatasetTableSchema, DatasetFieldSchema, DatasetSchema
 from schematools.naming import to_snake_case
 
 
+@method_decorator(gzip_page, name="dispatch")
 class DocsOverview(TemplateView):
     template_name = "dso_api/dynamic_api/docs/overview.html"
 
@@ -26,6 +29,7 @@ class DocsOverview(TemplateView):
         return context
 
 
+@method_decorator(gzip_page, name="dispatch")
 class DatasetDocView(TemplateView):
     template_name = "dso_api/dynamic_api/docs/dataset.html"
 

--- a/src/templates/dso_api/dynamic_api/docs/dataset.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset.html
@@ -28,7 +28,7 @@
 
   <h1>Tabellen</h1>
   {% for table in tables %}
-    <h2>{{ table.title }}</h2>
+    <h2><a id="{{ table.id }}">{{ table.title }}</a></h2>
     {% if table.description %}<p>{{ table.description }}</p>{% endif %}
 
     <ul>

--- a/src/templates/dso_api/dynamic_api/docs/overview.html
+++ b/src/templates/dso_api/dynamic_api/docs/overview.html
@@ -42,10 +42,10 @@
 <ul>
   {% for ds in datasets %}
   <li>
-    <a href="datasets/{{ ds.path }}.html">{{ ds.title|title }}</a>
+    <a href="{{ ds.uri }}">{{ ds.title|title }}</a>
     <ul>
     {% for table in ds.tables %}
-      <li><a href="datasets/{{ ds.path }}.html#{{ table }}">{{ table.title }}</a></li>
+      <li><a href="{{ ds.uri }}#{{ table }}">{{ table.title }}</a></li>
     {% endfor %}
     </ul>
   </li>

--- a/src/tests/test_dynamic_api/test_doc.py
+++ b/src/tests/test_dynamic_api/test_doc.py
@@ -13,3 +13,18 @@ def test_overview(api_client, fietspaaltjes_dataset):
 
     content = response.rendered_content
     assert """<a href="datasets/fietspaaltjes.html#fietspaaltjes">Fietspaaltjes</a>""" in content
+
+
+@pytest.mark.django_db
+def test_dataset(api_client, filled_router, gebieden_dataset):
+    """Tests documentation for a single dataset."""
+    gebieden_doc = reverse("dynamic_api:doc-gebieden")  # Gebieden has relationships between its tables.
+    assert gebieden_doc
+
+    response = api_client.get(gebieden_doc)
+    assert response.status_code == 200
+    content = response.rendered_content
+
+    # Check for self-link to wijken.
+    assert """<a id="wijken">""" in content
+    assert """<a href="/v1/docs/datasets/gebieden.html#wijken">gebieden:wijken:ligtInStadsdeel</a>""" in content


### PR DESCRIPTION
Includes a unit test. For [AB#61560](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/61560).

Also adds compression, which should be safe here because the response bodies are practically static.