### PR TITLE
Group minor Dependabot pip updates into one pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     directory: "/src" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      pip-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/src" # Location of package manifests
     schedule:


### PR DESCRIPTION
Have Dependabot group minor (and patch) pip version updates into one PR. 
This will hopefully make the number of PRs more managable without grouping PRs that may cause issues. 
PRs for updates that resolve security issues will still be created separately.

