### PR TITLE
Yrob/remove swagger

### DIFF
--- a/src/dso_api/dynamic_api/views/index.py
+++ b/src/dso_api/dynamic_api/views/index.py
@@ -29,6 +29,7 @@ class APIIndexView(APIView):
     description = (
         "To use the DSO-API, see the documentation at <https://api.data.amsterdam.nl/v1/docs/>. "
     )
+    response_formatter = "index_formatter"
 
     # Set by as_view
     api_type = "rest_json"

--- a/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
+++ b/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
@@ -117,16 +117,16 @@ input:invalid {
 .param-key, .param-val {
   width: calc(50% - 0.925em - 54px);
 }
-.request-form-tabs {
+.request-form-tabs, .response-tabs {
   width: 100%;
   display: inline-block;
 }
-.request-settings {
+.request-settings, .response-container {
   border-top-right-radius: 0;
   border-top-left-radius: 0;
   border-top: none;
 }
-.request-form-tab {
+.request-form-tab, .response-tab {
   padding: 6px 12px;
   line-height: 1.42857143;
   text-decoration: none;
@@ -136,6 +136,13 @@ input:invalid {
   border: 1px solid #ccc;
   border-bottom: 1px dotted #ddd;
 }
+
+.tab.disabled {
+  pointer-events: none;
+  color: lightgray !important;
+}
+
+.show-raw .response-tab.formatted-tab,.show-formatted .response-tab.raw-tab,
 .show-params .request-form-tab.headers-tab,.show-headers .request-form-tab.params-tab {
   padding: 6px 12px;
   color: #337ab7;
@@ -143,13 +150,17 @@ input:invalid {
   border: 1px solid #ddd;
   cursor: pointer;
 }
-.request-form-tab:last-child {
+
+.request-form-tab:last-child,.response-tab:last-child {
   border-top-right-radius: 4px;
 }
-.request-form-tab:first-child {
+
+.request-form-tab:first-child, .response-tab:first-child {
   border-right: 0 !important;
   border-top-left-radius: 4px;
 }
+
+.show-raw #formatted-response-container, .show-formatted #raw-response-container,
 .show-params #request-headers, .show-headers #request-params {
   display:none;
 }
@@ -240,4 +251,22 @@ input:invalid {
 }
 #authorize-btn.disabled {
   visibility: hidden;
+}
+
+#formatted-response-container {
+  white-space: unset;
+  padding-left: 20px;
+}
+
+
+dt, dd {
+  display: inline-block;
+}
+
+.request-method {
+  font-weight: bold;
+}
+
+.request-method.get {
+  color: blue
 }

--- a/src/dso_api/static/dso_api/dynamic_api/js/index_formatter.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/index_formatter.js
@@ -1,0 +1,40 @@
+
+// Format Dataset index JSON
+// Show pretty HTML version of dataset index JSON.
+//
+// parameter: rawJson (index JSON)
+// returns: HTML string
+
+
+var FORMATTER = (rawJson) => {
+  let datasetsEl = document.createElement('div');
+    datasetsEl.className = 'datasets';
+    Object.keys(rawJson.datasets).forEach(datasetId => {
+      let dataset = rawJson.datasets[datasetId];
+      let datasetEl = document.createElement('div');
+      datasetEl.className = 'dataset';
+      datasetEl.style="margin-bottom:30px"
+      datasetEl.innerHTML = `
+        <h3 class='dataset-name' style="text-transform: capitalize;">${dataset.service_name}</h3>
+        <p class='dataset-description' style="width:80%;">${dataset.description}</p>
+        <p class='dataset-api-authentication'><b>Autorisatie</b>:${dataset.api_authentication}</p>
+        
+      `
+
+      let urls = [
+        {"type": "api", "url": dataset.environments[0].api_url},
+        {"type": "documentation", "url": dataset.environments[0].documentation_url}
+      ]
+      if(dataset.related_apis) {
+        urls = urls.concat(dataset.related_apis);
+      }
+
+      let urlsEl = document.createElement('div');
+      urls.forEach(url => {
+        urlsEl.innerHTML += `<div><b>${url["type"]}:</b> <a href="${url["url"]}">${url["url"]}</a></div>`;
+      })
+      datasetEl.appendChild(urlsEl)
+      datasetsEl.appendChild(datasetEl);
+    })
+    return datasetsEl.innerHTML;
+}

--- a/src/dso_api/static/dso_api/dynamic_api/js/openapi_formatter.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/openapi_formatter.js
@@ -1,0 +1,43 @@
+
+// Format OpenAPI Specification
+// Show summary of OpenAPI Spec, in html with links to docs and endpoints.
+//
+// parameter: rawJson (OpenAPI specification JSON)
+// returns: HTML string
+
+const FORMATTER = (rawJson) => {
+
+    let openApiEl = document.createElement('div');
+    openApiEl.innerHTML = `
+      <h3>Open API ${rawJson.info.title}</h3>
+      <p><dt>Open API version</dt> <dd>${rawJson.openapi}</dd></p>
+      <p>
+        <dt>${rawJson.externalDocs.description}</dt> 
+        <dd><a href="${rawJson.externalDocs.url}" style="display:inline-block">${rawJson.externalDocs.url}</a></dd>
+      </p>
+      <h3>Paths:</h3>
+    `
+
+    // Add a link for each path
+    let pathsEl = document.createElement('div');
+    pathsEl.className = 'paths';
+    pathsEl.style = "padding-left: 10px;"
+    Object.keys(rawJson.paths).forEach(path => {
+      Object.keys(rawJson.paths[path]).forEach(method => {
+
+        let endpointEl = document.createElement('div');
+        endpointEl.className = 'endpoint';
+        
+        endpointEl.innerHTML = `
+          <p>
+            <div class='request-method get' style="display:inline-block">${method}</div>
+            <a href="${path}" style="display:inline-block" class='path'>${path}</a>
+          </p>
+        `
+        pathsEl.appendChild(endpointEl);
+      })
+    })
+    openApiEl.appendChild(pathsEl);
+
+    return openApiEl.innerHTML;
+}

--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -118,6 +118,12 @@ class BrowsableAPIRenderer(RendererMixin, renderers.BrowsableAPIRenderer):
         # Maintain compatibility with other types of ViewSets
         context["authorization_grantor"] = getattr(context["view"], "authorization_grantor", None)
 
+        # Insert formatter into context
+        if (
+            response_formatter := getattr(context["view"], "response_formatter", None)
+        ) is not None:
+            context["response_formatter"] = "dso_api/dynamic_api/js/" + response_formatter + ".js"
+
         if dataset_id := getattr(context["view"], "dataset_id", False):
             context["dataset_url"] = reverse(f"dynamic_api:openapi-{dataset_id}")
         # Fix response content-type when it's filled in by the exception_handler

--- a/src/templates/dso_api/dynamic_api/api.html
+++ b/src/templates/dso_api/dynamic_api/api.html
@@ -128,9 +128,14 @@
       <pre ><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
     </div>
 
-    <div class="response-info" aria-label="{% trans "response info" %}">
-      <pre ><span class="meta nocode"><span id="response-headers"></span></span> 
+    <div id="response-info" class="response-info {% if response_formatter %}show-formatted{% else %}show-raw{% endif %}" aria-label="{% trans "response info" %}">
+      <div class="response-tabs">
+        <div class="tab response-tab raw-tab" onclick="event.target.parentElement.parentElement.className='show-raw'" id="raw-tab">Raw</div><div id="formatted-tab" class="tab response-tab formatted-tab {% if not response_formatter %}disabled{% endif %}" onclick="event.target.parentElement.parentElement.className='show-formatted'">Formatted</div>
+      </div>
+      <pre class="response-container" id="raw-response-container"><span class="meta nocode"><span id="response-headers"></span></span> 
 <span id="response-content">Retrieving data...</span></pre>
+      <pre class="response-container" id="formatted-response-container"> 
+<span id="formatted-response-content">Retrieving data...</span></pre>
     </div>
   </div>
 
@@ -351,6 +356,9 @@
 <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
 <script src="{% static "rest_framework/js/csrf.js" %}"></script>
 <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
+{% if response_formatter %}
+  <script src="{% static response_formatter  %}"></script>
+{% endif %}
 
 <script>
   $(document).ready(function() {

--- a/src/tests/test_dynamic_api/test_openapi.py
+++ b/src/tests/test_dynamic_api/test_openapi.py
@@ -24,7 +24,7 @@ def test_get_patterns(afval_dataset, fietspaaltjes_dataset, filled_router):
 
 
 @pytest.mark.django_db
-def test_openapi_swagger(api_client, afval_dataset, filled_router):
+def test_openapi_frontend(api_client, afval_dataset, filled_router):
     """Prove that the OpenAPI page can be rendered."""
     url = reverse("dynamic_api:openapi-afvalwegingen")
     assert url == "/v1/afvalwegingen/"
@@ -33,7 +33,19 @@ def test_openapi_swagger(api_client, afval_dataset, filled_router):
     assert response.status_code == 200
     assert response["content-type"] == "text/html; charset=utf-8"
     content = read_response(response)
-    assert "ui.initOAuth(" in content
+    assert "/v1/oauth2-redirect.html" in content
+
+
+@pytest.mark.django_db
+def test_openapi_swagger(api_client, afval_dataset, filled_router):
+    """Prove that the oauth redirect page can be rendered."""
+    url = "/v1/oauth2-redirect.html"
+
+    response = api_client.get(url, HTTP_ACCEPT="text/html")
+    assert response.status_code == 200
+    assert response["content-type"] == "text/html; charset=utf-8"
+    content = read_response(response)
+    assert " <title>Swagger UI: OAuth2 Redirect</title>" in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION

*  #AB70579 meegepakt https://dev.azure.com/CloudCompetenceCenter/Data%20Diensten/_workitems/edit/70579
(Geen pagesize validatie meer voor html requests)

* swagger UI vervangen door browsable api.
Response op de api index en de OpenAPI spec paginas geeft (ook) een html samenvatting:

/v1/ ziet er dan zo uit:
![image](https://user-images.githubusercontent.com/7206601/218512665-58d3b633-2675-4fc7-b216-6fe2bbec316a.png)

/v1/leidingeninfrastructuur zo:
![image](https://user-images.githubusercontent.com/7206601/218513321-bc7af699-a34e-4349-a746-4a5fa5c6a652.png)



