### PR TITLE
Fix database error message handling

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -168,6 +168,7 @@ if _USE_SECRET_STORE or CLOUD_ENV.startswith("azure"):
             "PASSWORD": pgpassword,
             "HOST": env.str("PGHOST"),
             "PORT": env.str("PGPORT"),
+            "DISABLE_SERVER_SIDE_CURSORS": True,
             "OPTIONS": {
                 "sslmode": env.str("PGSSLMODE", default="require"),
             },
@@ -188,6 +189,7 @@ if _USE_SECRET_STORE or CLOUD_ENV.startswith("azure"):
                         "PASSWORD": pgpassword,
                         "HOST": env.str(f"PGHOST_REPLICA_{replica_count}"),
                         "PORT": env.str("PGPORT"),
+                        "DISABLE_SERVER_SIDE_CURSORS": True,
                         "OPTIONS": {
                             "sslmode": env.str("PGSSLMODE", default="require"),
                         },
@@ -231,6 +233,7 @@ else:
         ),
     }
     DATABASES["default"].setdefault("OPTIONS", {})
+    DATABASES["default"].setdefault("DISABLE_SERVER_SIDE_CURSORS", True)
     DATABASE_SET_ROLE = env.bool("DATABASE_SET_ROLE", False)
 
 DATABASES["default"]["OPTIONS"]["application_name"] = "DSO-API"

--- a/src/rest_framework_dso/embedding.py
+++ b/src/rest_framework_dso/embedding.py
@@ -369,8 +369,9 @@ class EmbeddedResultSet(ReturnGenerator):
             for instance in main_instances:
                 self.inspect_instance(instance)
 
-    def inspect_instance(self, instance):
-        """Inspect a main object to find any references for this embedded result."""
+    def inspect_instance(self, instance, **kwargs):
+        """Inspect a main object to find any references for this embedded result.
+        (kwargs can be the observable_iterator)."""
         ids = self.embedded_field.get_related_ids(instance)
         if ids:
             self.id_list.extend(ids)

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -589,6 +589,29 @@ class TestExceptionHandler:
             " */\n"
         ), data
 
+    @staticmethod
+    @pytest.mark.django_db
+    def test_pagination_beyond_last_page(api_client):
+        """Prove that going beyond the last page gives a 404."""
+        response_page_1 = api_client.get("/v1/movies", data={"page": 1})
+        data = read_response_json(response_page_1)
+        assert response_page_1.status_code == 200, data  # empty page
+        assert data == {
+            "_embedded": {"movie": []},
+            "_links": {"self": {"href": "http://testserver/v1/movies?page=1"}},
+            "page": {"number": 1, "size": 20},
+        }
+
+        response_page_2 = api_client.get("/v1/movies", data={"page": 2})
+        data = read_response_json(response_page_2)
+        assert response_page_2.status_code == 404, data  # not existent
+        assert data == {
+            "detail": "Invalid page.",
+            "status": 404,
+            "title": "Not found.",
+            "type": "urn:apiexception:not_found",
+        }
+
 
 @pytest.mark.django_db
 class TestListCount:


### PR DESCRIPTION
* Report when database roles have no access (no longer gives a 500)
* Fix 500 error HTML response messing up JSON syntax highlight.
* Make error handling easier, no longer jump through hoops to have a 404 for invalid page numbers.
* Remove server-side cursors as that breaks with PgBouncer.