### PR TITLE
AB#97545 Fix for db permission error on single record access.

### DIFF
--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -2496,7 +2496,7 @@ class TestFormats:
         data = json.loads(response.getvalue())
         assert data == {
             "type": "urn:apiexception:not_found",
-            "title": "No containers matches the given query.",
+            "title": "No Containers found matching the query",
             "detail": "Not found.",
             "status": 404,
         }


### PR DESCRIPTION
When a single resource was being accessed through the api, the full records was being collected from the datbase. However, in the PostgreSQL Azure situation, this fails, because the scope of the user is being used during database access.

Now the set of fields for this particular resource is being checked against the scopes of the requesting user. If needed, the Django ORM query is limited to the allowed fields only.

This scenario was already being unittested. However, the test framework has only one test database setup. It would be very time consuming to set up an extra postgres instance with the correct set of roles. So this aspect is not being unittested atm.