### PR TITLE
Altijd identifiers toevoegen in MVT data

### DIFF
--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -161,7 +161,12 @@ class DatasetMVTView(CheckPermissionsMixin, MVTView):
                 # Here we have to use the db_name, because that usually has a suffix not
                 # available on field.name.
                 field_name = toCamelCase(field.db_name)
-            if self.z >= 15 and field.db_name != layer.geom_field and field.name != "schema":
+            if (
+                self.z >= 15
+                and field.db_name != layer.geom_field
+                and field.name != "schema"
+                and field_name not in tile_fields
+            ):
                 # If we are zoomed far out (low z), only fetch the geometry field for a
                 # smaller payload. The cutoff is arbitrary. Play around with
                 # https://www.maptiler.com/google-maps-coordinates-tile-bounds-projection/

--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -147,7 +147,10 @@ class DatasetMVTView(CheckPermissionsMixin, MVTView):
         layer.geom_field = schema.main_geometry_field.python_name
 
         queryset = self.model.objects.all()
-        tile_fields = ()
+
+        # We always include the identifier fields
+        identifiers = schema.identifier_fields
+        tile_fields = tuple(id.name for id in identifiers)
 
         for field in schema.fields:
             field_name = field.name

--- a/src/tests/test_dynamic_api/views/test_mvt.py
+++ b/src/tests/test_dynamic_api/views/test_mvt.py
@@ -162,7 +162,7 @@ def test_mvt_content(
         }
     }
 
-    # Try again at a higher zoom level. We should get the same features, but with no properties.
+    # Try again at a higher zoom level. We should get the same features and only the "id" property.
     url = "/v1/mvt/afvalwegingen/containers/14/8415/5384.pbf"
     response = api_client.get(url)
     # MVT view returns 204 when the tile is empty.
@@ -179,7 +179,9 @@ def test_mvt_content(
             "features": [
                 {
                     "geometry": {"type": "Point", "coordinates": [3825, 1344]},
-                    "properties": {},
+                    "properties": {
+                        "id": 1,
+                    },
                     "id": 0,
                     "type": "Feature",
                 }


### PR DESCRIPTION
Hierdoor zijn de identifiers aanwezig ongeacht het zoomniveau.