### PR TITLE
Fix API performance

### DIFF
--- a/src/dso_api/dynamic_api/serializers/factories.py
+++ b/src/dso_api/dynamic_api/serializers/factories.py
@@ -534,11 +534,9 @@ def _build_serializer_embedded_field(
 
     embedded_field = EmbeddedFieldClass(
         serializer_class=cast(type[base.DynamicSerializer], serializer_class),
-        # serializer_class=serializer_class,
+        field_schema=field_schema,
         source=model_field.name,
     )
-    # Attach the field schema so access rules can be applied here.
-    embedded_field.field_schema = field_schema
 
     # The field name is still generated from the model_field, in case this is a reverse field.
     serializer_part.add_embedded_field(toCamelCase(model_field.name), embedded_field)


### PR DESCRIPTION
Fix massive DSO-API performance issue, due to deepcopy()

DRF performs a deepcopy() of the serializer._declared_fields before it will handle the request. This is analogous to how Django forms work, and updating the fields with request state and 'parent' references.

Since the deepcopy() also touched dataset definitions of Amsterdam Schema, it basically took 14sec to copy all those dicts as well. This can be avoided, bringing to performance of DSO-API back to reasonable levels.