### PR TITLE
AB#94572  Add download button to API page

### DIFF
--- a/src/templates/dso_api/dynamic_api/api.html
+++ b/src/templates/dso_api/dynamic_api/api.html
@@ -97,6 +97,20 @@
                 {% endfor %}
               </ul>
             </div>
+            <div class="btn-group format-selection">
+              <a id="download-button" class="btn btn-primary js-tooltip" onclick="alert('dd')"  rel="nofollow" title="Make a GET request to download the {{ name }} resource">Download</a>
+
+              <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                {% for format in available_formats %}
+                  <li>
+                    <a class="js-tooltip download-format-option" href="{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}" rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
           {% else %}
             <a id="get-button" class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
           {% endif %}


### PR DESCRIPTION
Normally, the output (be it json, csv or geojson) is rendered in the html page. Using `_format=<a format>` the use can start downloading to a file. However, when an `Authorization` header is needed, this cannot be added to this download request (only when using curl, which is a bridge too far for some users).

A download button had been added to download data *and* take headers and query parameters into account.

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
