### PR TITLE
Remove setting that causes disabling of geosearch for datasets.

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -445,7 +445,7 @@ DATAPUNT_AUTHZ = {
 
 # -- Local app settings
 
-AMSTERDAM_SCHEMA = {"geosearch_disabled_datasets": ["bag", "meetbouten"]}
+AMSTERDAM_SCHEMA = {"geosearch_disabled_datasets": []}
 
 # On unapplied migrations, the Django 'check' fails when trying to
 # Fetch datasets from the database. Viewsets are not needed when migrating.


### PR DESCRIPTION
This was an old setting, because bag was being geosearched using the old bag/v11 until recently. But now, we want geosearch to use the ref db for Bag.