### PR TITLE
Add API Key Middleware

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -93,6 +93,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authorization_django.authorization_middleware",
     "dso_api.middleware.AuthMiddleware",
+    "apikeyclient.ApiKeyMiddleware",
 ]
 
 AUTHENTICATION_BACKENDS = [
@@ -104,7 +105,7 @@ if DEBUG:
         "debug_toolbar",
         "django_extensions",
     ]
-    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
+    MIDDLEWARE.insert(1, "debug_toolbar.middleware.DebugToolbarMiddleware")
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
@@ -443,3 +444,6 @@ SHELL_PLUS_POST_IMPORTS = (
     "from dso_api.dynamic_api.serializers import serializer_factory",
     "from pprint import pprint",
 )
+APIKEY_MANDATORY = False
+APIKEY_ENDPOINT = env.str("APIKEY_ENDPOINT", "http://localhost:8001/signingkeys/")
+APIKEY_LOCALKEYS = env.json("APIKEY_LOCALKEYS", None)

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,6 +9,7 @@ djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 1.0
 amsterdam-schema-tools[django] == 5.11.5
+datadiensten-apikeyclient == 0.1.0
 datapunt-authorization-django==1.3.3
 drf-spectacular == 0.25.1
 Geoalchemy2 == 0.11.1

--- a/src/requirements_dev.in
+++ b/src/requirements_dev.in
@@ -7,5 +7,5 @@ termcolor==2.0.1
 pre-commit==2.20.0
 django-debug-toolbar==3.7.0
 django-extensions==3.2.1
-pip-tools==6.12.1
+pip-tools==6.13.0
 tomli==1.1.0

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1324,3 +1324,13 @@ def verblijfsobjecten_data(verblijfsobjecten_model, buurten_data, nummeraanduidi
         heeft_hoofdadres_identificatie="nm3",
         heeft_hoofdadres_volgnummer=6,
     )
+
+
+@pytest.fixture(autouse=True)
+def disable_apikey_middelware(settings):
+    # The apikey middleware sets up a thread that wants
+    # to grab signings keys. We remove this middelware.
+    try:
+        settings.MIDDLEWARE.remove("apikeyclient.ApiKeyMiddleware")
+    except ValueError:
+        pass


### PR DESCRIPTION
For now, the API Key has been set to be optional.
However, if provided, it will be validated.

pip-tools needed to be upgraded to get it running again. Django check gave a warning about the Middleware not being in the correct order in the settings.MIDDLEWARE, so it had been moved.