### PR TITLE
Bump schematools to v6.5

### DIFF
--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 1.0.1
 djangorestframework == 3.15.2
 djangorestframework-csv == 3.0.2
 djangorestframework-gis == 1.1
-amsterdam-schema-tools[django] == 6.4
+amsterdam-schema-tools[django] == 6.5
 azure-identity == 1.19.0
 azure-monitor-opentelemetry == 1.6.4
 cachetools == 5.5.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==6.4 \
-    --hash=sha256:c2910a58405e66eddf70dc685d9fa0b81de34635544ab4aedbc245e5d3d473a7 \
-    --hash=sha256:f7c5711af393a2b3b498c936f3b56cd0acd7dce34d467bb14214396227f73c39
+amsterdam-schema-tools[django]==6.5 \
+    --hash=sha256:60562588d2f64134481bd748e6f3afa02b84786e7ead445e78f55f76d46d26d2 \
+    --hash=sha256:aaef66b9e5f2aecb00019ab87a2169a5e44c48d98ac3ba65f6dcaa555f2c9733
     # via -r requirements.in
 argparse==1.4.0 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4 \

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements_dev.txt requirements_dev.in
 #
-amsterdam-schema-tools[django]==6.4 \
-    --hash=sha256:c2910a58405e66eddf70dc685d9fa0b81de34635544ab4aedbc245e5d3d473a7 \
-    --hash=sha256:f7c5711af393a2b3b498c936f3b56cd0acd7dce34d467bb14214396227f73c39
+amsterdam-schema-tools[django]==6.5 \
+    --hash=sha256:60562588d2f64134481bd748e6f3afa02b84786e7ead445e78f55f76d46d26d2 \
+    --hash=sha256:aaef66b9e5f2aecb00019ab87a2169a5e44c48d98ac3ba65f6dcaa555f2c9733
     # via -r ./requirements.in
 argparse==1.4.0 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4 \


### PR DESCRIPTION
6.5 fixt db persistence en db_name en python_name properties op Scope objects. 