### PR TITLE
Port GIS docs to Markdown as well

### DIFF
--- a/src/dso_api/dynamic_api/urls.py
+++ b/src/dso_api/dynamic_api/urls.py
@@ -12,7 +12,7 @@ from .views.doc import DocsOverview, GenericDocs
 def get_patterns(router_urls):
     """Generate the actual URL patterns for this file."""
     return [
-        path("docs/generic/rest/<str:topic>.html", GenericDocs.as_view()),
+        path("docs/generic/<str:category>/<str:topic>.html", GenericDocs.as_view()),
         path("docs/", DocsOverview.as_view(), name="docs-index"),
         path("mvt/", views.DatasetMVTIndexView.as_view(), name="mvt-index"),
         path("wfs/", views.DatasetWFSIndexView.as_view()),

--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -23,9 +23,9 @@ markdown = Markdown(extensions=[TableExtension()])
 
 @method_decorator(gzip_page, name="get")
 class GenericDocs(View):
-    def get(self, request, topic="index", *args, **kwargs):
+    def get(self, request, category, topic="index", *args, **kwargs):
         uri = request.build_absolute_uri(reverse("dynamic_api:api-root"))
-        md = render_to_string(f"dso_api/dynamic_api/docs/rest/{topic}.md", context={"uri": uri})
+        md = render_to_string(f"dso_api/dynamic_api/docs/{category}/{topic}.md", context={"uri": uri})
         return HttpResponse(markdown.convert(md))
 
 

--- a/src/templates/dso_api/dynamic_api/docs/gis/manual.md
+++ b/src/templates/dso_api/dynamic_api/docs/gis/manual.md
@@ -1,0 +1,348 @@
+# WFS handmatig koppelen
+
+De WFS server kan rechtstreeks vanuit de browser of HTTP client (curl
+e.d.) uitgelezen worden. Gebruik de basis URL
+`https://api.data.amsterdam.nl/v1/wfs/{<dataset naam>}/` in een
+WFS-client.
+
+Voor HTTP-clients, voeg je
+`?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES={laagnaam}`
+toe. De `?expand` en `?embed` parameters (bovenaan beschreven) werken
+ook.
+
+## Export formaten
+
+De volgende export formaten zijn beschikbaar:
+
+  - GeoJSON
+  - CSV
+
+Deze worden opgevraagd door zelf een **GetFeature** aanvraag samen te
+stellen. Hiervoor zijn de parameters `TYPENAMES={laagnaam}` en
+`OUTPUTFORMAT={formaat}` nodig. De volledige URL wordt dan:
+
+`https://api.data.amsterdam.nl/v1/wfs/{dataset}/?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES={laagnaam}&OUTPUTFORMAT={formaat}`.
+
+Bijvoorbeeld:
+
+  - [...\&TYPENAMES=wijken\&OUTPUTFORMAT=geojson](https://api.data.amsterdam.nl/v1/wfs/gebieden/?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=geojson)
+  - [...\&TYPENAMES=wijken\&OUTPUTFORMAT=csv](https://api.data.amsterdam.nl/v1/wfs/gebieden/?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=csv)
+
+<div class="tip">
+
+<div class="title">
+
+Tip
+
+</div>
+
+In de bovenstaande links is een `COUNT=` parameter opgenomen, die
+paginering activeert. Door deze parameter weg te laten worden *alle
+objecten* in een enkele request opgehaald. De server kan voor de meeste
+datasets dit met een goede performance leveren.
+
+</div>
+
+## Relaties bij exportformaten
+
+De exportformaten ondersteunen tevens het embedden/nesten van relaties.
+Hiervoor is het voldoende om de nesting-parameters te gebruiken bij het
+export links.
+
+Bijvoorbeeld:
+
+  - [?embed=ligt\_in\_stadsdeel&...\&TYPENAMES=wijken\&OUTPUTFORMAT=geojson](https://api.data.amsterdam.nl/v1/wfs/gebieden/?embed=ligt_in_stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=geojson)
+  - [?expand=ligt\_in\_stadsdeel&...\&TYPENAMES=wijken\&OUTPUTFORMAT=geojson](https://api.data.amsterdam.nl/v1/wfs/gebieden/?expand=ligt_in_stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=geojson)
+  - [?embed=ligt\_in\_stadsdeel&...\&TYPENAMES=wijken\&OUTPUTFORMAT=csv](https://api.data.amsterdam.nl/v1/wfs/gebieden/?embed=ligt_in_stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=csv)
+  - [?expand=ligt\_in\_stadsdeel&...\&TYPENAMES=wijken\&OUTPUTFORMAT=csv](https://api.data.amsterdam.nl/v1/wfs/gebieden/?expand=ligt_in_stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=csv)
+
+<div class="admonition">
+
+Sommige formaten hebben beperkingen
+
+De CSV export kan alleen complexe relaties verwerken als deze ook
+platgeslagen kunnen worden. Dit is een beperking van het bestandsformaat
+zelf.
+
+</div>
+
+## Geometrie projectie
+
+De exportlink kan uitgebreid worden met de `SRSNAME` parameter om
+geometrie velden in de gewenste projectie te ontvangen. Bijvoorbeeld:
+`SRSNAME=urn:ogc:def:crs:EPSG::3857` voor de web-mercator projectie die
+Google Maps gebruikt. De toegestane projecties zijn:
+
+| Projectie                     | Toelichting                                     |
+| ----------------------------- | ----------------------------------------------- |
+| `urn:ogc:def:crs:EPSG::28992` | Nederlandse rijksdriehoekscoördinaten (RD New). |
+| `urn:ogc:def:crs:EPSG::4258`  | ETRS89, Europese projectie.                     |
+| `urn:ogc:def:crs:EPSG::3857`  | Pseudo-Mercator (vergelijkbaar met Google Maps) |
+| `urn:ogc:def:crs:EPSG::4326`  | WGS 84 longitude-latitude, wereldwijd.          |
+
+## Eenvoudige Filters
+
+Het WFS-protocol biedt een krachtige syntax voor het filteren van data.
+Gebruik hiervoor `REQUEST=GetFeature` en het `FILTER` argument, waarbij
+de waarde als XML wordt uitgedrukt:
+
+``` xml
+<Filter>
+    <PropertyIsEqualTo>
+        <ValueReference>ligt_in_stadsdeel/naam</ValueReference>
+        <Literal>Centrum</Literal>
+    </PropertyIsEqualTo>
+</Filter>
+```
+
+Dit wordt dan in de request verwerkt, bijvoorbeeld:
+
+  - [...\&TYPENAMES=wijken\&OUTPUTFORMAT=geojson\&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CValueReference...](https://api.data.amsterdam.nl/v1/wfs/gebieden/?expand=ligt_in_stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=wijken&COUNT=10&OUTPUTFORMAT=geojson&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Eligt_in_stadsdeel/naam%3C/ValueReference%3E%3CLiteral%3ECentrum%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E)
+
+De `FILTER` parameter vervangt de losse parameters `BBOX` en
+`RESOURCEID`. Als je deze parameters ook gebruikt, moet je deze opnemen
+in het filter:
+
+``` xml
+<Filter>
+    <And>
+        <BBOX>
+            <gml:Envelope srsName="EPSG:4326">
+                <gml:lowerCorner>4.58565 52.03560</gml:lowerCorner>
+                <gml:upperCorner>5.31360 52.48769</gml:upperCorner>
+            </gml:Envelope>
+        </BBOX>
+        <PropertyIsEqualTo>
+            <ValueReference>status</ValueReference>
+            <Literal>1</Literal>
+        </PropertyIsEqualTo>
+    </And>
+</Filter>
+```
+
+De `RESOURCEID` kan in het filter meermaals voorkomen:
+
+``` xml
+<Filter>
+    <ResourceId rid="TYPENAME.123" />
+    <ResourceId rid="TYPENAME.4325" />
+    <ResourceId rid="OTHERTYPE.567" />
+</Filter>
+```
+
+## Complexe filters
+
+De WFS Filter Encoding Standaard (FES) ondersteund veel operatoren. Deze
+tags worden allemaal ondersteund:
+
+| Element                            | SQL equivalent            | Omschrijving                                                                                      |
+| ---------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------- |
+| `<PropertyIsEqualTo>`              | `{a} == {b}`              | Exacte waarde vergelijken tussen 2 expressies.                                                    |
+| `<PropertyIsNotEqualTo>`           | `{a} != {b}`              | Waarde moet ongelijk zijn.                                                                        |
+| `<PropertyIsLessThan>`             | `{a} < {b}`               | Waarde 1 moet kleiner zijn dan waarde 2.                                                          |
+| `<PropertyIsGreaterThan>`          | `{a} > {b}`               | Waarde 1 moet groter zijn dan waarde 2.                                                           |
+| `<PropertyIsLessThanOrEqualTo>`    | `{a} <= {b}`              | Waarde 1 moet kleiner of gelijk zijn dan waarde 2.                                                |
+| `<PropertyIsGreaterThanOrEqualTo>` | `{a} >= {b}`              | Waarde 1 moet groter of gelijk zijn dan waarde 2.                                                 |
+| `<PropertyIsBetween>`              | `{a} BETWEEN {x} AND {y}` | Vergelijkt tussen `<LowerBoundary>` en `<UpperBoundary>`, die beiden een expressie bevatten.      |
+| `<PropertyIsLike>`                 | `{a} LIKE {b}`            | Voert een wildcard vergelijking uit.                                                              |
+| `<PropertyIsNil>`                  | `{a} IS NULL`             | Waarde moet `NULL` zijn (`xsi:nil="true"` in XML).                                                |
+| `<PropertyIsNull>`                 | n.b.                      | Property mag niet bestaan (momenteel identiek aan `<PropertyIsNil>` geïmplementeerd).             |
+| `<BBOX>`                           | `ST_Intersects({a}, {b})` | Geometrie moet in waarde 2 voorkomen. De veldnaam mag weggelaten worden.                          |
+| `<Contains>`                       | `ST_Contains({a}, {b})`   | Geometrie 1 bevat geometrie 2 compleet.                                                           |
+| `<Crosses>`                        | `ST_Crosses({a}, {b})`    | Geometrieën lopen door elkaar heen.                                                               |
+| `<Disjoint>`                       | `ST_Disjoint({a}, {b})`   | Geometrieën zijn niet verbonden.                                                                  |
+| `<Equals>`                         | `ST_Equals({a}, {b})`     | Geometrieën moeten gelijk zijn.                                                                   |
+| `<Intersects>`                     | `ST_Intersects({a}, {b})` | Geometrieën zitten in dezelfde ruimte.                                                            |
+| `<Touches>`                        | `ST_Touches({a}, {b})`    | Randen van de geometrieën raken elkaar.                                                           |
+| `<Overlaps>`                       | `ST_Overlaps({a}, {b})`   | Geometrie 1 en 2 overlappen elkaar.                                                               |
+| `<Within>`                         | `ST_Within({a}, {b})`     | Geometrie 1 ligt compleet in geometrie 2.                                                         |
+| `<And>`                            | `{a} AND {b}`             | De geneste elementen moeten allemaal waar zijn.                                                   |
+| `<Or>`                             | `{a} OR {b}`              | Slechts één van de geneste elementen hoeft waar zijn.                                             |
+| `<Not>`                            | `NOT {a}`                 | Negatie van het geneste element.                                                                  |
+| `<ResourceId>`                     | `table.id == {value}`     | Zoekt slechts een enkel element op "typenaam.identifier". Meerdere combineren tot een `IN` query. |
+
+<div class="tip">
+
+<div class="title">
+
+Tip
+
+</div>
+
+Bij de `<BBOX>` operator mag het geometrieveld weggelaten worden. Het
+standaard geometrieveld wordt dan gebruikt (doorgaans het eerste veld).
+
+</div>
+
+<div class="note">
+
+<div class="title">
+
+Note
+
+</div>
+
+Hoewel een aantal geometrie-operatoren dubbelop lijken voor vlakken
+(zoals `<Intersects>`, `<Crosses>` en `<Overlaps>`), worden de
+onderlinge verschillen met name zichtbaar bij het vergelijken van punten
+met vlakken.
+
+</div>
+
+Als waarde mogen diverse expressies gebruikt worden:
+
+| Expressie          | SQL equivalent      | Omschrijving                                              |
+| ------------------ | ------------------- | --------------------------------------------------------- |
+| `<ValueReference>` | `{veldnaam}`        | Verwijzing naar een veld.                                 |
+| `<Literal>`        | waarde              | Letterlijke waarde, mag ook een GML-object zijn.          |
+| `<Function>`       | `{functienaam}(..)` | Uitvoer van een functie, zoals `abs`, `sin`, `strLength`. |
+| `<Add>`            | `{a} + {b}`         | Waarden optellen (WFS 1 expressie).                       |
+| `<Sub>`            | `{a} - {b}`         | Waarden aftrekken (WFS 1 expressie).                      |
+| `<Mul>`            | `{a} * {b}`         | Waarden ermenigvuldigen (WFS 1 expressie).                |
+| `<Div>`            | `{a} / {b}`         | Waarden delen (WFS 1 expressie).                          |
+
+Dit maakt complexe filters mogelijk, bijvoorbeeld:
+
+``` xml
+<Filter>
+    <And>
+        <PropertyIsEqualTo>
+            <ValueReference>status</ValueReference>
+            <Literal>1</Literal>
+        </PropertyIsEqualTo>
+        <Or>
+            <PropertyIsEqualTo>
+                <ValueReference>fractie_omschrijving</ValueReference>
+                <Literal>Rest</Literal>
+            </PropertyIsEqualTo>
+            <PropertyIsEqualTo>
+                <ValueReference>fractie_omschrijving</ValueReference>
+                <Literal>Textiel</Literal>
+            </PropertyIsEqualTo>
+            <PropertyIsEqualTo>
+                <ValueReference>fractie_omschrijving</ValueReference>
+                <Literal>Glas</Literal>
+            </PropertyIsEqualTo>
+            <PropertyIsEqualTo>
+                <ValueReference>fractie_omschrijving</ValueReference>
+                <Literal>Papier</Literal>
+            </PropertyIsEqualTo>
+            <PropertyIsEqualTo>
+                <ValueReference>fractie_omschrijving</ValueReference>
+                <Literal>Gft</Literal>
+            </PropertyIsEqualTo>
+            <PropertyIsEqualTo>
+                <ValueReference>fractie_omschrijving</ValueReference>
+                <Literal>Plastic</Literal>
+            </PropertyIsEqualTo>
+        </Or>
+    </And>
+</Filter>
+```
+
+## Functies
+
+Functies worden uitgevoerd door met de tag `<Function
+name="..">..</Function>`. Dit mag op iedere plek als expressie gebruikt
+worden in plaats van een `<ValueReference>` of `<Literal>`.
+
+Binnen in de function worden de parameters tevens als expressie
+opgegeven: een `<ValueReference>`, `<Literal>` of nieuwe `<Function>`.
+Als simpel voorbeeld:
+
+``` xml
+<fes:Function name="sin">
+    <fes:ValueReference>fieldname</fes:ValueReference>
+</fes:Function>
+```
+
+De volgende functies zijn beschikbaar in de server:
+
+| Functie                              | SQL equivalent               | Omschrijving                                               |
+| ------------------------------------ | ---------------------------- | ---------------------------------------------------------- |
+| `strConcat(string)`                  | `CONCAT()`                   | Combineert teksten                                         |
+| `strToLowerCase(string)`             | `LOWER()`                    | Tekst omzetten naar kleine letters.                        |
+| `strToUpperCase(string)`             | `UPPER()`                    | Tekst omzetten naar hoofdletters                           |
+| `strTrim(string)`                    | `TRIM()`                     | Witruimte aan het begin en einde verwijderen.              |
+| `strLength(string)`                  | `LENGTH()` / `CHAR_LENGTH()` | Tekstlengte bepalen.                                       |
+| `length(string)`                     | `LENGTH()` / `CHAR_LENGTH()` | Alias van `strLength()`.                                   |
+| `abs(number)`                        | `ABS()`                      | Negatieve getallen omdraaien.                              |
+| `ceil(number)`                       | `CEIL()`                     | Afronden naar boven.                                       |
+| `floor(number)`                      | `FLOOR()`                    | Afronden naar beneden.                                     |
+| `round(value)`                       | `ROUND()`                    | Afronden                                                   |
+| `min(value1, value2)`                | `LEAST()`                    | Kleinste getal gebruiken.                                  |
+| `max(value1, value2)`                | `GREATEST()`                 | Grootste getal gebruiken.                                  |
+| `pow(base, exponent)`                | `POWER()`                    | Machtsverheffing                                           |
+| `exp(value)`                         | `EXP()`                      | Exponent van 𝑒 (2,71828...; natuurlijke logaritme).        |
+| `log(value)`                         | `LOG()`                      | Logaritme; inverse van een exponent.                       |
+| `sqrt(value)`                        | `SQRT()`                     | Worteltrekken; inverse van machtsverheffen.                |
+| `acos(value)`                        | `ACOS()`                     | Arccosinus; inverse van cosinus.                           |
+| `asin(value)`                        | `ASIN()`                     | Arcsinus; inverse van sinus.                               |
+| `atan(value)`                        | `ATAN()`                     | Arctangens; invere van tangens.                            |
+| `atan2(x, y)`                        | `ATAN2()`                    | Arctangens, voor bereik buiten een circel.                 |
+| `cos(radians)`                       | `COS()`                      | Cosinus                                                    |
+| `sin(radians)`                       | `SIN()`                      | Sinus                                                      |
+| `tan(radians)`                       | `TAN()`                      | Tanges                                                     |
+| `pi()`                               | `PI`                         | De waarde van π (3,141592653...)                           |
+| `toDegrees(radians)`                 | `DEGREES()`                  | Omzetting radialen naar graden.                            |
+| `toRadians(degree)`                  | `RADIANS()`                  | Omzetting graden naar radialen.                            |
+| `Area(geometry)`                     | `ST_AREA()`                  | Geometrie omzetten naar gebied.                            |
+| `Centroid(features)`                 | `ST_Centroid()`              | Geometrisch centrum als "zwaartekrachtpunt" teruggeven.    |
+| `Difference(geometry1, geometry2)`   | `ST_Difference()`            | Delen van geometrie 1 die niet overlappen met geometrie 2. |
+| `distance(geometry1, geometry2)`     | `ST_Distance()`              | Minimale afstand tussen 2 geometrieën.                     |
+| `Envelope(geometry)`                 | `ST_Envelope()`              | Geometrie omzetten naar bounding box.                      |
+| `Intersection(geometry1, geometry2)` | `ST_Intersection()`          | Delen van geometrie 1 die overlappen met geometrie 2.      |
+| `Union(geometry1, geometry2)`        | `ST_Union()`                 | Geometrie 1 en 2 samenvoegen.                              |
+
+## Filter compatibiliteit
+
+Officieel zijn XML-namespaces verplicht in het filter. Aangezien veel
+clients deze achterwege laten, ondersteund de server ook aanvragen
+zonder namespaces. Voor de volledigheid zal het request er met
+namespaces zo uit zien:
+
+``` xml
+<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.opengis.net/fes/2.0
+        http://schemas.opengis.net/filter/2.0/filterAll.xsd">
+    <fes:PropertyIsEqualTo>
+        <fes:ValueReference>stadsdeel/naam</fes:ValueReference>
+        <fes:Literal>Centrum</fes:Literal>
+    </fes:PropertyIsEqualTo>
+</fes:Filter>
+```
+
+Bij geometrie filters is dat officieel zelfs:
+
+``` xml
+<fes:Filter
+    xmlns:fes="http://www.opengis.net/fes/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/fes/2.0
+    http://schemas.opengis.net/filter/2.0/filterAll.xsd
+    http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd">
+    <fes:BBOX>
+        <gml:Polygon gml:id="P1" srsName="http://www.opengis.net/def/crs/epsg/0/4326">
+            <gml:exterior>
+                <gml:LinearRing>
+                    <gml:posList>10 10 20 20 30 30 40 40 10 10</gml:posList>
+                </gml:LinearRing>
+            </gml:exterior>
+        </gml:Polygon>
+    </fes:BBOX>
+</fes:Filter>
+```
+
+Conform de XML-regels mag hier de "fes" namespace alias hernoemd worden,
+of weggelaten worden als er alleen `xmlns="..."` gebruikt wordt i.p.v.
+`xmlns:fes="..."`.
+
+Diverse bestaande filters gebruiken nog andere WFS 1 elementen, zoals
+`<PropertyName>` in plaats van `<ValueReference>`. Voor compatibiliteit
+wordt deze tag ook ondersteund.
+
+De WFS 1 expressies `<Add>`, `<Sub>`, `<Mul>` en `<Div>` zijn tevens
+geïmplementeerd om rekenkundige operaties te ondersteunen vanuit QGIS
+(optellen, aftrekken, vermenigvuldigen en delen).

--- a/src/templates/dso_api/dynamic_api/docs/gis/qgis.md
+++ b/src/templates/dso_api/dynamic_api/docs/gis/qgis.md
@@ -1,0 +1,143 @@
+# Werken met QGIS
+
+## Eenmalige lokale setup
+
+Let op, een eenmalige setup van de qgis-auth.db in je locale profiel is
+nodig voordat je de API endpoints toevoegt. Onthoudt jouw gebruikersnaam
+en wachtwoord goed.
+
+## WFS
+
+De WFS-lagen zijn beschikbaar onder de volgende URL's:
+
+`https://api.data.amsterdam.nl/v1/wfs/{<dataset>}/`
+
+Gebruik zo'n URL in QGIS:
+
+<img alt="Voorbeeldafbeelding van QGIS" src="/v1/static/images/qgis-add-wfs.png" style="width: 670px; height: 791px;">
+
+In de bovenstaande afbeelding wordt QGIS gekoppeld met de BAG dataset:
+<https://api.data.amsterdam.nl/v1/wfs/bag/>
+
+<div class="tip">
+
+<div class="title">
+
+Tip
+
+</div>
+
+De parameters `?SERVICE=WFS&VERSION=2.0.0&REQUEST=..` worden door QGIS
+zelf achter de URL gezet. Het is niet nodig deze zelf toe te voegen.
+
+</div>
+
+<div class="tip">
+
+<div class="title">
+
+Tip
+
+</div>
+
+De schuine streep aan het einde van de URL is belangrijk. QGIS werkt
+niet als deze ontbreekt. Dit is een beperking in QGIS.
+
+</div>
+
+## Vector tiles (MVT)
+
+De volgende stappen moeten uitgevoerd worden om vector tiles in QGIS te
+laden:
+
+  - In de *Browser* (linker tabblad), rechtermuisklik op *Vector Tiles*,
+    dan *Nieuwe algemene verbinding* (*New Generic Connection*).
+  - De URL is
+    `https://api.data.amsterdam.nl/v1/mvt/<dataset>/<tabel>/{z}/{x}/{y}.pbf`.
+    Vervang `<dataset>` en `<tabel>` door de namen in kwestie, maar laat
+    `{z}/{x}/{y}` staan, inclusief de accolades.
+  - *Min. zoomniveau* (*Min. Zoom Level*) staat standaard op 0. Zet dit
+    op 1.
+
+Een lijst van datasets die vector tiles ondersteunen is beschikbaar op:
+<https://api.data.amsterdam.nl/v1/mvt/>.
+
+## Autorisatie
+
+Voor gesloten datasets moet ook een autorisatieconfiguratie worden
+toegevoegd. Dit kan door op het groene kruisje in het bovenstaande menu
+te klikken. Selecteer OAuth2-authenticatie, met 'implicit' grant flow.
+Vul bij 'request url'
+`https://iam.amsterdam.nl/auth/realms/datapunt-ad/protocol/openid-connect/auth`
+en bij 'token url'
+`https://iam.amsterdam.nl/auth/realms/datapunt-ad/protocol/openid-connect/certs`
+in. De client id is `qgis`, Scope is `email` en access method is
+`header`. QGIS zal bij het activeren van een kaartlaag een browserscherm
+openen, waarin gebruikersnaam en wachtwoord kunnen worden ingevoerd.
+
+**Voor acceptatie vervang je in bovengenoemde URLs "datapunt-ad" met
+"datapunt-ad-acc"**.
+
+<img alt="Voorbeeldafbeelding van QGIS-authenticatie"
+ src="/v1/static/images/qgis-add-authentication.png"
+ style="width: 670px; height: 791px;">
+
+In de bovenstaande afbeelding wordt authenticatieconfiguratie
+ingevoerd in QGIS.
+
+Hierna zijn de gegevens te raadplegen, te filteren en te combineren:
+
+<img src="/v1/static/images/qgis-bag.png" width="2438" height="1614"
+ style="width: 609.5px; height: 403.5px;"
+ alt="Stadsdelen weergegeven in QGIS"/>
+
+## Queries op relaties
+
+Om object-relaties uit te lezen in WFS (momenteel niet ondersteund door
+MVT) kun je de volgende optie toevoegen aan de URL:
+
+  - `?embed={relatienaam},{...}` zal een veld platgeslagen invoegen.
+  - `?expand={relatienaam},{...}` zal een veld als "complex feature"
+    invoegen.
+
+Gebruik deze URL in QGIS, of een ander GIS-pakket.
+
+Als voorbeeld: de BAG feature type *buurt* een relatie met een
+*stadsdeel*. Deze kan op beide manieren geconfigureerd worden in een
+GIS-pakket:
+
+  - `https://api.data.amsterdam.nl/v1/wfs/bag/?embed=stadsdeel` levert
+    een [stadsdelen met platgeslagen
+    dot-notate](https://api.data.amsterdam.nl/v1/wfs/bag/?embed=stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=buurt&COUNT=5).
+  - `https://api.data.amsterdam.nl/v1/wfs/bag/?expand=stadsdeel` levert
+    een [stadsdelen als complex
+    feature](https://api.data.amsterdam.nl/v1/wfs/bag/?expand=stadsdeel&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=buurt&COUNT=5).
+
+Deze parameters kunnen gecombineerd worden met de `OUTPUTFORMAT`
+parameter, zodat het export formaat ook geneste relaties bevat.
+
+<div class="admonition">
+
+Embed of expand gebruiken?
+
+QGIS 3 heeft geen ondersteuning voor complex features, en verwerkt deze
+als tekst. Gebruikt in QGIS daarom alleen de platgeslagen versie met
+`?embed={...}`. De `?expand={...}` versie is daarentegen ideaal voor
+GeoJSON exports, die wel goed kan omgaan met geneste structuren.
+
+</div>
+
+## Datasets met meerdere geometrieën
+
+Indien een tabel meerdere geometriëen bevat, zal deze voor ieder
+geometrieveld los opgenomen worden in de WFS. Zodoende kunnen
+GIS-pakketten op beide geometrieën weergeven op de kaart.
+
+Via MVT kan alleen de hoofdgeometrie (`mainGeometry`) van een dataset
+worden geladen.
+
+Dit is bijvoorbeeld te zien bij Horeca-exploitatievergunningen: er wordt
+een aparte laag voor het pand, en de bijbehorende terrassen beschikbaar
+gesteld. Zodoende kunnen beide geometriën uitgelezen worden. De data van
+beide lagen is identiek; alleen de volgorde van geometrie-velden is
+aangepast.

--- a/src/templates/dso_api/dynamic_api/docs/gis/wfs_technical.md
+++ b/src/templates/dso_api/dynamic_api/docs/gis/wfs_technical.md
@@ -1,0 +1,106 @@
+# Technische achtergrond
+
+## Technische implementatie
+
+De WFS server is gebouwd op basis van
+[django-gisserver](https://django-gisserver.readthedocs.io). Deze Django
+module ondersteunt het "Basic WFS" conformance level, en is getest op
+compatibiliteit met de [CITE Teamengine Test
+Suite](https://cite.opengeospatial.org/teamengine/).
+
+## Beveiliging
+
+De ingeladen features kunnen verschillen per gebruiker. De "feature
+type" die de server intern opbouwd bevat alleen de attributen waar een
+gebruiker toegang toe heeft. Het is daardoor niet mogelijk om te
+filteren op afgeschermde velden, simpelweg omdat de server deze velden
+niet herkent.
+
+## Embedding
+
+De XML uitvoer van de WFS server verschilt bij het gebruik van
+`?embed={relatienaam},{...}` en `?expand={relatienaam},{...}`.
+
+Deze embed logica is een uitbreiding op
+[django-gisserver](https://django-gisserver.readthedocs.io). Door het
+gebruik van `?embed` en `?expand` wordt er een andere feature-definitie
+geactiveerd in de server, die een geneste structuur oplevert. Hierdoor
+veranderd het gedrag en uitvoer van de server.
+
+Bij een platgeslagen relatie worden alle veldnamen met een punt erin
+opgebouwd:
+
+``` xml
+<app:buurt gml:id="buurt.03630000000078">
+    <gml:name>00a</gml:name>
+    <app:id>03630000000078</app:id>
+    <app:code>00a</app:code>
+    <app:naam>Kop Zeedijk</app:naam>
+    <app:vollcode>A00a</app:vollcode>
+    <app:geometrie>...
+        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="buurt.03630000000078.1">
+            ...
+        </gml:Polygon>
+    </app:geometrie>
+    <app:stadsdeel.id>03630000000018</app:stadsdeel.id>
+    <app:stadsdeel.code>A</app:stadsdeel.code>
+    <app:stadsdeel.naam>Centrum</app:stadsdeel.naam>
+    <app:stadsdeel.vervallen xsi:nil="true" />
+    <app:stadsdeel.date_modified>2020-07-28T22:25:24.197978+00:00</app:stadsdeel.date_modified>
+    <app:stadsdeel.ingang_cyclus>2015-01-01</app:stadsdeel.ingang_cyclus>
+    <app:stadsdeel.begin_geldigheid>2015-01-01</app:stadsdeel.begin_geldigheid>
+    <app:stadsdeel.einde_geldigheid xsi:nil="true" />
+    <app:stadsdeel.brondocument_naam>3B/2015/134</app:stadsdeel.brondocument_naam>
+    <app:stadsdeel.brondocument_datum>2015-06-23</app:stadsdeel.brondocument_datum>
+    <app:stadsdeel_id>03630000000018</app:stadsdeel_id>
+    <app:vervallen xsi:nil="true" />
+    <app:date_modified>2020-07-28T22:25:32.261814+00:00</app:date_modified>
+    <app:ingang_cyclus>2006-06-12</app:ingang_cyclus>
+    <app:begin_geldigheid>2006-06-12</app:begin_geldigheid>
+    <app:buurtcombinatie_id>3630012052036</app:buurtcombinatie_id>
+    <app:einde_geldigheid xsi:nil="true" />
+    <app:brondocument_naam />
+    <app:brondocument_datum xsi:nil="true" />
+    <app:gebiedsgerichtwerken_id>DX01</app:gebiedsgerichtwerken_id>
+</app:buurt>
+```
+
+Bij een "complex feature" gebruikt de XML uitvoer een eigen
+`<app:stadsdeel>` object:
+
+``` xml
+<app:buurt gml:id="buurt.03630000000078">
+    <gml:name>00a</gml:name>
+    <app:id>03630000000078</app:id>
+    <app:code>00a</app:code>
+    <app:naam>Kop Zeedijk</app:naam>
+    <app:vollcode>A00a</app:vollcode>
+    <app:geometrie>...
+        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="buurt.03630000000078.1">
+            ...
+        </gml:Polygon>
+    </app:geometrie>
+    <app:stadsdeel>
+        <app:id>03630000000018</app:id>
+        <app:code>A</app:code>
+        <app:naam>Centrum</app:naam>
+        <app:vervallen xsi:nil="true" />
+        <app:date_modified>2020-07-28T22:25:24.197978+00:00</app:date_modified>
+        <app:ingang_cyclus>2015-01-01</app:ingang_cyclus>
+        <app:begin_geldigheid>2015-01-01</app:begin_geldigheid>
+        <app:einde_geldigheid xsi:nil="true" />
+        <app:brondocument_naam>3B/2015/134</app:brondocument_naam>
+        <app:brondocument_datum>2015-06-23</app:brondocument_datum>
+    </app:stadsdeel>
+    <app:stadsdeel_id>03630000000018</app:stadsdeel_id>
+    <app:vervallen xsi:nil="true" />
+    <app:date_modified>2020-07-28T22:25:32.261814+00:00</app:date_modified>
+    <app:ingang_cyclus>2006-06-12</app:ingang_cyclus>
+    <app:begin_geldigheid>2006-06-12</app:begin_geldigheid>
+    <app:buurtcombinatie_id>3630012052036</app:buurtcombinatie_id>
+    <app:einde_geldigheid xsi:nil="true" />
+    <app:brondocument_naam></app:brondocument_naam>
+    <app:brondocument_datum xsi:nil="true" />
+    <app:gebiedsgerichtwerken_id>DX01</app:gebiedsgerichtwerken_id>
+</app:buurt>
+```


### PR DESCRIPTION
Again converted with pandoc -t gfm, but with the images manually fixed up afterward.