### PR TITLE
Remove some cruft from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-.. vim:noswapfile:nobackup:nowritebackup:
-.. highlight:: console
-
 # DSO API
 
 A new generic API that exposes datasets.


### PR DESCRIPTION
This includes some instructions for Vim that don't actually seem to work. GitHub is displaying them, which looks rather unprofessional.