### PR TITLE
Remove pip-tools from requirements_dev.txt

### DIFF
--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -2,7 +2,6 @@
 -r ./requirements.txt
 
 # Tools for maintaining requirements.txt:
-pip-tools == 6.9.0
 pur == 7.0.0
 
 # Useful extra developer packages:


### PR DESCRIPTION
It's also in requirements.in, and the versions were different.