### PR TITLE
Fix invalid CRS handling

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -3,7 +3,7 @@ django-environ == 0.9.0
 django-cors-headers == 3.13.0
 django-healthchecks == 1.5.0
 django-postgres-unlimited-varchar == 1.1.2
-django-gisserver == 1.2.3
+django-gisserver == 1.2.5
 django-vectortiles == 0.2.0
 djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -265,9 +265,9 @@ django-environ==0.9.0 \
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
-django-gisserver==1.2.3 \
-    --hash=sha256:1b4474b1bed4339332b5653611aaafa4d14d5187a713cd134b427f39501958a1 \
-    --hash=sha256:3e316b5caddaeec8ba3fe289c1cf62e3a91524e2d86af430aca02797a01bdb6c
+django-gisserver==1.2.5 \
+    --hash=sha256:46771b96f49b9dd7a1bda3bed7bbbe6b0021f8ceca1777d5842a53abd32b818b \
+    --hash=sha256:853a88fd4739104f9f1722aaafd14f59e03134408071a685e8d589ad553f6b36
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools

--- a/src/rest_framework_dso/views.py
+++ b/src/rest_framework_dso/views.py
@@ -4,6 +4,7 @@ from inspect import isgeneratorfunction
 from typing import Optional, Union
 
 from django.http import HttpResponseNotFound, JsonResponse
+from gisserver.exceptions import ExternalValueError
 from rest_framework import status
 from rest_framework.exceptions import APIException, ErrorDetail, NotAcceptable, ValidationError
 from rest_framework.renderers import JSONRenderer
@@ -327,7 +328,7 @@ class DSOViewMixin:
 
         try:
             accept_crs = crs.CRS.from_string(value)
-        except ValueError as e:
+        except ExternalValueError as e:
             raise NotAcceptable(f"Chosen CRS is invalid: {e}") from e
 
         if accept_crs not in self.accept_crs:

--- a/src/tests/files/datasets/afval.json
+++ b/src/tests/files/datasets/afval.json
@@ -4,6 +4,7 @@
   "title": "Afvalwegingen",
   "status": "beschikbaar",
   "description": "unit testing version of afvalwegingen",
+  "publisher": "Nobody",
   "license": "CC0 1.0",
   "version": "0.0.1",
   "crs": "EPSG:28992",

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -110,8 +110,9 @@ class TestDSOViewMixin:
     def test_bogus_crs(self, api_client, afval_dataset, filled_router):
         """Prove that invalid CRS leads to a 406 status"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        response = api_client.get(url, HTTP_ACCEPT_CRS="nonsense")
-        assert response.status_code == 406, response.data
+        for crs in ("nonsense", "EPSG:", "EPSG:foo"):
+            response = api_client.get(url, HTTP_ACCEPT_CRS=crs)
+            assert response.status_code == 406, response.data
 
     def test_response_has_crs_from_accept_crs(self, api_client, afval_dataset, filled_router):
         """Prove that response has a CRS header taken from the Accept-Crs header"""


### PR DESCRIPTION
Uses the new version of gisserver, which no longer raises `SyntaxError`. Only check for its `ExternalValueError` type, so we don't send error 406 for `ValueErrors` caused by bugs.

Fixes [AB#67466](https://dev.azure.com/CloudCompetenceCenter/089b38ee-0066-4b66-a36c-20744a0e4348/_workitems/edit/67466).