### PR TITLE
Fix filter relation.ident[isnull]=true

### DIFF
--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -267,8 +267,10 @@ class QueryFilterEngine:
 
         # Make sure loose relations don't return all historical records,
         # but only match the selected point in time.
-        if temporal_lookups := self._create_temporal_filters(parts):
-            q_object &= temporal_lookups
+        # Don't do this for isnull, which checks whether a relation exists at all.
+        if lookup != "isnull":
+            if temporal_lookups := self._create_temporal_filters(parts):
+                q_object &= temporal_lookups
 
         # Also tell whether the filter-path walks over many-to-many relationships.
         # These will need extra care to avoid duplicate results in the final filter call.
@@ -303,7 +305,7 @@ class QueryFilterEngine:
 
     def _translate_lookup(
         self, filter_input: FilterInput, filter_part: FilterPathPart, value: Any
-    ):
+    ) -> str:
         """Convert the lookup value into the Django ORM type."""
         lookup = filter_input.lookup
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -17,6 +17,7 @@ from jwcrypto.jwt import JWT
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
 from schematools.contrib.django.models import Dataset, DynamicModel, Profile
+from schematools.utils import dataset_schema_from_path
 from schematools.types import DatasetSchema, ProfileSchema
 
 from rest_framework_dso.crs import RD_NEW
@@ -858,6 +859,27 @@ def explosieven_data(explosieven_model):
         id=1,
         pdf="https://host.domain/file space space.extension",
         emailadres="account@host.domain",
+    )
+
+
+@pytest.fixture()
+def huishoudelijkafval_schema():
+    path = HERE / "files" / "huishoudelijkafval" / "dataset.json"
+    return dataset_schema_from_path(path)
+
+
+@pytest.fixture()
+def huishoudelijkafval_dataset(bag_dataset, huishoudelijkafval_schema, dynamic_models):
+    return Dataset.objects.create(
+        name="huishoudelijkafval", path="huishoudelijkafval", schema_data=huishoudelijkafval_schema.json(),
+    )
+
+
+@pytest.fixture()
+def huishoudelijkafval_data(dynamic_models, huishoudelijkafval_dataset):
+    model = dynamic_models["huishoudelijkafval"]["cluster"]
+    return model.objects.create(
+        id=1,
     )
 
 

--- a/src/tests/files/huishoudelijkafval/cluster/v2.0.0.json
+++ b/src/tests/files/huishoudelijkafval/cluster/v2.0.0.json
@@ -1,0 +1,102 @@
+{
+  "id": "cluster",
+  "version": "2.0.0",
+  "type": "table",
+  "provenance": "afval_api_cluster",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "mainGeometry": "geometrie",
+    "identifier": "id",
+    "required": [
+      "id",
+      "schema"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+      },
+      "id": {
+        "type": "string",
+        "provenance": "cluster_id",
+        "description": "Uniek identificerend kenmerk van cluster"
+      },
+      "subclusterIndicatie": {
+        "type": "boolean",
+        "provenance": "cluster_subcluster_indicatie",
+        "enum": [
+          true,
+          false
+        ],
+        "description": "Indicatie of het een cluster betreft dat is gesplitst door een weg"
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/Point.json",
+        "provenance": "cluster_geometrie",
+        "description": "Geometrie van het type POINT van de het zwaartepunt van het cluster in RD (epsg:28992))"
+      },
+      "datumOpvoer": {
+        "type": "string",
+        "provenance": "cluster_datum_opvoer",
+        "format": "date-time",
+        "description": "Datum opvoer van het cluster. Dit is afgeleid van wanneer het gegeven bij het systeem bekend is of peildatum 01-01-2016"
+      },
+      "datumOntstaan": {
+        "type": "string",
+        "provenance": "cluster_datum_ontstaan",
+        "format": "date",
+        "description": "Datum opvoer van het cluster. Dit is afgeleid van de plaatsingsdatum van de oudste container ,wanneer het gegeven bij het systeem bekend is of peildatum 01-01-2016"
+      },
+      "datumEinde": {
+        "type": "string",
+        "provenance": "cluster_datum_einde",
+        "format": "date",
+        "description": "Datum wanneer het cluster geen relaties meer heeft met containers met status=1."
+      },
+      "wijzigingsdatumDp": {
+        "type": "string",
+        "provenance": "cluster_wijzigingsdatum_dp",
+        "format": "date-time",
+        "description": "Datum waarop het object is gewijzigd"
+      },
+      "verwijderdDp": {
+        "type": "boolean",
+        "provenance": "cluster_verwijderd_dp",
+        "description": "Indicatie of het object verwijderd is bij de bronhouder"
+      },
+      "status": {
+        "type": "integer",
+        "provenance": "cluster_status",
+        "enum": [
+          0,
+          1
+        ],
+        "description": "Status van het cluster (0 - inactief , 1 - actief)"
+      },
+      "bagHoofdadresVerblijfsobject": {
+        "type": "string",
+        "relation": "bag:verblijfsobjecten",
+        "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+        "description": "Een identificatiecode van een verblijfsobject is een authentiek gegeven en een unieke aanduiding van het verblijfsobject."
+      },
+      "gbdBuurt": {
+        "type": "string",
+        "relation": "gebieden:buurten",
+        "uri": "https://www.amsterdam.nl/stelselpedia/gebieden-index/catalogus/buurt",
+        "description": "Unieke identificatie van het object"
+      },
+      "bagNummeraanduiding": {
+        "type": "string",
+        "relation": "bag:nummeraanduidingen",
+        "uri": "https://bag.basisregistraties.overheid.nl/def/bag#identificatiecode",
+        "description": "Identificatie nummeraanduiding"
+      },
+      "bronadres": {
+        "type": "string",
+        "description": "Adres van het cluster zoals die in bron geregistreerd is."
+      }
+    }
+  }
+}

--- a/src/tests/files/huishoudelijkafval/dataset.json
+++ b/src/tests/files/huishoudelijkafval/dataset.json
@@ -1,0 +1,49 @@
+{
+  "id": "huishoudelijkafval",
+  "type": "dataset",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "Deze gegevensset wordt onderhouden voor uitvoering van taken betreffende het inzamelen van huishoudelijk afval. De juridische basis is de Wet Milieubeheer, Hoofdstuk 10. Afvalstoffen.",
+  "theme": [
+    "Wonen",
+    "duurzaamheid en milieu",
+    "Ruimte en Topografie"
+  ],
+  "homepage": "https://data.amsterdam.nl",
+  "owner": "Gemeente Amsterdam, Stadswerken",
+  "dateModified": "2020-01-13T00:00:00+01:00",
+  "spatialDescription": "Gemeente Amsterdam",
+  "version": "2.1.0",
+  "default_version": "2.1.0",
+  "title": "Onder- en bovengrondse Afvalcontainers en putten",
+  "language": "nl",
+  "dateCreated": "2020-01-13T00:00:00+01:00",
+  "license": "Creative Commons, Naamsvermelding",
+  "hasBeginning": "2016-01-01T00:00:00+01:00",
+  "accrualPeriodicity": "dagelijks",
+  "description": "Alle locaties van de actieve onder- en bovengronds afvalcontainers en betonputten van de Gemeente Amsterdam. De locaties worden dagelijks bijgewerkt en bevatten de fracties Rest, Papier, Glas, Textiel en Plastic. Naast de objectinformatie zijn ook de weeggegevens beschikbaar.",
+  "status": "beschikbaar",
+  "keywords": [
+    "Afval",
+    "Afvalcontainers",
+    "Containers",
+    "Glas",
+    "Glasbak",
+    "Oud papier",
+    "Plastic",
+    "Textiel"
+  ],
+  "crs": "EPSG:28992",
+  "objective": "Het doel van deze dataset is het beschikbaar stellen van gegevens voor het ondersteunen van plaatsingsbeleid betreffende ondergrondse afvalcontainers en het ondersteunen van routeoptimalisatie voor afvalinzameling.",
+  "temporalUnit": "uren",
+  "creator": "Directie Afval en Grondstoffen",
+  "publisher": "Datateam Beheer en Openbare Ruimte",
+  "tables": [
+    {
+      "id": "cluster",
+      "$ref": "cluster/v2.0.0",
+      "activeVersions": {
+        "2.0.0": "cluster/v2.0.0"
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -584,6 +584,20 @@ class TestDynamicFilterSet:
         assert response.status_code == HTTP_400_BAD_REQUEST
 
 
+@pytest.mark.django_db
+def test_temporal_relation_isnull(huishoudelijkafval_data, filled_router):
+    """isnull on a relation should check whether a relation exists at all,
+    not check that a relation exists with a null identifier.
+    """
+    response = APIClient().get(
+        "/v1/huishoudelijkafval/cluster/?bagNummeraanduiding.identificatie[isnull]=true"
+    )
+    assert response.status_code == 200
+    data = read_response_json(response)
+
+    assert len(data["_embedded"]["cluster"]) > 0
+
+
 @pytest.mark.parametrize(
     "value",
     [


### PR DESCRIPTION
This would previously check whether an object is related to another object with a null identifier, which would always fail. It now checks whether the relation is present at all.

Includes a severely trimmed version of the huishoudelijkafval dataset from amsterdam-schema, since no other present test set would exhibit the buggy behavior.

Fixes [AB#60099](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/60099).