### PR TITLE
Re-add the link to the api key form.

### DIFF
--- a/src/templates/dso_api/dynamic_api/api.html
+++ b/src/templates/dso_api/dynamic_api/api.html
@@ -51,8 +51,8 @@
         <p><em>Dit heeft gevolgen voor uw systemen!</em></p>
 
         <p>
-        Vraag tijdig een API key aan om uw systemen hierop aan te passen. Het formulier hiervoor komt binnenkort beschikbaar.
-        <!-- <a href="https://keys.api.data.amsterdam.nl/clients/v1/">U kunt met dit formulier een API key aanvragen</a>. -->
+        Vraag tijdig een API key aan om uw systemen hierop aan te passen.
+        <a href="https://keys.api.data.amsterdam.nl/clients/v1/">U kunt met dit formulier een API key aanvragen</a>.
         </p>
 </blockquote>
 


### PR DESCRIPTION
Now that the api key server is running in PRD
we can re-add the link to the form where a key can be requested.