### PR TITLE
Update to django-gisserver 1.4.0 for better performance

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -519,3 +519,4 @@ EXPORT_BASE_URI = env.str("BULK_ENDPOINT", "https://api.data.amsterdam.nl/bulk-d
 
 # Setting for django-gisserver, disabling this makes WFS much faster
 GISSERVER_CAPABILITIES_BOUNDING_BOX = False
+GISSERVER_COUNT_NUMBER_MATCHED = 0  # 0 = no counting, 1 = all pages, 2 = only first page

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -4,7 +4,7 @@ django-cors-headers == 3.13.0
 django-healthchecks == 1.5.0
 django-postgres-unlimited-varchar == 1.1.2
 django-redis == 5.4.0
-django-gisserver == 1.2.7
+django-gisserver == 1.4.0
 django-vectortiles == 0.2.0
 djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -350,9 +350,9 @@ django-environ==0.9.0 \
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools
-django-gisserver==1.2.7 \
-    --hash=sha256:625843059ccf496594b0d1ce83c7f49afd4081c1613e9107ef75744207d0ef0f \
-    --hash=sha256:a371ef22a5aacc4c1468fed096016921c091b33de1d26a99f773291dece97750
+django-gisserver==1.4.0 \
+    --hash=sha256:8f765eb39277540c43c75c264272f34594cef387c2a95efad915837a2c3a26c8 \
+    --hash=sha256:f437c3aff5c6c6d33f2fc28d8e3e5e3428416e9783f3fd4620e0b27271475c71
     # via
     #   -r requirements.in
     #   amsterdam-schema-tools

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -409,9 +409,9 @@ django-extensions==3.2.1 \
     --hash=sha256:2a4f4d757be2563cd1ff7cfdf2e57468f5f931cc88b23cf82ca75717aae504a4 \
     --hash=sha256:421464be390289513f86cb5e18eb43e5dc1de8b4c27ba9faa3b91261b0d67e09
     # via -r requirements_dev.in
-django-gisserver==1.2.7 \
-    --hash=sha256:625843059ccf496594b0d1ce83c7f49afd4081c1613e9107ef75744207d0ef0f \
-    --hash=sha256:a371ef22a5aacc4c1468fed096016921c091b33de1d26a99f773291dece97750
+django-gisserver==1.4.0 \
+    --hash=sha256:8f765eb39277540c43c75c264272f34594cef387c2a95efad915837a2c3a26c8 \
+    --hash=sha256:f437c3aff5c6c6d33f2fc28d8e3e5e3428416e9783f3fd4620e0b27271475c71
     # via
     #   -r ./requirements.in
     #   amsterdam-schema-tools


### PR DESCRIPTION
This introduces many performance improvements, see https://github.com/Amsterdam/django-gisserver/pull/29