### PR TITLE
Fix documentation bug

### DIFF
--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -52,7 +52,7 @@ def search_index(_request) -> HttpResponse:
         index[uri] = {
             "description": schema.description,
             "fields": [
-                f.title + " " + f.id + " " + f.description
+                (f.title or "") + " " + f.id + " " + (f.description or "")
                 for t in schema.get_tables()
                 for f in t.fields
             ],


### PR DESCRIPTION
Title and description methods can return None,
This led to an unsupported operand error for '+' on NoneType.

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
