### PR TITLE
Temporary removal of link to api key server.

### DIFF
--- a/src/templates/dso_api/dynamic_api/api.html
+++ b/src/templates/dso_api/dynamic_api/api.html
@@ -51,7 +51,8 @@
         <p><em>Dit heeft gevolgen voor uw systemen!</em></p>
 
         <p>
-        Vraag tijdig een API key aan om uw systemen hierop aan te passen. <a href="https://keys.api.data.amsterdam.nl/clients/v1/">U kunt met dit formulier een API key aanvragen</a>.
+        Vraag tijdig een API key aan om uw systemen hierop aan te passen. Het formulier hiervoor komt binnenkort beschikbaar.
+        <!-- <a href="https://keys.api.data.amsterdam.nl/clients/v1/">U kunt met dit formulier een API key aanvragen</a>. -->
         </p>
 </blockquote>
 


### PR DESCRIPTION
Because the azure production environment is not yet ready, we commented out the link to the apikey server form.
