### PR TITLE
Fix code display from Markdown

### DIFF
--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -18,7 +18,7 @@ from schematools.naming import to_snake_case
 from schematools.types import DatasetFieldSchema, DatasetSchema, DatasetTableSchema
 
 
-markdown = Markdown(extensions=[TableExtension()])
+markdown = Markdown(extensions=[TableExtension(), "fenced_code"])
 
 
 @method_decorator(gzip_page, name="get")


### PR DESCRIPTION
This is required to render triple-backtick blocks the GFM way.