### PR TITLE
Support configuring static host from env

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -30,8 +30,9 @@ DSO_API_LOG_LEVEL = env.str("DSO_API_LOG_LEVEL", "INFO")
 DSO_API_AUDIT_LOG_LEVEL = env.str("DSO_API_AUDIT_LOG_LEVEL", "INFO")
 SENTRY_BLOCKED_PATHS: Final[list[str]] = env.list("SENTRY_BLOCKED_PATHS", default=[])
 
+STATIC_HOST = env.str("STATIC_HOST", "")
+STATIC_URL = f"{STATIC_HOST}/v1/static/"
 # Whitenoise needs a place to store static files and their gzipped versions.
-STATIC_URL = "/v1/static/"
 STATIC_ROOT = env.str("DSO_STATIC_DIR")
 
 DATAPUNT_API_URL = env.str("DATAPUNT_API_URL", "https://api.data.amsterdam.nl/")


### PR DESCRIPTION
Required in order to use Whitenoise behind Azure CDN