### PR TITLE
Enable use of X-Forwarded-Host

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -452,3 +452,6 @@ APIKEY_MANDATORY = False
 APIKEY_ENDPOINT = env.str("APIKEY_ENDPOINT", "http://localhost:8001/signingkeys/")
 APIKEY_LOCALKEYS = env.json("APIKEY_LOCALKEYS", None)
 APIKEY_LOGGER = "opencensus"
+
+# Initially we are proxy-ing from cvps HAProxy
+USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
Because we want to proxy from HAProxy to Azure, we need to use this header.