### PR TITLE
Upgrade to amsterdam-schema-tools 6.0 for better performance

### DIFF
--- a/src/dso_api/dynamic_api/management/commands/dump_serializers.py
+++ b/src/dso_api/dynamic_api/management/commands/dump_serializers.py
@@ -90,8 +90,8 @@ class Command(BaseCommand):
 
         # Give access to all fields, so these can all be dumped.
         wsgi_request.user_scopes = UserScopes(query_params={}, request_scopes=[])
-        wsgi_request.user_scopes.has_any_scope = lambda *scopes: True
-        wsgi_request.user_scopes.has_all_scopes = lambda *scopes: True
+        wsgi_request.user_scopes.has_any_scope = lambda scopes: True
+        wsgi_request.user_scopes.has_all_scopes = lambda scopes: True
 
         # Wrap in DRF request object, like the view would have done.
         drf_request = Request(wsgi_request)

--- a/src/dso_api/dynamic_api/openapi.py
+++ b/src/dso_api/dynamic_api/openapi.py
@@ -41,8 +41,8 @@ def build_mock_request(method, path, view, original_request, **kwargs):
 
     # Make sure all fields are displayed in the OpenAPI spec:
     request.user_scopes = UserScopes(query_params={}, request_scopes=[])
-    request.user_scopes.has_any_scope = lambda *scopes: True
-    request.user_scopes.has_all_scopes = lambda *scopes: True
+    request.user_scopes.has_any_scope = lambda scopes: True
+    request.user_scopes.has_all_scopes = lambda scopes: True
     return request
 
 

--- a/src/dso_api/dynamic_api/remote/views.py
+++ b/src/dso_api/dynamic_api/remote/views.py
@@ -89,7 +89,7 @@ class HaalCentraalBRK(View):
     This is a pass-through proxy like BAG, but with authorization added.
     """
 
-    _NEEDED_SCOPES = ["BRK/RO", "BRK/RS", "BRK/RSN"]
+    _NEEDED_SCOPES = frozenset({"BRK/RO", "BRK/RS", "BRK/RSN"})
 
     def __init__(self):
         super().__init__()
@@ -109,10 +109,10 @@ class HaalCentraalBRK(View):
             )
 
     def get(self, request: HttpRequest, subpath: str):
-        access = request.user_scopes.has_all_scopes(*self._NEEDED_SCOPES)
+        access = request.user_scopes.has_all_scopes(self._NEEDED_SCOPES)
         permissions.log_access(request, access)
         if not access:
-            raise PermissionDenied(f"You need scopes {self._NEEDED_SCOPES}")
+            raise PermissionDenied(f"You need scopes {','.join(self._NEEDED_SCOPES)}")
 
         url: str = settings.HAAL_CENTRAAL_BRK_ENDPOINT + subpath
         headers = {

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 0.2.0
 djangorestframework == 3.14.0
 djangorestframework-csv == 2.1.1
 djangorestframework-gis == 1.0
-amsterdam-schema-tools[django] == 5.26.1
+amsterdam-schema-tools[django] == 6.0
 datadiensten-apikeyclient == 0.5.0
 datapunt-authorization-django==1.3.3
 drf-spectacular == 0.25.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.txt --resolver=legacy requirements.in
 #
-amsterdam-schema-tools[django]==5.26.1 \
-    --hash=sha256:88d4eb7d7e471c76d10b8152e8de256d182d8bf511f8f0e76cfdb01381717868 \
-    --hash=sha256:e2cadfd52d3c330e62e28996cf4fdb70bd146af6239e0a8c9206b5e20b831351
+amsterdam-schema-tools[django]==6.0 \
+    --hash=sha256:0f714c07e79a3b3f139e4b710ec007eda34fba39c714e23e4476be086e626f09 \
+    --hash=sha256:e551da8eb89d5864dd5672b7790d9f2bb0bffb3887a086e8b957a6d28efd1a40
     # via -r requirements.in
 argparse==1.4.0 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4 \
@@ -743,9 +743,6 @@ mercantile==1.2.1 \
     --hash=sha256:30f457a73ee88261aab787b7069d85961a5703bb09dc57a170190bc042cd023f \
     --hash=sha256:fa3c6db15daffd58454ac198b31887519a19caccee3f9d63d17ae7ff61b3b56b
     # via django-vectortiles
-methodtools==0.4.7 \
-    --hash=sha256:e213439dd64cfe60213f7015da6efe5dd4003fd89376db3baa09fe13ec2bb0ba
-    # via amsterdam-schema-tools
 more-ds==0.0.6 \
     --hash=sha256:777df5b01e3a492ccccd4058156e7d916013e02e85248a8b2c2ca1d1ab13789b \
     --hash=sha256:931d6913beebcf9c4e8155b6b58eef3fc94f000c5b6fb838261b2c0c8886b69c
@@ -1265,7 +1262,6 @@ six==1.16.0 \
     #   python-dateutil
     #   python-owasp-zap-v2-4
     #   rfc3339-validator
-    #   wirerope
 smmap==5.0.0 \
     --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94 \
     --hash=sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936
@@ -1367,9 +1363,6 @@ whitenoise==6.4.0 \
     --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
     --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
     # via -r requirements.in
-wirerope==0.4.7 \
-    --hash=sha256:f3961039218276283c5037da0fa164619def0327595f10892d562a61a8603990
-    # via methodtools
 zipp==3.19.1 \
     --hash=sha256:2828e64edb5386ea6a52e7ba7cdb17bb30a73a858f5eb6eb93d8d36f5ea26091 \
     --hash=sha256:35427f6d5594f4acf82d25541438348c26736fa9b3afa2754bcd63cdb99d8e8f

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements_dev.txt --resolver=legacy requirements_dev.in
 #
-amsterdam-schema-tools[django]==5.26.1 \
-    --hash=sha256:88d4eb7d7e471c76d10b8152e8de256d182d8bf511f8f0e76cfdb01381717868 \
-    --hash=sha256:e2cadfd52d3c330e62e28996cf4fdb70bd146af6239e0a8c9206b5e20b831351
+amsterdam-schema-tools[django]==6.0 \
+    --hash=sha256:0f714c07e79a3b3f139e4b710ec007eda34fba39c714e23e4476be086e626f09 \
+    --hash=sha256:e551da8eb89d5864dd5672b7790d9f2bb0bffb3887a086e8b957a6d28efd1a40
     # via -r ./requirements.in
 argparse==1.4.0 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4 \
@@ -814,9 +814,6 @@ mercantile==1.2.1 \
     --hash=sha256:30f457a73ee88261aab787b7069d85961a5703bb09dc57a170190bc042cd023f \
     --hash=sha256:fa3c6db15daffd58454ac198b31887519a19caccee3f9d63d17ae7ff61b3b56b
     # via django-vectortiles
-methodtools==0.4.5 \
-    --hash=sha256:9370156e9036789e98cf0e97355b3be3bcd7cc9e520d1e15893a1407719effb2
-    # via amsterdam-schema-tools
 more-ds==0.0.6 \
     --hash=sha256:777df5b01e3a492ccccd4058156e7d916013e02e85248a8b2c2ca1d1ab13789b \
     --hash=sha256:931d6913beebcf9c4e8155b6b58eef3fc94f000c5b6fb838261b2c0c8886b69c
@@ -1369,7 +1366,6 @@ six==1.16.0 \
     #   python-dateutil
     #   python-owasp-zap-v2-4
     #   rfc3339-validator
-    #   wirerope
 smmap==5.0.0 \
     --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94 \
     --hash=sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936
@@ -1495,9 +1491,6 @@ whitenoise==6.4.0 \
     --hash=sha256:599dc6ca57e48929dfeffb2e8e187879bfe2aed0d49ca419577005b7f2cc930b \
     --hash=sha256:a02d6660ad161ff17e3042653c8e3f5ecbb2a2481a006bde125b9efb9a30113a
     # via -r ./requirements.in
-wirerope==0.4.6 \
-    --hash=sha256:bd1a151d4133b3ce30ecb76ed92f861505f688151173d22be2e29f4f02e60392
-    # via methodtools
 zipp==3.19.1 \
     --hash=sha256:2828e64edb5386ea6a52e7ba7cdb17bb30a73a858f5eb6eb93d8d36f5ea26091 \
     --hash=sha256:35427f6d5594f4acf82d25541438348c26736fa9b3afa2754bcd63cdb99d8e8f


### PR DESCRIPTION
This improves the performance of has_field_access() checks and direct "auth" field access.

As part of this improvement, the call signature of has_all_scopes() was changed, which affected the old Haalcentraal BRK API proxy code.
