### PR TITLE
AB#107499 Fix issue with expand query with only open fields

### DIFF
--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -162,8 +162,8 @@ def normalize_data(data):
     return orjson.loads(json.dumps(data, default=_default))
 
 
-def api_request_with_scopes(scopes) -> Request:
-    request = APIRequestFactory().get("/v1/dummy/")
+def api_request_with_scopes(scopes, data=None) -> Request:
+    request = APIRequestFactory().get("/v1/dummy/", data=data)
     request.accept_crs = None  # for DSOSerializer, expects to be used with DSOViewMixin
     request.response_content_crs = None
 


### PR DESCRIPTION
It should be possible for a request to fetch unprotected fields (using the `_fields` query parameter).