### PR TITLE
Snake-case dataset ids for linking to docs

### DIFF
--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.schemas import get_schema_view
 from rest_framework.views import APIView
 from schematools.contrib.django.models import Dataset
+from schematools.naming import to_snake_case
 from schematools.permissions import UserScopes
 from schematools.types import DatasetSchema
 
@@ -126,7 +127,7 @@ def get_openapi_json_view(dataset: Dataset):
         "externalDocs": {
             "url": urljoin(
                 settings.DATAPUNT_API_URL,  # to preserve hostname
-                f"/v1/docs/datasets/{dataset_schema.id}.html",
+                f"/v1/docs/datasets/{to_snake_case(dataset_schema.id)}.html",
             )
         },
     }

--- a/src/dso_api/static/dso_api/dynamic_api/js/openapi_formatter.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/openapi_formatter.js
@@ -9,8 +9,8 @@ const FORMATTER = (rawJson) => {
 
     let openApiEl = document.createElement('div');
     openApiEl.innerHTML = `
-      <h3>Open API ${rawJson.info.title}</h3>
-      <p><dt>Open API version</dt> <dd>${rawJson.openapi}</dd></p>
+      <h3>OpenAPI ${rawJson.info.title}</h3>
+      <p><dt>OpenAPI version</dt> <dd>${rawJson.openapi}</dd></p>
       <p>
         <dt>${rawJson.externalDocs.description}</dt> 
         <dd><a href="${rawJson.externalDocs.url}" style="display:inline-block">${rawJson.externalDocs.url}</a></dd>


### PR DESCRIPTION
E.g., https://api.data.amsterdam.nl/v1/bor_inspecties/ would previously show a link to /v1/docs/datasets/borInspecties.html, which does not exist. The dataset docs use the snake-case form, just like the endpoints.

Also fixed a typo.