### PR TITLE
MVT tilejson

### DIFF
--- a/dev-docs/source/api/dso_api.dynamic_api.views.rst
+++ b/dev-docs/source/api/dso_api.dynamic_api.views.rst
@@ -55,6 +55,10 @@ MVT API
    :show-inheritance:
    :members:
 
+.. autoclass:: dso_api.dynamic_api.views.DatasetTileJSONView
+   :show-inheritance:
+   :members:
+
 
 Documentation
 -------------

--- a/src/dso_api/dynamic_api/filters/values.py
+++ b/src/dso_api/dynamic_api/filters/values.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 # Don't want Decimal("NaN"), Decimal("-inf") or '0.321000e+2' to be accepted.
 RE_DECIMAL = re.compile(r"^[0-9]+(\.[0-9]+)?$")
+AMSTERDAM_BOUNDS = [4.72876, 52.2782, 5.07916, 52.4311]
+DAM_SQUARE = [4.8925627, 52.3731139, 14]  # Zoom = 14
 
 
 def str2bool(value: str) -> bool:

--- a/src/dso_api/dynamic_api/routers.py
+++ b/src/dso_api/dynamic_api/routers.py
@@ -50,6 +50,7 @@ from .views import (
     DatasetDocView,
     DatasetMVTSingleView,
     DatasetMVTView,
+    DatasetTileJSONView,
     DatasetWFSDocView,
     DatasetWFSView,
     viewset_factory,
@@ -384,6 +385,14 @@ class DynamicRouter(routers.DefaultRouter):
                     "mvt/" + dataset.path + "/",
                     DatasetMVTSingleView.as_view(),
                     name="mvt-single-dataset",
+                    kwargs={"dataset_name": dataset_id},
+                )
+            )
+            results.append(
+                path(
+                    "mvt/" + dataset.path + "/tilejson.json",
+                    DatasetTileJSONView.as_view(),
+                    name="mvt-tilejson",
                     kwargs={"dataset_name": dataset_id},
                 )
             )

--- a/src/dso_api/dynamic_api/views/__init__.py
+++ b/src/dso_api/dynamic_api/views/__init__.py
@@ -3,7 +3,7 @@
 from .api import DynamicApiViewSet, viewset_factory
 from .doc import DatasetDocView, DatasetWFSDocView, DocsOverview
 from .index import APIIndexView
-from .mvt import DatasetMVTIndexView, DatasetMVTSingleView, DatasetMVTView
+from .mvt import DatasetMVTIndexView, DatasetMVTSingleView, DatasetMVTView, DatasetTileJSONView
 from .oauth import oauth2_redirect
 from .wfs import DatasetWFSIndexView, DatasetWFSView
 
@@ -14,6 +14,7 @@ __all__ = (
     "DatasetMVTView",
     "DatasetMVTIndexView",
     "DatasetMVTSingleView",
+    "DatasetTileJSONView",
     "DatasetWFSDocView",
     "DatasetWFSView",
     "DatasetWFSIndexView",

--- a/src/templates/dso_api/dynamic_api/docs/gis/qgis.md
+++ b/src/templates/dso_api/dynamic_api/docs/gis/qgis.md
@@ -60,7 +60,9 @@ laden:
     op 1.
 
 Een lijst van datasets die vector tiles ondersteunen is beschikbaar op:
-<https://api.data.amsterdam.nl/v1/mvt/>.
+<https://api.data.amsterdam.nl/v1/mvt/>. Op
+<https://api.data.amsterdam.nl/v1/mvt/<dataset>/tilejson.json> vind je URLs
+voor alle tabellen met geo-velden.
 
 ## Autorisatie
 


### PR DESCRIPTION
Dit voegt een tilejson.json route toe voor alle datasets. Daarin zijn vervolgens de verschillende tile layers te vinden (1 voor elke tabel die een geoveld heeft). 

Geeft 404 voor datasets met alleen tabellen zonder geoveld. 

NB: Ik heb overigens nog geen manier gevonden om dit zo in QGis in te laden dat ie alle lagen toevoegt. Had een plugin gevonden die met TileJSON overweg kan, maar die pakt alleen de eerste. In de meeste voorbeelden van tilejsons online zie ik trouwens ook dat het een lijst is van verschillende endpoints die dezelfde data geven, ipv daadwerkelijk verschillende lagen. Wellicht is het de intentie dat dit per tabel wordt gedaan ipv per dataset? 