### PR TITLE
Fixup HTML docs

### DIFF
--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -173,8 +173,6 @@ def _table_context(table: DatasetTableSchema):
         "id": table.id,
         "title": to_snake_case(table.id).replace("_", " ").capitalize(),
         "uri": uri,
-        "rest_csv": f"{uri}?_format=csv",
-        "rest_geojson": f"{uri}?_format=geojson",
         "description": table.get("description"),
         "fields": [_get_field_context(field) for field in fields],
         "filters": filters,

--- a/src/templates/dso_api/dynamic_api/docs/dataset.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset.html
@@ -57,9 +57,9 @@
         <tr>
           <td>
             {% if field.is_deprecated %}
-            <s>{{ field.api_name }}</s> <i>gaat vervallen</i>
+            <s><code>{{ field.api_name }}</code></s> <i>gaat vervallen</i>
             {% else %}
-            {{ field.api_name }}
+            <code>{{ field.api_name }}</code>
             {% endif %}
           </td>
           <td>
@@ -88,9 +88,9 @@
         <tr>
           <td>
             {% if filter.is_deprecated %}
-              <s>{{ filter.name }}</s> <i>gaat vervallen</i>
+              <s><code>{{ filter.name }}</code></s> <i>gaat vervallen</i>
             {% else %}
-              {{ filter.name }}
+              <code>{{ filter.name }}</code>
             {% endif %}
           </td>
           <td>{{ filter.auth|join:", " }}</td>
@@ -101,9 +101,9 @@
           <tr>
             <td>
               {% if filter.is_deprecated %}
-                <s>{{ filter.name }}[{{ lookup.operator }}]</s> <i>gaat vervallen</i>
+                <s><code>{{ filter.name }}[{{ lookup.operator }}]</code></s> <i>gaat vervallen</i>
               {% else %}
-                {{ filter.name }}[{{ lookup.operator }}]
+                <code>{{ filter.name }}[{{ lookup.operator }}]</code>
               {% endif %}
             </td>
             <td>{{ filter.auth|join:", " }}</td>
@@ -130,7 +130,7 @@
           {% for expand in table.expands %}
             <tr>
               <td>{{ expand.api_name }}</td>
-              <td><a href="{{ expand.target_doc_id }}">{{ expand.relation_id }}</a></td>
+              <td><a href="{{ expand.target_doc }}">{{ expand.relation_id }}</a></td>
               <td>{{ expand.related_table.description|default:"" }}</td>
             </tr>
           {% endfor %}

--- a/src/templates/dso_api/dynamic_api/docs/dataset.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset.html
@@ -51,6 +51,7 @@
         <tr>
           <th>Veldnaam</th>
           <th>Type</th>
+          <th>Identifier</th>
           <th>Omschrijving</th>
         </tr>
       </thead>
@@ -66,9 +67,9 @@
           </td>
           <td>
             {{ field.type|default:"" }}
-            {% if field.is_identifier %}<i>identificatie</i>{% endif %}
-            {% if field.is_relation or field.is_foreign_id %}<i>relatie</i>{% endif %}
+            {% if field.is_relation or field.is_foreign_id %}(<i>relatie</i>){% endif %}
           </td>
+          <td>{% if field.is_identifier %}☑{% endif %}</td>
           <td>{{ field.description|default:"" }}</td>
         </tr>
         {% endfor %}

--- a/src/templates/dso_api/dynamic_api/docs/dataset.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset.html
@@ -5,7 +5,7 @@
   {% block extrahead %}{% endblock %}
 </head>
 <body>
-  <h1>{% if schema.title %}{{ schema.title }}{% else %}{{ name|title }}{% endif %} MVT</h1>
+  <h1>{% if schema.title %}{{ schema.title }}{% else %}{{ name|title }}{% endif %}</h1>
   <p>{% if schema.description %}{{ schema.description }}{% endif %}</p>
   <ul>
     <li><strong>ID:</strong> {{ schema.id }}</li>
@@ -41,6 +41,8 @@
         {% endif %}
       </li>
       <li><strong>REST URI:</strong> <a href="{{ table.uri }}">{{ table.uri }}</a></li>
+      <li><strong>CSV-export:</strong> <a href="{{ table.uri }}?_format=csv">{{ table.uri }}?_format=csv</a></li>
+      <li><strong>GeoJSON-export:</strong> <a href="{{ table.uri }}?_format=geojson">{{ table.uri }}?_format=geojson</a></li>
     </ul>
 
     <p>De volgende velden zijn beschikbaar:</p>

--- a/src/templates/dso_api/dynamic_api/docs/dataset_wfs.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset_wfs.html
@@ -55,7 +55,7 @@
       {% for expand in table.expands %}
         <tr>
           <td><code>{{ expand.python_name }}</code></td>
-          <td><a href="{{ expand.target_doc_id }}"><code>{{ expand.relation_id }}</code></a></td>
+          <td><a href="{{ expand.target_doc }}"><code>{{ expand.relation_id }}</code></a></td>
           <td>{{ expand.related_table.description|default:"" }}</td>
         </tr>
       {% endfor %}

--- a/src/tests/test_dynamic_api/test_doc.py
+++ b/src/tests/test_dynamic_api/test_doc.py
@@ -20,6 +20,7 @@ def test_overview(api_client, filled_router, fietspaaltjes_dataset):
         """<a href="/v1/docs/datasets/fietspaaltjes.html#fietspaaltjes">Fietspaaltjes</a>"""
         in content
     )
+    assert "`" not in content  # Check for leftover ` from ReST-to-HTML conversion.
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Convert ReST quotes to ``<code>`` in HTML docs, restore missing export links, code cosmetics.

For [AB#61559](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/61559).