### PR TITLE
Configure static files dir with env var DSO_STATIC_DIR

### DIFF
--- a/dev-docs/source/howto/install.rst
+++ b/dev-docs/source/howto/install.rst
@@ -79,6 +79,11 @@ Then the ``DATABASE_URL`` can be pointed at it::
 Completing the Setup
 --------------------
 
+Install static files::
+
+    export DSO_STATIC_DIR="$HOME/dso_static"
+    ./manage.py collectstatic
+
 Create database tables::
 
     ./manage.py migrate

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/pyth
 WORKDIR /app
 COPY . ./
 
-ENV DJANGO_SETTINGS_MODULE=dso_api.settings DJANGO_DEBUG=false
+ENV DJANGO_SETTINGS_MODULE=dso_api.settings DJANGO_DEBUG=false DSO_STATIC_DIR=/static
 RUN python manage.py collectstatic --noinput
 
 EXPOSE 8000

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -30,9 +30,9 @@ DSO_API_LOG_LEVEL = env.str("DSO_API_LOG_LEVEL", "INFO")
 DSO_API_AUDIT_LOG_LEVEL = env.str("DSO_API_AUDIT_LOG_LEVEL", "INFO")
 SENTRY_BLOCKED_PATHS: Final[list[str]] = env.list("SENTRY_BLOCKED_PATHS", default=[])
 
-# Paths
+# Whitenoise needs a place to store static files and their gzipped versions.
 STATIC_URL = "/v1/static/"
-STATIC_ROOT = "/static/"
+STATIC_ROOT = env.str("DSO_STATIC_DIR")
 
 DATAPUNT_API_URL = env.str("DATAPUNT_API_URL", "https://api.data.amsterdam.nl/")
 SCHEMA_URL = env.str("SCHEMA_URL", "https://schemas.data.amsterdam.nl/datasets/")


### PR DESCRIPTION
Whitenoise needs to install the static files somewhere writable, because it generates gzipped versions of them dynamically.

With this patch, DSO-API will refuse to start when `DSO_STATIC_DIR` is not set. That seems a better option to me than letting it pick some implicit default location.