### PR TITLE
Make useage of api keys configurable.

### DIFF
--- a/dev-docs/source/howto/install.rst
+++ b/dev-docs/source/howto/install.rst
@@ -118,3 +118,13 @@ Then start DSO-API:
     ./manage.py runserver localhost:8000
 
 The API can now be accessed at: http://localhost:8000.
+
+
+API key middleware
+------------------
+
+The DSO API can be protected with an API key. A middleware from `datadiensten-apikeyclient`
+has been added tot the Django middleware settings.
+This middleware tries to fetch signing keys from an endpoint that is configured with `APIKEY_ENDPOINT`.
+During development, the activation of this middleware can be disabled by setting an 
+environment variable `APIKEY_ENABLED` to `false`.

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -94,8 +94,10 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "authorization_django.authorization_middleware",
     "dso_api.middleware.AuthMiddleware",
-    "apikeyclient.ApiKeyMiddleware",
 ]
+
+if env.bool("APIKEY_ENABLED", True):
+    MIDDLEWARE.append("apikeyclient.ApiKeyMiddleware")
 
 AUTHENTICATION_BACKENDS = [
     "schematools.contrib.django.auth_backend.ProfileAuthorizationBackend",


### PR DESCRIPTION
It can be annoying that the api key middelware keeps trying to get the signing keys when developing the dso locally.

So, now an environment variable `APIKEY_ENABLED` can be used to avoid the activation of the api key middleware. If the value of `APIKEY_ENABLED` is `false`, the middleware is not activated.
