### PR TITLE
Add support for primary keys that have a relation

### DIFF
--- a/src/dso_api/dynamic_api/filters/openapi.py
+++ b/src/dso_api/dynamic_api/filters/openapi.py
@@ -75,7 +75,7 @@ def get_table_filter_params(table_schema: DatasetTableSchema) -> list[dict]:  # 
     """
     openapi_params = []
 
-    for field in table_schema.get_fields(include_subfields=False):
+    for field in table_schema.fields:
         if field.is_array_of_objects:
             # M2M relation or nested table.
             for sub_field in field.subfields:

--- a/src/dso_api/dynamic_api/serializers/base.py
+++ b/src/dso_api/dynamic_api/serializers/base.py
@@ -313,8 +313,8 @@ class DynamicSerializer(FieldAccessMixin, DSOModelSerializer):
 
     serializer_field_mapping = {
         **DSOModelSerializer.serializer_field_mapping,
-        LooseRelationField: fields.HALLooseRelationUrlField,
-        LooseRelationManyToManyField: fields.HALLooseRelationUrlField,
+        LooseRelationField: fields.HALRawIdentifierUrlField,
+        LooseRelationManyToManyField: fields.HALRawIdentifierUrlField,
     }
 
     table_schema: DatasetTableSchema = None

--- a/src/dso_api/dynamic_api/serializers/base.py
+++ b/src/dso_api/dynamic_api/serializers/base.py
@@ -545,6 +545,20 @@ class LinkSerializer(FieldAccessMixin, DSOModelSerializerBase):
     This applies the field permissions to the display_name field (through FieldAccessMixin).
     """
 
+    def build_standard_field(self, field_name, model_field):
+        field_class, field_kwargs = super().build_standard_field(field_name, model_field)
+        if model_field.one_to_one and model_field.primary_key:
+            # When the OneToOneField is a primary key, and field isn't statically declared,
+            # DRF will generate one when on the fly but complain about a missing "view_name".
+            # In case code changes lead to this error, make it easier to trace the actual solution.
+            raise RuntimeError(
+                f"serializer_factory() has incomplete definition"
+                f" for '{self.field_name}.{field_name}', either fix the 'source' value"
+                " or make sure a proper field is predefined."
+            )
+
+        return field_class, field_kwargs
+
     def build_relational_field(self, field_name: str, relation_info: RelationInfo):
         """Factory logic - This makes sure temporal links get a different field class."""
         field_class, field_kwargs = super().build_relational_field(field_name, relation_info)

--- a/src/dso_api/dynamic_api/serializers/factories.py
+++ b/src/dso_api/dynamic_api/serializers/factories.py
@@ -29,7 +29,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.models.fields import AutoFieldMixin
 from django.db.models.fields.related import RelatedField
-from django.db.models.fields.reverse_related import ForeignObjectRel
 from django.utils.functional import SimpleLazyObject
 from drf_spectacular.drainage import set_override
 from rest_framework import serializers
@@ -72,7 +71,7 @@ EXPOSED_SHORTNAMES = {
 
 
 def _needs_shortname_compatibility(
-    field_schema: DatasetFieldSchema, model_field: models.Field | ForeignObjectRel
+    field_schema: DatasetFieldSchema, model_field: models.Field | models.ForeignObjectRel
 ):
     """Tell whether the field needs to provide backwards compatibility.
     We've accidentally exposed shortnames in the API.
@@ -332,7 +331,7 @@ def _links_serializer_factory(
         # This includes LooseRelationManyToManyField
         elif isinstance(model_field, models.ManyToManyField):
             _build_m2m_serializer_field(serializer_part, model_field)
-        elif isinstance(model_field, (RelatedField, ForeignObjectRel)):
+        elif isinstance(model_field, (RelatedField, models.ForeignObjectRel)):
             _build_link_serializer_field(serializer_part, model_field)
 
     # Generate serializer class
@@ -476,7 +475,7 @@ def _build_serializer_field(  # noqa: C901
             # Forward relation, or loose relation, add an id field in the main body.
             _build_serializer_related_id_field(serializer_part, model_field)
         return
-    elif isinstance(model_field, ForeignObjectRel):
+    elif isinstance(model_field, models.ForeignObjectRel):
         # Reverse relations, are only added as embedded field when there is an explicit declaration
         field_schema = DynamicModel.get_field_schema(model_field)
         additional_relation = field_schema.reverse_relation
@@ -493,7 +492,7 @@ def _build_serializer_field(  # noqa: C901
 
 def _build_serializer_embedded_field(
     serializer_part: SerializerAssemblyLine,
-    model_field: RelatedField | ForeignObjectRel,
+    model_field: RelatedField | models.ForeignObjectRel,
     nesting_level: int,
 ):
     """Build a embedded field for the serializer"""
@@ -695,7 +694,7 @@ def _build_plain_serializer_field(
 
 
 def _build_link_serializer_field(
-    serializer_part: SerializerAssemblyLine, model_field: models.Field | models.ForeignObjectRel
+    serializer_part: SerializerAssemblyLine, model_field: RelatedField | models.ForeignObjectRel
 ):
     """Build a field that will be an item in the ``_links`` section."""
     related_model = model_field.related_model

--- a/src/dso_api/dynamic_api/serializers/factories.py
+++ b/src/dso_api/dynamic_api/serializers/factories.py
@@ -137,6 +137,13 @@ class SerializerAssemblyLine:
         }
         self.deprecate_fields = []
 
+    def __repr__(self):
+        """Give a better overview during debugging which layer a function constructs."""
+        table_id = self.class_attrs["table_schema"].qualified_id
+        factory_function = self.class_attrs["_factory_function"]
+        factory = f" by {factory_function}()" if factory_function else ""
+        return f"<SerializerAssemblyLine: for '{table_id}'{factory}>"
+
     def add_field(self, name, field: serializers.Field, is_deprecated=False):
         """Add a field to the serializer assembly"""
         self.class_attrs[name] = field

--- a/src/dso_api/dynamic_api/serializers/fields.py
+++ b/src/dso_api/dynamic_api/serializers/fields.py
@@ -116,8 +116,8 @@ class TemporalReadOnlyField(serializers.ReadOnlyField):
         return split_on_separator(str(value))[0]
 
 
-class HALLooseRelationUrlField(HyperlinkedRelatedField):
-    """Wrap the URL from LooseRelationUrlField according to HAL specs."""
+class HALRawIdentifierUrlField(HyperlinkedRelatedField):
+    """Generate an URL value based on the incoming string value.."""
 
     def use_pk_only_optimization(self):
         return True
@@ -129,7 +129,7 @@ class HALLooseRelationUrlField(HyperlinkedRelatedField):
         )
 
 
-class HALLooseM2MUrlField(HALLooseRelationUrlField):
+class HALLooseM2MUrlField(HALRawIdentifierUrlField):
     def get_url(self, obj, *args, **kwargs):
         """Generate /path/{<primary_id>}/
 

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -8,7 +8,7 @@ django-vectortiles == 0.2.0
 djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 1.0
-amsterdam-schema-tools[django] == 5.1
+amsterdam-schema-tools[django] == 5.1.5
 datapunt-authorization-django==1.3.3
 drf-spectacular == 0.24.2
 jsonschema == 4.16.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==5.1
+amsterdam-schema-tools[django]==5.1.5
     # via -r requirements.in
 arrow==1.2.3
     # via isoduration
@@ -48,7 +48,7 @@ cryptography==38.0.1
     #   jwcrypto
     #   msal
     #   pyjwt
-datapunt-authorization-django==1.3.2
+datapunt-authorization-django==1.3.3
     # via -r requirements.in
 decorator==5.1.1
     # via jsonpath-rw

--- a/src/rest_framework_dso/serializers.py
+++ b/src/rest_framework_dso/serializers.py
@@ -735,8 +735,11 @@ class DSOModelSerializer(DSOSerializer, DSOModelSerializerBase):
             return empty
 
 
-class HALLooseLinkSerializer(serializers.Serializer):
-    """This is an empty class that is used to type a _links subfield
-    as a loose relation. This information is necessary to determine the
-    runtime behavior of the serializer object structure, for example
-    when resolving the prefetch lookups for a queryset."""
+class HALRawIdentifierLinkSerializer(serializers.Serializer):
+    """Tagging interface to recognize serializers that don't receive objects.
+
+    This is an empty class that is used to tag a '_links' subfield
+    that only receives a raw identifier as its 'source' value.
+    This information is necessary to determine the runtime behavior,
+    for example when resolving the prefetch lookups for a queryset.
+    """

--- a/src/rest_framework_dso/utils.py
+++ b/src/rest_framework_dso/utils.py
@@ -31,7 +31,7 @@ def get_serializer_relation_lookups(
     """Find all relations that a serializer instance would request.
     This allows to prepare a ``prefetch_related()`` call on the queryset.
     """
-    from rest_framework_dso.serializers import HALLooseLinkSerializer
+    from rest_framework_dso.serializers import HALRawIdentifierLinkSerializer
 
     # Unwrap the list serializer construct for the one-to-many relationships.
     if isinstance(serializer, serializers.ListSerializer):
@@ -40,9 +40,9 @@ def get_serializer_relation_lookups(
     lookups: dict[str, serializers.Field] = {}
 
     for field in serializer.fields.values():  # type: serializers.Field
-        if isinstance(field, HALLooseLinkSerializer):
-            # shortcircuit loose relations, which can not be passed to prefetch_related
-            # because they are regular CharFields
+        if isinstance(field, HALRawIdentifierLinkSerializer):
+            # Shortcircuit serializer objects that only receive a string value (like a CharField).
+            # This doesn't need to be passed to prefetch_related.
             continue
         elif field.source == "*":
             if isinstance(field, serializers.BaseSerializer):

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -199,6 +199,16 @@ def schema_loader() -> FileSystemSchemaLoader:
     return FileSystemSchemaLoader(HERE / "files/datasets")
 
 
+@pytest.fixture
+def aardgasverbruik_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("aardgasverbruik.json")
+
+
+@pytest.fixture
+def aardgasverbruik_dataset(aardgasverbruik_schema) -> Dataset:
+    return Dataset.create_for_schema(aardgasverbruik_schema)
+
+
 @pytest.fixture()
 def afval_schema(schema_loader) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("afval.json")

--- a/src/tests/files/datasets/aardgasverbruik.json
+++ b/src/tests/files/datasets/aardgasverbruik.json
@@ -1,0 +1,90 @@
+{
+  "type": "dataset",
+  "id": "aardgasverbruik",
+  "title": "aardgasverbruik",
+  "status": "beschikbaar",
+  "version": "1.0.0",
+  "owner": "Liander / Gemeente Amsterdam",
+  "publisher": "Datateam Basisstatistiek",
+  "crs": "EPSG:28992",
+  "creator": "Onderzoek en Statistiek",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "OIS",
+  "tables": [
+    {
+      "id": "mraLiander",
+      "title": "Data over Standaard Jaarverbruik (SJV) en aantal aansluitingen per postcode-range in de MRA",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "id",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "title": "id",
+            "type": "string",
+            "description": "Unieke identificatie"
+          },
+          "dataDate": {
+            "title": "dataDate",
+            "type": "string",
+            "format": "date",
+            "description": "Datum van de aangeleverde data"
+          },
+          "postcodeVanaf": {
+            "title": "postcodeVanaf",
+            "type": "string",
+            "description": "Postcode vanaf (eerste postcode in postcoderange)"
+          },
+          "postcodeTotEnMet": {
+            "title": "postcodeTotEnMet",
+            "type": "string",
+            "description": "Postcode t/m (laatste postcode in postcoderange)"
+          }
+        }
+      }
+    },
+    {
+      "id": "mraStatistiekenPcranges",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "identifier": "id",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "schema"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "id": {
+            "title": "id",
+            "type": "string",
+            "description": "Unieke identificatie",
+            "relation": "aardgasverbruik:mraLiander"
+          },
+          "gemiddeldVerbruik": {
+            "title": "gemiddeldAardgasverbruikPerAansluiting",
+            "type": "number",
+            "description": "Gemiddeld standaard jaarverbruik per aansluiting"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -7,7 +7,7 @@ from schematools.permissions import UserScopes
 from schematools.types import ProfileSchema
 
 from dso_api.dynamic_api.serializers import clear_serializer_factory_cache, serializer_factory
-from dso_api.dynamic_api.serializers.fields import HALLooseRelationUrlField
+from dso_api.dynamic_api.serializers.fields import HALRawIdentifierUrlField
 from rest_framework_dso.fields import EmbeddedField
 from tests.utils import (
     api_request_with_scopes,
@@ -809,8 +809,8 @@ class TestDynamicSerializer:
             statistiek, context={"request": drf_request}
         )
         buurt_field = statistieken_serializer.fields["_links"].fields["buurt"]
-        assert buurt_field.__class__.__name__ == "GebiedenBuurtenLooseLinkSerializer"
-        assert isinstance(buurt_field.fields["href"], HALLooseRelationUrlField)
+        assert buurt_field.__class__.__name__ == "GebiedenBuurtenRawIdentifierSerializer"
+        assert isinstance(buurt_field.fields["href"], HALRawIdentifierUrlField)
 
         assert (
             statistieken_serializer.data["_links"]["buurt"]["href"]


### PR DESCRIPTION
This addresses the needs for the dataset 'aardgasverbruik', that has a primary key that is also a relationship.