### PR TITLE
Revert OpenAPI caching and compression

### DIFF
--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -11,8 +11,6 @@ import drf_spectacular.plumbing
 from django.conf import settings
 from django.urls import URLPattern, URLResolver, get_resolver, get_urlconf
 from django.utils.functional import lazy
-from django.views.decorators.cache import cache_page
-from django.views.decorators.gzip import gzip_page
 from rest_framework import permissions, renderers
 from rest_framework.response import Response
 from rest_framework.schemas import get_schema_view
@@ -142,9 +140,7 @@ def get_openapi_json_view(dataset: Dataset):
     }
 
     # Wrap the view in a "decorator" that shows the Swagger interface for browsers.
-    view = gzip_page(openapi_view)
-    view = cache_page(CACHE_DURATION)(view)
-    return _html_on_browser(view, dataset_schema)
+    return _html_on_browser(openapi_view, dataset_schema)
 
 
 CACHE_DURATION = 3600  # Seconds.


### PR DESCRIPTION
OpenAPI pages inconsistently deliver JSON or HTML
pages in browser. Revert for now, look at this monday

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
