### PR TITLE
Expand tests for relation[isnull] filters

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1163,6 +1163,13 @@ def panden_data(panden_model, dossiers_model, bouwblokken_data):
         ligt_in_bouwblok_volgnummer="1",
         heeft_dossier_id="GV00000406",
     )
+    panden_model.objects.create(
+        id="9999999999999999.9",
+        identificatie="9999999999999999",
+        volgnummer=3,
+        begin_geldigheid=DATE_2021_FEB,
+        naam="Pand zonder bouwblok of dossier",
+    )
     dossiers_model.objects.create(dossier="GV00000406")
 
 

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -204,7 +204,7 @@ class TestFilterEngine:
     @pytest.mark.parametrize(
         "query,expect",
         [
-            ("", 1),
+            ("", 2),
             ("ligtInBouwblok.identificatie=03630012096483&ligtInBouwblok.volgnummer=1", 1),
             ("ligtInBouwblok.identificatie=03630012096483&ligtInBouwblok.volgnummer=2", 0),
             ("ligtInBouwblokId=03630012096483.1", 1),  # deprecated format, but test anyway!
@@ -213,6 +213,10 @@ class TestFilterEngine:
             ("ligtInBouwblok=123", 0),
             ("ligtInBouwblok.ligtInBuurtId=03630000000078.2", 1),
             ("ligtInBouwblok.ligtInBuurt.identificatie=03630000000078", 1),
+            ("ligtInBouwblok.identificatie[isnull]=true", 1),
+            ("ligtInBouwblok.identificatie[isnull]=false", 1),
+            ("heeftDossier[isnull]=true", 1),
+            ("heeftDossier.dossier=GV00000406", 1),
         ],
     )
     def test_filter_temporal(bag_dataset, panden_model, panden_data, query, expect):

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -1140,6 +1140,7 @@ class TestEmbedTemporalTables:
             data={
                 "_expand": "true",
                 "_expandScope": "ligtInBouwblok.ligtInBuurt.ligtInWijk.ligtInStadsdeel",
+                "naam": "Voorbeeldpand",
             },
         )
         data = read_response_json(response)
@@ -1333,7 +1334,7 @@ class TestEmbedTemporalTables:
                 "self": {
                     "href": (
                         "http://testserver/v1/bag/panden/?_expand=true"
-                        "&_expandScope=ligtInBouwblok.ligtInBuurt.ligtInWijk.ligtInStadsdeel"
+                        "&_expandScope=ligtInBouwblok.ligtInBuurt.ligtInWijk.ligtInStadsdeel&naam=Voorbeeldpand"
                     )
                 }
             },


### PR DESCRIPTION
For [AB#60099](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/60099). Doesn't solve the issue, but should narrow it down.