### PR TITLE
MVT correct field names

### DIFF
--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -158,9 +158,6 @@ class DatasetMVTView(CheckPermissionsMixin, MVTView):
                 # Here we have to use the db_name, because that usually has a suffix not
                 # available on field.name.
                 field_name = toCamelCase(field.db_name)
-            if field_name != field.db_name and field_name.lower() != field_name:
-                # Annotate camelCased field names so they can be found.
-                queryset = queryset.annotate(**{field_name: F(field.db_name)})
             if self.z >= 15 and field.db_name != layer.geom_field and field.name != "schema":
                 # If we are zoomed far out (low z), only fetch the geometry field for a
                 # smaller payload. The cutoff is arbitrary. Play around with
@@ -168,6 +165,10 @@ class DatasetMVTView(CheckPermissionsMixin, MVTView):
                 # to get a feel for the MVT zoom levels and how much detail a single tile
                 # should contain. We exclude the main geometry and `schema` fields.
                 tile_fields += (field_name,)
+
+                if field_name != field.db_name and field_name.lower() != field_name:
+                    # Annotate camelCased field names so they can be found.
+                    queryset = queryset.annotate(**{field_name: F(field.db_name)})
         layer.queryset = queryset
         layer.tile_fields = tile_fields
 

--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -158,7 +158,7 @@ class DatasetMVTView(CheckPermissionsMixin, MVTView):
                 # Here we have to use the db_name, because that usually has a suffix not
                 # available on field.name.
                 field_name = toCamelCase(field.db_name)
-            if field_name != field.db_name and any(char.isupper() for char in field_name):
+            if field_name != field.db_name and field_name.lower() != field_name:
                 # Annotate camelCased field names so they can be found.
                 queryset = queryset.annotate(**{field_name: F(field.db_name)})
             if self.z >= 15 and field.db_name != layer.geom_field and field.name != "schema":

--- a/src/tests/test_dynamic_api/views/test_mvt.py
+++ b/src/tests/test_dynamic_api/views/test_mvt.py
@@ -11,7 +11,12 @@ CONTENT_TYPE = "application/vnd.mapbox-vector-tile"
 @pytest.mark.django_db
 class TestDatasetMVTIndexView:
     def test_mvt_index(
-        self, api_client, afval_dataset, fietspaaltjes_dataset, filled_router, drf_request
+        self,
+        api_client,
+        afval_dataset,
+        fietspaaltjes_dataset,
+        filled_router,
+        drf_request,
     ):
         """Prove that the MVT index view works."""
         response = api_client.get("/v1/mvt/")
@@ -108,7 +113,9 @@ def test_mvt_single(api_client, afval_container, filled_router):
 
 
 @pytest.mark.django_db
-def test_mvt_content(api_client, afval_container_model, afval_cluster, filled_router):
+def test_mvt_content(
+    api_client, afval_dataset, filled_router, afval_container_model, afval_cluster
+):
     """Prove that the MVT view produces vector tiles."""
 
     # Coordinates below have been calculated using https://oms.wff.ch/calc.htm
@@ -141,15 +148,12 @@ def test_mvt_content(api_client, afval_container_model, afval_cluster, filled_ro
                 {
                     "geometry": {"type": "Point", "coordinates": [1928, 2558]},
                     "properties": {
-                        # TODO These are snake-cased database field names.
-                        # We should return schema field names instead.
-                        # Also, what happens in the case of relations?
                         "id": 1,
-                        "cluster_id": "c1",
+                        "clusterId": "c1",  # relation
                         "serienummer": "foobar-123",
-                        "datum_creatie": "2021-01-03",
-                        "eigenaar_naam": "Dataservices",
-                        "datum_leegmaken": "2021-01-03 12:13:14+01",
+                        "datumCreatie": "2021-01-03",
+                        "eigenaarNaam": "Dataservices",
+                        "datumLeegmaken": "2021-01-03 12:13:14+01",
                     },
                     "id": 0,
                     "type": "Feature",
@@ -199,7 +203,6 @@ def test_mvt_forbidden(api_client, geometry_auth_thing, fetch_auth_token, filled
 @pytest.mark.django_db
 def test_mvt_model_auth(api_client, geometry_auth_model, fetch_auth_token, filled_router):
     """Prove that unauthorized fields are excluded from vector tiles"""
-
     # See test_mvt_content for how to compute the coordinates.
     geometry_auth_model.objects.create(
         id=1,


### PR DESCRIPTION
This ensures that the fields on the feature are camelCased. 
- Altered the existing test so that the expected response conforms to the schema. 
- Annotated the queryset with the camelCased field names referring to their db names.
- Added the correct names to the tile_fields. 
- Refactored to dedupe logic. 
