### PR TITLE
AB-62685 Remove use of Avenir font

### DIFF
--- a/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
+++ b/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
@@ -38,7 +38,7 @@ h1 {
     line-height: 38px;
     font-size: 30px;
     font-weight: 700;
-    font-family: Avenir Next, Arial, sans-serif;
+    font-family: Amsterdam Sans, Arial, sans-serif;
     font-stretch: normal;
     letter-spacing: normal;
     line-height: 38px;


### PR DESCRIPTION
Because the license ends. Now use "Amsterdam Sans".

This font is included in the Amsterdam static css that is loaded by DSO browsable api.