### PR TITLE
Remove X-Content-Type-Options: nosniff

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -342,6 +342,13 @@ REST_FRAMEWORK = dict(
     VIEW_NAME_FUNCTION="rest_framework_dso.views.get_view_name",
 )
 
+# Disable X-Content-Type-Options: nosniff header. Workaround for the fact
+# that our static files don't get a Content-Type.
+#
+# The nosniff option is meant to secure uploaded files, which we don't have.
+# TODO: fix the Content-Type issue and remove this.
+SECURE_CONTENT_TYPE_NOSNIFF = False
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "DSO-API",
     "VERSION": "v1",


### PR DESCRIPTION
The previous patch fixed a local install in debug mode, but not the server deployment, which still fails to send Content-Type headers.