### PR TITLE
AB#101824 fix partially protected relations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,8 +10,8 @@ sync:
 
 .PHONY: requirements
 requirements: requirements.in requirements_dev.in
-	pip-compile -v --generate-hashes --resolver=backtracking --output-file requirements.txt requirements.in
-	pip-compile -v --generate-hashes --resolver=backtracking --output-file requirements_dev.txt requirements_dev.in
+	pip-compile -v --generate-hashes --resolver=legacy --output-file requirements.txt requirements.in
+	pip-compile -v --generate-hashes --resolver=legacy --output-file requirements_dev.txt requirements_dev.in
 
 .PHONY: upgrade
 upgrade:

--- a/src/dso_api/dynamic_api/models.py
+++ b/src/dso_api/dynamic_api/models.py
@@ -1,4 +1,9 @@
+import logging
+
+from django.conf import settings
 from schematools.contrib.django.models import DynamicModel
+
+logger = logging.getLogger(__name__)
 
 
 class SealedDynamicModel(DynamicModel):
@@ -18,9 +23,15 @@ class SealedDynamicModel(DynamicModel):
         the queryset/manager and queryset iterator.
         """
         if fields and fields[0] not in self.__dict__:
-            raise RuntimeError(
+
+            message = (
                 f"Deferred attribute access: field '{fields[0]}' "
                 f"was excluded by .only() but was still accessed."
             )
+            if settings.SEAL_WARN_ONLY:
+                logger.warning(message)
+                return None
+            else:
+                raise RuntimeError(message)
 
         return super().refresh_from_db(using=using, fields=fields)

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -49,7 +49,7 @@ def filter_unauthorized_expands(
     result = []
     for match in expanded_fields:
         field_perm = user_scopes.has_field_access(match.field.field_schema)
-        table_perm = user_scopes.has_table_access(match.field.related_model.table_schema())
+        table_perm = user_scopes.has_table_fields_access(match.field.related_model.table_schema())
         if field_perm and table_perm:
             # Only add the field when there is permission
             result.append(match)

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -6,6 +6,7 @@ from rest_framework.viewsets import ViewSetMixin
 from schematools.permissions import UserScopes
 from schematools.types import DatasetFieldSchema
 
+from dso_api.dynamic_api.utils import user_scopes_have_table_fields_access
 from rest_framework_dso.embedding import EmbeddedFieldMatch
 from rest_framework_dso.serializers import ExpandableSerializer
 
@@ -49,7 +50,9 @@ def filter_unauthorized_expands(
     result = []
     for match in expanded_fields:
         field_perm = user_scopes.has_field_access(match.field.field_schema)
-        table_perm = user_scopes.has_table_fields_access(match.field.related_model.table_schema())
+        table_perm = user_scopes_have_table_fields_access(
+            user_scopes, match.field.related_model.table_schema()
+        )
         if field_perm and table_perm:
             # Only add the field when there is permission
             result.append(match)

--- a/src/dso_api/dynamic_api/serializers/base.py
+++ b/src/dso_api/dynamic_api/serializers/base.py
@@ -54,6 +54,7 @@ from dso_api.dynamic_api.utils import (
     has_field_access,
     limit_queryset_for_scopes,
     resolve_model_lookup,
+    user_scopes_have_table_fields_access,
 )
 from rest_framework_dso.embedding import EmbeddedFieldMatch
 from rest_framework_dso.fields import AbstractEmbeddedField, DSORelatedLinkField
@@ -240,8 +241,8 @@ class FieldAccessMixin(serializers.ModelSerializer):
             # The sub serializers do their own permission checks for their fields.
             # Anything else (even with source="*") passes through to enforce checks.
             return True
-        elif isinstance(field, FieldAccessMixin) and not user_scopes.has_table_fields_access(
-            field.Meta.model.table_schema()
+        elif isinstance(field, FieldAccessMixin) and not user_scopes_have_table_fields_access(
+            user_scopes, field.Meta.model.table_schema()
         ):
             # Extra case for the _links section: when a LinkSerializer object will not render
             # any fields (due to not having access to the table), don't render that block at all.

--- a/src/dso_api/dynamic_api/serializers/base.py
+++ b/src/dso_api/dynamic_api/serializers/base.py
@@ -265,6 +265,13 @@ class FieldAccessMixin(serializers.ModelSerializer):
         for model_field in model_fields:
             field_schema = DynamicModel.get_field_schema(model_field)
 
+            # XXX Temporary fix. This has been fixed in schematools
+            # on the field_schema.auth property, however atm we cannot
+            # use that version of schematools, because of incompatible django
+            # version.
+            # So remove this if statement after upgrading to schematools >= 5.21.0
+            if field_schema.is_subfield:
+                field_schema = field_schema.parent_field
             # Check access
             permission = user_scopes.has_field_access(field_schema)
             if not permission:

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -482,3 +482,5 @@ APIKEY_LOGGER = "opencensus"
 
 # Initially we are proxy-ing from cvps HAProxy
 USE_X_FORWARDED_HOST = True
+
+SEAL_WARN_ONLY = True

--- a/src/rest_framework_dso/fields.py
+++ b/src/rest_framework_dso/fields.py
@@ -294,7 +294,10 @@ class AbstractEmbeddedField:
         self.parent_serializer_class = None
 
     def __repr__(self):
-        parent_serializer = self.parent_serializer_class.__name__
+        try:
+            parent_serializer = self.parent_serializer_class.__name__
+        except AttributeError:
+            parent_serializer = "not bound"
         return (
             f"<{self.__class__.__name__}: {parent_serializer}.{self.field_name},"
             f" {self.serializer_class.__name__}>"

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1334,3 +1334,18 @@ def disable_apikey_middelware(settings):
         settings.MIDDLEWARE.remove("apikeyclient.ApiKeyMiddleware")
     except ValueError:
         pass
+
+
+@pytest.fixture()
+def monumenten_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("monumenten.json")
+
+
+@pytest.fixture()
+def monumenten_dataset(monumenten_schema) -> Dataset:
+    return Dataset.create_for_schema(monumenten_schema)
+
+
+@pytest.fixture()
+def monumenten_models(monumenten_dataset, dynamic_models):
+    return dynamic_models["monumenten"]

--- a/src/tests/files/datasets/monumenten.json
+++ b/src/tests/files/datasets/monumenten.json
@@ -1,0 +1,112 @@
+{
+  "type": "dataset",
+  "id": "monumenten",
+  "title": "monumenten",
+  "version": "1.0.0",
+  "crs": "EPSG:28992",
+  "owner": "Gemeente Amsterdam, DataOffice",
+  "publisher": "Datateam Basis- en Kernregistraties",
+  "creator": "Monumenten en Archeologie",
+  "status": "beschikbaar",
+  "description": "de kernregistratie monumenten bevat alle rijksmonumenten en gemeentelijke monumenten in Amsterdam",
+  "homepage": "https://www.amsterdam.nl/stelselpedia/monumenten-index",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "gebruik.basisinformatie@amsterdam.nl",
+  "contactPoint": {
+    "email": "OIS.GOB@amsterdam.nl"
+  },
+  "tables": [
+    {
+      "id": "monumenten",
+      "type": "table",
+      "auth": "OPENBAAR",
+      "version": "2.0.0",
+      "description": "Een beschermd monument is een onroerend monument ofwel zaak of terrein dat beschermd is vanwege het algemeen belang wegens zijn schoonheid, betekenis voor de wetenschap of cultuurhistorische waarde",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "mainGeometry": "geometrie",
+        "identifier": ["identificatie"],
+        "required": ["schema", "identificatie"],
+        "display": "identificatie",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "unieke identificatie van het object"
+          },
+          "monumentnummer": {
+            "type": "integer",
+            "description": "toegekend door het collegen van Amsterdam (M&A), Gedeputeerde Staten resp. de minister van Onderwijs, Cultuur en Wetschap"
+          },
+          "beschrijving": {
+            "auth": "MON/RDM",
+            "reasonsNonPublic": ["5.1 1d: Bevat persoonsgegevens"],
+            "type": "string",
+            "description": "Afgeschermde beschrijving van gebouwtype, bouwgeschiedenis, architectonische verschijningsvorm en of stedebouwkundige en cultuurhistorische context"
+          },
+          "ligtInMonumentenComplex": {
+            "type": "object",
+            "properties": {
+              "identificatie": {
+                "type": "string"
+              }
+            },
+            "relation": "monumenten:complexen",
+            "description": "complex waartoe het monument behoort"
+          }
+        }
+      }
+    },
+    {
+      "id": "complexen",
+      "type": "table",
+      "auth": "OPENBAAR",
+      "version": "3.0.0",
+      "description": "Een complex is een verzameling monumenten waarvan de onderlinge samenhang een zekere cultuurhistorische waarde bezit",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "identifier": ["identificatie"],
+        "required": ["schema", "identificatie"],
+        "display": "identificatie",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.3.0#/definitions/schema"
+          },
+          "identificatie": {
+            "type": "string",
+            "description": "unieke identificatie van het object"
+          },
+          "naam": {
+            "type": "string",
+            "description": "naam waaronder het complex bekend staat"
+          },
+          "bestaatUitMonumentenMonumenten": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "identificatie": {
+                  "type": "string"
+                }
+              }
+            },
+            "relation": "monumenten:monumenten",
+            "description": "een complex kan bestaan uit meerdere monumenten"
+          },
+          "beschrijving": {
+            "auth": "MON/RDM",
+            "reasonsNonPublic": ["5.1 1d: Bevat persoonsgegevens"],
+            "type": "string",
+            "description": "Afgeschermde beschrijving van het complex aan de hand van gebouwtype en bouwgeschiedenis, architectonische verschijningsvorm en cultuurhistorische context"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/settings.py
+++ b/src/tests/settings.py
@@ -50,3 +50,6 @@ INITIALIZE_DYNAMIC_VIEWSETS = False
 # Prevent tests to crash because of missing staticfiles manifests
 WHITENOISE_MANIFEST_STRICT = False
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
+# During testing we want to see if there is unwanted deferred access
+SEAL_WARN_ONLY = False

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -14,6 +14,7 @@ from tests.utils import (
     normalize_data,
     patch_field_auth,
     to_drf_request,
+    to_serializer_view,
     unlazy,
 )
 
@@ -91,7 +92,8 @@ class TestDynamicSerializer:
         # Prove that data is serialized with relations.
         # Both the cluster_id field and 'cluster' field are generated.
         container_serializer = ContainerSerializer(
-            afval_container, context={"request": drf_request}
+            afval_container,
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
         )
         data = normalize_data(container_serializer.data)
         assert data == {
@@ -130,7 +132,7 @@ class TestDynamicSerializer:
         # Prove that expands work on object-detail level
         container_serializer = ContainerSerializer(
             afval_container,
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
             fields_to_expand=["cluster"],
         )
         data = normalize_data(container_serializer.data)
@@ -185,7 +187,7 @@ class TestDynamicSerializer:
         )
         container_serializer = ContainerSerializer(
             container_without_cluster,
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
             fields_to_expand=["cluster"],
         )
         data = normalize_data(container_serializer.data)
@@ -224,7 +226,7 @@ class TestDynamicSerializer:
         )
         container_serializer = ContainerSerializer(
             container_invalid_cluster,
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
             fields_to_expand=["cluster"],
         )
         data = normalize_data(container_serializer.data)
@@ -272,7 +274,7 @@ class TestDynamicSerializer:
         # Prove that expands work on object-detail level
         container_serializer = ContainerSerializer(
             afval_container,
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
             fields_to_expand=["cluster"],
         )
         data = normalize_data(container_serializer.data)
@@ -332,7 +334,8 @@ class TestDynamicSerializer:
         with django_assert_num_queries(1):
             pc_range = PostcodeRange.objects.get(id="123")
             postcode_serializer = PostcodeRangeSerializer(
-                pc_range, context={"request": drf_request}
+                pc_range,
+                context={"request": drf_request, "view": to_serializer_view(PostcodeRange)},
             )
             data = normalize_data(postcode_serializer.data)
             assert data == {
@@ -377,7 +380,7 @@ class TestDynamicSerializer:
         StadsdelenSerializer = serializer_factory(stadsdelen_model)
         stadsdelen_serializer = StadsdelenSerializer(
             stadsdeel,
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(stadsdelen_model)},
         )
         data = normalize_data(stadsdelen_serializer.data)
         assert data == {
@@ -425,7 +428,10 @@ class TestDynamicSerializer:
 
         vestiging_serializer = VestigingSerializer(
             vestiging1,
-            context={"request": drf_request},
+            context={
+                "request": drf_request,
+                "view": to_serializer_view(vestiging_vestiging_model),
+            },
         )
         data = normalize_data(vestiging_serializer.data)
         assert data == {
@@ -455,7 +461,10 @@ class TestDynamicSerializer:
 
         vestiging_serializer = VestigingSerializer(
             vestiging2,
-            context={"request": drf_request},
+            context={
+                "request": drf_request,
+                "view": to_serializer_view(vestiging_vestiging_model),
+            },
         )
         data = normalize_data(vestiging_serializer.data)
         assert data == {
@@ -486,7 +495,7 @@ class TestDynamicSerializer:
         AdresSerializer = serializer_factory(vestiging_adres_model)
         adres_serializer = AdresSerializer(
             post_adres1,
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(vestiging_adres_model)},
         )
         data = normalize_data(adres_serializer.data)
         assert data == {
@@ -557,7 +566,13 @@ class TestDynamicSerializer:
 
         # Prove that data is serialized with relations.
 
-        parkeervak_serializer = ParkeervakSerializer(parkeervak, context={"request": drf_request})
+        parkeervak_serializer = ParkeervakSerializer(
+            parkeervak,
+            context={
+                "request": drf_request,
+                "view": to_serializer_view(parkeervakken_parkeervak_model),
+            },
+        )
         data = normalize_data(parkeervak_serializer.data)
         assert data == {
             "_links": {
@@ -600,7 +615,8 @@ class TestDynamicSerializer:
         FietsplaatjesSerializer = serializer_factory(fietspaaltjes_model)
 
         fietsplaatjes_serializer = FietsplaatjesSerializer(
-            fietspaaltjes_data, context={"request": drf_request}
+            fietspaaltjes_data,
+            context={"request": drf_request, "view": to_serializer_view(fietspaaltjes_model)},
         )
 
         assert "'title', 'reference for DISPLAY FIELD'" in str(fietsplaatjes_serializer.data)
@@ -613,7 +629,11 @@ class TestDynamicSerializer:
 
         FietsplaatjesSerializer = serializer_factory(fietspaaltjes_model_no_display)
         fietsplaatjes_serializer = FietsplaatjesSerializer(
-            fietspaaltjes_data_no_display, context={"request": drf_request}
+            fietspaaltjes_data_no_display,
+            context={
+                "request": drf_request,
+                "view": to_serializer_view(fietspaaltjes_model_no_display),
+            },
         )
 
         assert "'title', 'reference for DISPLAY FIELD'" not in str(fietsplaatjes_serializer.data)
@@ -630,7 +650,8 @@ class TestDynamicSerializer:
 
         ExplosievenSerializer = serializer_factory(explosieven_model)
         explosieven_serializer = ExplosievenSerializer(
-            explosieven_data, context={"request": drf_request}
+            explosieven_data,
+            context={"request": drf_request, "view": to_serializer_view(explosieven_model)},
         )
 
         # Validation passes if outcome is None
@@ -642,7 +663,8 @@ class TestDynamicSerializer:
 
         ExplosievenSerializer = serializer_factory(explosieven_model)
         explosieven_serializer = ExplosievenSerializer(
-            explosieven_data, context={"request": drf_request}
+            explosieven_data,
+            context={"request": drf_request, "view": to_serializer_view(explosieven_model)},
         )
 
         # Validation passes if a space does not exists (translated to %20)
@@ -658,7 +680,8 @@ class TestDynamicSerializer:
 
         ExplosievenSerializer = serializer_factory(explosieven_model)
         explosieven_serializer = ExplosievenSerializer(
-            explosieven_data, context={"request": drf_request}
+            explosieven_data,
+            context={"request": drf_request, "view": to_serializer_view(explosieven_model)},
         )
 
         # Validation passes if outcome is None
@@ -677,7 +700,8 @@ class TestDynamicSerializer:
         """Prove that the ``_links`` field also handles permissions."""
         ContainerSerializer = serializer_factory(afval_container_model)
         container_serializer = ContainerSerializer(
-            afval_container, context={"request": drf_request}
+            afval_container,
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
         )
         data = normalize_data(container_serializer.data)
         assert data == {
@@ -710,7 +734,8 @@ class TestDynamicSerializer:
         # And again with scopes
         drf_request = to_drf_request(api_request_with_scopes(["BAG/R"]))
         container_serializer = ContainerSerializer(
-            afval_container, context={"request": drf_request}
+            afval_container,
+            context={"request": drf_request, "view": to_serializer_view(afval_container_model)},
         )
         data = normalize_data(container_serializer.data)
         assert data["_links"]["cluster"] == {
@@ -752,7 +777,8 @@ class TestDynamicSerializer:
 
         FietspaaltjesSerializer = serializer_factory(fietspaaltjes_model)
         fietspaaltjes_serializer = FietspaaltjesSerializer(
-            fietspaaltjes_data, context={"request": drf_request}
+            fietspaaltjes_data,
+            context={"request": drf_request, "view": to_serializer_view(fietspaaltjes_model)},
         )
 
         assert fietspaaltjes_serializer.data["area"] == "A"
@@ -789,7 +815,7 @@ class TestDynamicSerializer:
         FietspaaltjesSerializer = serializer_factory(fietspaaltjes_model)
         fietspaaltjes_serializer = FietspaaltjesSerializer(
             fietspaaltjes_model.objects.all(),
-            context={"request": drf_request},
+            context={"request": drf_request, "view": to_serializer_view(fietspaaltjes_model)},
             many=True,
         )
 
@@ -808,7 +834,8 @@ class TestDynamicSerializer:
         StatistiekenSerializer = serializer_factory(statistieken_model)
 
         statistieken_serializer = StatistiekenSerializer(
-            statistiek, context={"request": drf_request}
+            statistiek,
+            context={"request": drf_request, "view": to_serializer_view(statistieken_model)},
         )
         buurt_field = statistieken_serializer.fields["_links"].fields["buurt"]
         assert buurt_field.__class__.__name__ == "GebiedenBuurtenRawIdentifierSerializer"
@@ -829,7 +856,13 @@ class TestDynamicSerializer:
             eind_geldigheid="2021-01-01",
         )
         serializer_class = serializer_factory(unconventional_temporal_model)
-        serializer = serializer_class(obj, context={"request": drf_request})
+        serializer = serializer_class(
+            obj,
+            context={
+                "request": drf_request,
+                "view": to_serializer_view(unconventional_temporal_model),
+            },
+        )
 
         fields = serializer.fields
         assert set(fields.keys()) == {
@@ -852,3 +885,147 @@ class TestDynamicSerializer:
             fields["_links"]["self"]["unconventionalTemporalId"].source
             == "unconventional_temporal_id"
         )
+
+    @staticmethod
+    def test_skipping_protected_relations(drf_request, monumenten_models):
+        """Prove that title element shows display value if display field is specified"""
+
+        monumenten_model = monumenten_models["monumenten"]
+        complexen_model = monumenten_models["complexen"]
+        ComplexenSerializer = serializer_factory(complexen_model)
+        MonumentenSerializer = serializer_factory(monumenten_model)
+        monumenten_data = monumenten_model.objects.create(
+            identificatie="AB.CD",
+            monumentnummer=1,
+            beschrijving="oud gebouw",
+        )
+        complexen_data = complexen_model.objects.create(
+            identificatie="AB",
+            naam="Paleis",
+            beschrijving="prachtig complex",
+        )
+        monumenten_data.ligt_in_monumenten_complex = complexen_data
+        complexen_data.bestaat_uit_monumenten_monumenten.set([monumenten_data])
+
+        drf_request = to_drf_request(api_request_with_scopes(["BAG/R"]))
+        complexen_serializer = ComplexenSerializer(
+            complexen_data,
+            context={"request": drf_request, "view": to_serializer_view(complexen_model)},
+        )
+
+        monumenten_serializer = MonumentenSerializer(
+            monumenten_data,
+            context={"request": drf_request, "view": to_serializer_view(monumenten_model)},
+        )
+
+        # Because the monumenten schema has on protected field,
+        # the M2M link to monumenten will no be available in the output.
+        data = normalize_data(complexen_serializer.data)
+        assert data == {
+            "_links": {
+                "schema": "https://schemas.data.amsterdam.nl/"
+                "datasets/monumenten/dataset#complexen",
+                "self": {
+                    "href": "http://testserver/v1/monumenten/complexen/AB/",
+                    "identificatie": "AB",
+                    "title": "AB",
+                },
+            },
+            "identificatie": "AB",
+            "naam": "Paleis",
+        }
+
+        data = normalize_data(monumenten_serializer.data)
+        assert data == {
+            "_links": {
+                "schema": "https://schemas.data.amsterdam.nl/"
+                "datasets/monumenten/dataset#monumenten",
+                "self": {
+                    "href": "http://testserver/v1/monumenten/monumenten/AB.CD/",
+                    "identificatie": "AB.CD",
+                    "title": "AB.CD",
+                },
+            },
+            "identificatie": "AB.CD",
+            "ligtInMonumentenComplexId": "AB",
+            "monumentnummer": 1,
+        }
+
+    @staticmethod
+    def test_getting_protected_relations_when_using_scope(monumenten_models):
+        """Prove that title element shows display value if display field is specified"""
+
+        monumenten_model = monumenten_models["monumenten"]
+        complexen_model = monumenten_models["complexen"]
+        ComplexenSerializer = serializer_factory(complexen_model)
+        MonumentenSerializer = serializer_factory(monumenten_model)
+        monumenten_data = monumenten_model.objects.create(
+            identificatie="AB.CD",
+            monumentnummer=1,
+            beschrijving="oud gebouw",
+        )
+        complexen_data = complexen_model.objects.create(
+            identificatie="AB",
+            naam="Paleis",
+            beschrijving="prachtig complex",
+        )
+        monumenten_data.ligt_in_monumenten_complex = complexen_data
+        complexen_data.bestaat_uit_monumenten_monumenten.set([monumenten_data])
+
+        drf_request = to_drf_request(api_request_with_scopes(["MON/RDM"]))
+        complexen_serializer = ComplexenSerializer(
+            complexen_data,
+            context={"request": drf_request, "view": to_serializer_view(complexen_model)},
+        )
+
+        monumenten_serializer = MonumentenSerializer(
+            monumenten_data,
+            context={"request": drf_request, "view": to_serializer_view(monumenten_model)},
+        )
+
+        # Because the monumenten schema has on protected field,
+        # the M2M link to monumenten will no be available in the output.
+        data = normalize_data(complexen_serializer.data)
+        assert data == {
+            "_links": {
+                "bestaatUitMonumentenMonumenten": [
+                    {
+                        "href": "http://testserver/v1/monumenten/monumenten/AB.CD/",
+                        "identificatie": "AB.CD",
+                        "title": "AB.CD",
+                    }
+                ],
+                "schema": "https://schemas.data.amsterdam.nl/"
+                "datasets/monumenten/dataset#complexen",
+                "self": {
+                    "href": "http://testserver/v1/monumenten/complexen/AB/",
+                    "identificatie": "AB",
+                    "title": "AB",
+                },
+            },
+            "beschrijving": "prachtig complex",
+            "identificatie": "AB",
+            "naam": "Paleis",
+        }
+
+        data = normalize_data(monumenten_serializer.data)
+        assert data == {
+            "_links": {
+                "ligtInMonumentenComplex": {
+                    "href": "http://testserver/v1/monumenten/complexen/AB/",
+                    "identificatie": "AB",
+                    "title": "AB",
+                },
+                "schema": "https://schemas.data.amsterdam.nl/"
+                "datasets/monumenten/dataset#monumenten",
+                "self": {
+                    "href": "http://testserver/v1/monumenten/monumenten/AB.CD/",
+                    "identificatie": "AB.CD",
+                    "title": "AB.CD",
+                },
+            },
+            "beschrijving": "oud gebouw",
+            "identificatie": "AB.CD",
+            "ligtInMonumentenComplexId": "AB",
+            "monumentnummer": 1,
+        }

--- a/src/tests/test_dynamic_api/test_views_api.py
+++ b/src/tests/test_dynamic_api/test_views_api.py
@@ -480,10 +480,6 @@ class TestAuth:
         assert response.status_code == 200, data
         assert data == {
             "_links": {
-                "schema": (
-                    "https://schemas.data.amsterdam.nl"
-                    "/datasets/parkeervakken/dataset#parkeervakken"
-                ),
                 "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/", "id": "1"},
             },
             # no ID field (not authorized)
@@ -525,10 +521,6 @@ class TestAuth:
         data = read_response_json(response)
         assert data == {
             "_links": {
-                "schema": (
-                    "https://schemas.data.amsterdam.nl"
-                    "/datasets/parkeervakken/dataset#parkeervakken"
-                ),
                 "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/", "id": "1"},
             },
             "soort": "N",  # letters:1
@@ -541,10 +533,6 @@ class TestAuth:
         assert response.status_code == 200, data
         assert data == {
             "_links": {
-                "schema": (
-                    "https://schemas.data.amsterdam.nl"
-                    "/datasets/parkeervakken/dataset#parkeervakken"
-                ),
                 "self": {"href": "http://testserver/v1/parkeervakken/parkeervakken/1/", "id": "1"},
             },
             "type": "Langs",  # read permission
@@ -2458,9 +2446,10 @@ class TestFormats:
     }
 
     @pytest.mark.parametrize("format", sorted(DETAIL_FORMATS.keys()))
-    def test_detail(self, format, api_client, afval_container, filled_router):
+    def test_detail(self, format, api_client, afval_schema, afval_container, filled_router):
         """Prove that the detail view also returns an export of a single feature."""
         decoder, expected_type, expected_data = self.DETAIL_FORMATS[format]
+        patch_table_auth(afval_schema, "clusters", auth=["OPENBAAR"])
         url = reverse(
             "dynamic_api:afvalwegingen-containers-detail",
             kwargs={"pk": afval_container.pk},

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -184,6 +184,14 @@ def to_drf_request(api_request):
     return request
 
 
+def to_serializer_view(model):
+    class DummyView:
+        def __init__(self, model):
+            self.model = model
+
+    return DummyView(model)
+
+
 def unlazy(value: SimpleLazyObject):
     """Extract the original object from a SimpleLazyObject()
     so it can be used for 'is' reference comparisons.


### PR DESCRIPTION
The Django ORM has been designed around the idea that a single database user with wide permissions is accessing the database. Authorization-based filtering is done at the python level, e.g. in DRF serializers.

However, our PostgreSQL database has been protected at the row-level with fine-grained permissions and the user accessing the database is not a generic database user, but the user accessing the API (based on the JWT auth token).

This leads to problems, especially when following relations. The Django ORM tries to fetch all rows (SELECT * FROM) and a permission exception will be raised by the database driver.

At several places extra scope-checks need to be applied to force the ORM to only fetch the rows that are allowed. 