### PR TITLE
Bump requirement authorization_django

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 1.0
 amsterdam-schema-tools[django] == 5.1
-datapunt-authorization-django==1.3.2
+datapunt-authorization-django==1.3.3
 drf-spectacular == 0.24.2
 jsonschema == 4.16.0
 lru_dict == 1.1.8


### PR DESCRIPTION
This pins our jwcrypto version to >= 1.4.2.