### PR TITLE
Fix xss vulnerability in browsable api

### DIFF
--- a/src/dso_api/static/dso_api/dynamic_api/js/browsable_api.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/browsable_api.js
@@ -833,7 +833,11 @@ function createParamEl(key = null, value = null, op = "eq", active = true, insid
 
   let opEl = document.createElement('select');
   opEl.className = "param-op";
-  opEl.innerHTML = `<option value="${op}" selected>${OPERATORS[op] || op}</option>`;
+  let option = document.createElement("option");
+  option.value = op;
+  option.textContent = OPERATORS[op] || op;
+  opEl.innerHTML = "";
+  opEl.appendChild(option);
   opEl.addEventListener('change', onParamOpSet);
   paramEl.appendChild(opEl);
 


### PR DESCRIPTION
User input was not properly sanitized before writing to DOM.
This should fix an issue brought up by github code-scanning.