### PR TITLE
gzip all the responses

### DIFF
--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.urls import URLPattern, URLResolver, get_resolver, get_urlconf
 from django.utils.functional import lazy
 from django.views.decorators.cache import cache_page
-from django.views.decorators.gzip import gzip_page
 from django.views.decorators.vary import vary_on_headers
 from rest_framework import permissions, renderers
 from rest_framework.response import Response
@@ -166,7 +165,6 @@ def _html_on_browser(openapi_view, dataset_schema):
             # Add accept and format to the Vary header so cache is
             # triggered on the json response only
             view = vary_on_headers("Accept", "format")(openapi_view)
-            view = gzip_page(view)
             view = cache_page(CACHE_DURATION)(view)
             return view(request)
         else:

--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -12,7 +12,6 @@ from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
 from django.views import View
 from django.views.decorators.cache import cache_page
-from django.views.decorators.gzip import gzip_page
 from django.views.generic import TemplateView
 from markdown import Markdown
 from markdown.extensions.tables import TableExtension
@@ -28,10 +27,9 @@ markdown = Markdown(extensions=[TableExtension(), "fenced_code"])
 
 CACHE_DURATION = 3600  # seconds.
 
-decorators = [cache_page(CACHE_DURATION), gzip_page]
+decorators = [cache_page(CACHE_DURATION)]
 
 
-@gzip_page
 def search(request: HttpRequest) -> HttpResponse:
     template = "dso_api/dynamic_api/docs/search.html"
     query = request.GET.get("q", "").strip()
@@ -39,7 +37,6 @@ def search(request: HttpRequest) -> HttpResponse:
 
 
 @cache_page(CACHE_DURATION)
-@gzip_page
 def search_index(_request) -> HttpResponse:
     index = {}
     for ds in Dataset.objects.api_enabled().db_enabled():

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.gzip.GZipMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
This reduces bandwidth for ordinary JSON responses by a factor 4-7, GeoJSON by up to a factor 10, and even MVT responses are compressible.

HTTP compression exposes us to the [BREACH](https://www.breachattack.com/) attack, which reconstructs secrets in the response body by looking at how its length changes from echoing parts of the requests. In practice, that means CSRF tokens can be leaked. But we don't use CSRF tokens for anything. We pass tokens in the request header, which doesn't get compressed.