### PR TITLE
Remove unused method ObservableQuerySet.add_observer

### DIFF
--- a/src/rest_framework_dso/paginator.py
+++ b/src/rest_framework_dso/paginator.py
@@ -172,10 +172,6 @@ class ObservableQuerySet(QuerySet):
 
         return iterator
 
-    def add_observer(self, callback: Callable):
-        """Install an observer callback that is notified when items are iterated"""
-        self._item_callbacks.append(callback)
-
     def _item_observer(self, item, is_empty=False):
         """Notify all observers."""
         for callback in self._item_callbacks:


### PR DESCRIPTION
This method duplicates the functionality of `ObservableIterator.add_observer`. It isn't called anywhere.