### PR TITLE
AB#104026 Fix viewset name for docs

### DIFF
--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -295,7 +295,7 @@ LOOKUP_CONTEXT = {
 def _table_context(ds: Dataset, table: DatasetTableSchema):
     """Collect all table data for the REST API spec."""
     dataset_name = to_snake_case(table.dataset.id)
-    table_name = table.db_name_variant(with_dataset_prefix=False)
+    table_name = to_snake_case(table.id)
     uri = reverse(f"dynamic_api:{dataset_name}-{table_name}-list")
     fields = _list_fields(table.fields)
     filters = _get_filters(table.fields)


### PR DESCRIPTION
To generate the viewnames for the documentation, the db_name_variant function was used. However, that takes shortnames into account. The Django viewset ids names are using the full names of the schema-tables, so there is a mismatch leading to a 500 error for datasettables with a shortname.