### PR TITLE
fix order_by in TemporalTableQuery to include prefix and identifier -…

### DIFF
--- a/src/dso_api/dynamic_api/temporal.py
+++ b/src/dso_api/dynamic_api/temporal.py
@@ -173,14 +173,15 @@ class TemporalTableQuery:
             # and allow ?geldigOp=* to return all data
             return queryset
 
+        identifier = self.table_schema.identifier[0]  # from ["identificatie", "volgnummer"]
+
         try:
             range_q, main_ordering = self._compile_range_query(prefix)
-            return queryset.filter(range_q).order_by(main_ordering)
+            return queryset.filter(range_q).order_by(f"{prefix}{identifier}", main_ordering)
         except RuntimeError:
             # Last attempt to get only the current temporal record; order by sequence.
             # does SELECT DISTINCT ON(identifier) ... ORDER BY identifier, sequence DESC
             # Alternative would be something like `HAVING sequence = MAX(SELECT sequence FROM ..)`
-            identifier = self.table_schema.identifier[0]  # from ["identificatie", "volgnummer"]
             sequence_name = self.table_schema.temporal.identifier
             return queryset.distinct(
                 *queryset.query.distinct_fields, f"{prefix}{identifier}"

--- a/src/dso_api/dynamic_api/temporal.py
+++ b/src/dso_api/dynamic_api/temporal.py
@@ -173,7 +173,12 @@ class TemporalTableQuery:
             # and allow ?geldigOp=* to return all data
             return queryset
 
-        identifier = self.table_schema.identifier[0]  # from ["identificatie", "volgnummer"]
+        identifier_set = set(self.table_schema.identifier)  # from ["identificatie", "volgnummer"]
+        if len(identifier_set) != 2:
+            raise RuntimeError("Schema does not implement usable temporal dimensions")
+        sequence_name = self.table_schema.temporal.identifier
+        # Order of identifier_set is not guaranteed, so we explicitly remove the sequence_name
+        identifier = list(identifier_set - {sequence_name})[0]
 
         try:
             range_q, main_ordering = self._compile_range_query(prefix)
@@ -182,7 +187,6 @@ class TemporalTableQuery:
             # Last attempt to get only the current temporal record; order by sequence.
             # does SELECT DISTINCT ON(identifier) ... ORDER BY identifier, sequence DESC
             # Alternative would be something like `HAVING sequence = MAX(SELECT sequence FROM ..)`
-            sequence_name = self.table_schema.temporal.identifier
             return queryset.distinct(
                 *queryset.query.distinct_fields, f"{prefix}{identifier}"
             ).order_by(f"{prefix}{identifier}", f"-{prefix}{sequence_name}")


### PR DESCRIPTION
… ensure unique ordering so, entries don't get lost or returned multiple times

