### PR TITLE
Simplify filter implementation

### DIFF
--- a/src/dso_api/dynamic_api/temporal.py
+++ b/src/dso_api/dynamic_api/temporal.py
@@ -147,10 +147,10 @@ class TemporalTableQuery:
 
         return self._filter_queryset(queryset, prefix="")
 
-    def create_range_filter(self, prefix: str) -> Q | None:
+    def create_range_filter(self, prefix: str) -> Q:
         """Create a simple Q-object for filtering on a temporal range."""
         if not self.is_versioned or self.slice_value == "*":
-            return None
+            return Q()
         else:
             return self._compile_range_query(prefix)[0]
 


### PR DESCRIPTION
An empty `django.db.models.Q` object is a no-op and is False in a boolean context. Use that to our advantage: we don't need to build up lists of `Q`'s with special handling for empty lists. Only `QueryFilterEngine.filter_queryset` needs to check whether it needs to do any work.

I also removed `LOOKUP_MERGE_OPERATORS`, which was just a complicated way of checking for `not`.