### PR TITLE
Add button to copy token to clipboard

### DIFF
--- a/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
+++ b/src/dso_api/static/dso_api/dynamic_api/css/browsable_api.css
@@ -207,12 +207,25 @@ input:invalid {
   z-index: 10;
 }
 
+.param-info .copy-to-clipboard{
+  bottom: 0;
+  right: 0;
+  font-size: 1.5em;
+  visibility: visible;
+  position: absolute;
+  cursor: pointer;
+}
+
+.copy-to-clipboard:active {
+  border: 1px solid #0000;
+}
+
 .param-info .summary {
   width: fit-content;
   background: white;
   display: ruby;
   position: absolute;
-  right: -23px;
+  right: -3px;
   padding: 2px;
   top: -3px;
   padding-right: 20px;

--- a/src/dso_api/static/dso_api/dynamic_api/js/browsable_api.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/browsable_api.js
@@ -817,7 +817,9 @@ function setInfoBubble(element) {
     let minutesRemaining = Math.floor((new Date(token.exp * 1000) - new Date()) / 60000);
     expiredText = `Exp:${minutesRemaining}min`;
     summary = `${token.preferred_username} ${isExpired?"Expired":expiredText} `;
-    infoEl.innerHTML = `<div class="summary">${summary}</div><pre>${syntaxHighlight(JSON.stringify(token,null,4))}</pre>`;
+    infoEl.innerHTML = `<div class="summary">${summary}</div>`
+    infoEl.innerHTML += `<div title="copy token to clipboard" class="copy-to-clipboard" onclick="navigator.clipboard.writeText('${valueEl.value.substr(7)}')">&#x1F4CB;</div>`
+    infoEl.innerHTML += `<pre>${syntaxHighlight(JSON.stringify(token,null,4))}</pre>`;
     infoEl.classList.remove("hidden");
   } else {
     infoEl.classList.add("hidden");


### PR DESCRIPTION
Users like to extract the token for debugging and other things. THis adds a button next to the token header field, to copy the token to the clipboard.

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
