### PR TITLE
Docs: log and ignore broken datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,10 @@ repos:
       - id: bandit
         args: [--quiet, --exclude, src/tests]
 
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.9
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2


### PR DESCRIPTION
`/v1/docs` is broken because of one dataset. I can't reproduce the error locally. For now, log the error so we can serve the rest of the list.