### PR TITLE
Display authorize button on every page

### DIFF
--- a/src/dso_api/static/dso_api/dynamic_api/js/browsable_api.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/browsable_api.js
@@ -144,10 +144,10 @@ function updatePageRequest(url, method = "GET", pushHistory = true, headerSettin
 
 function authorize() {
   // Start authorization flow
-  if (!oaSpec) {
-    return
+  authUrl = new URL(OAUTHURI)
+  if (oaSpec) {
+    authUrl = new URL(oaSpec.components.securitySchemes.oauth2.flows.implicit.authorizationUrl);
   }
-  authUrl = new URL(oaSpec.components.securitySchemes.oauth2.flows.implicit.authorizationUrl);
   authUrl.searchParams.set("client_id", CLIENTID);
   authUrl.searchParams.set("redirect_uri", REDIRECTURI);
   authUrl.searchParams.set("response_type", "token");

--- a/src/rest_framework_dso/renderers.py
+++ b/src/rest_framework_dso/renderers.py
@@ -115,6 +115,7 @@ class BrowsableAPIRenderer(RendererMixin, renderers.BrowsableAPIRenderer):
 
         # Maintain compatibility with other types of ViewSets
         context["authorization_grantor"] = getattr(context["view"], "authorization_grantor", None)
+        context["oauth_url"] = settings.OAUTH_URL
 
         # Insert formatter into context
         if (

--- a/src/templates/dso_api/dynamic_api/api.html
+++ b/src/templates/dso_api/dynamic_api/api.html
@@ -32,7 +32,7 @@
 {% block content %}
 
 <div class="content-main" role="main"  aria-label="{% trans "main content" %}">
-  <btn id="authorize-btn" class="btn btn-primary disabled" onclick="authorize()">Authorize</btn>
+  <btn id="authorize-btn" class="btn btn-primary {% if not oauth_url %}disabled{% endif %}" onclick="authorize()">Authorize</btn>
   <div class="page-header">
     <h1>{{ name }}</h1>
     <h5>Bronhouder: {{ authorization_grantor|default_if_none:"Onbekend"}}</h5>
@@ -350,6 +350,7 @@
   };
   const CLIENTID = "dso-api-open-api";
   const REDIRECTURI = window.location.origin + "/v1/oauth2-redirect.html";
+  const OAUTHURI = "{{ oauth_url }}"
 </script>
 <script src="{% static "dso_api/dynamic_api/js/browsable_api.js" %}"></script>
 <script src="{% static "rest_framework/js/jquery-3.5.1.min.js" %}"></script>


### PR DESCRIPTION
Authorize button was using the oauth_uri from OpenAPI spec. So it was not available on all pages.
Now it is injected into the view, so the authorization button appears on all pages.

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
