### PR TITLE
Fix documentation link in OpenAPI spec

### DIFF
--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -123,7 +123,7 @@ def get_openapi_json_view(dataset: Dataset):
         },
         "externalDocs": {
             "url": urljoin(
-                settings.SPECTACULAR_SETTINGS["EXTERNAL_DOCS"]["url"],  # to preserve hostname
+                settings.DATAPUNT_API_URL,  # to preserve hostname
                 f"/v1/docs/datasets/{dataset_schema.id}.html",
             )
         },


### PR DESCRIPTION
Documentation link was pointing to production independent of environment. Now we use the DATAPUNT_API_URL envronment setting, so the OPENAPI spec in acceptance points to acceptance docs

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
