### PR TITLE
Don't build docs for datasets marked niet_beschikbaar

### DIFF
--- a/docs/source/datasets.py
+++ b/docs/source/datasets.py
@@ -441,7 +441,8 @@ def render_datasets(schema_dir):
     datasets_path = BASE_PATH / Path("datasets")
 
     for path, dataset in schemas.items():
-        render_dataset_docs(dataset, path)
+        if dataset.status == DatasetSchema.Status.beschikbaar:
+            render_dataset_docs(dataset, path)
 
     # Leverage the fact that the dataset rendering has written the same
     # directory structure as the remote datasets listing in order
@@ -470,7 +471,8 @@ def render_datasets(schema_dir):
     )
 
     for path, dataset in schemas.items():
-        render_wfs_dataset_docs(dataset, path)
+        if dataset.status == DatasetSchema.Status.beschikbaar:
+            render_wfs_dataset_docs(dataset, path)
 
     datasets_path = BASE_PATH / Path("wfs-datasets")
 


### PR DESCRIPTION
With this change, `bag_azure` and `brk2` no longer appear in `source/datasets`, `source/wfs-datasets` or the `index.rst` files in those directories.