### PR TITLE
Show all fields on wfs index page

### DIFF
--- a/src/dso_api/dynamic_api/views/wfs.py
+++ b/src/dso_api/dynamic_api/views/wfs.py
@@ -281,8 +281,11 @@ class DatasetWFSView(CheckPermissionsMixin, WFSView):
         """
         fields = []
         other_geo_fields = []
+        is_index_view = self.is_index_request()
         for model_field in model._meta.get_fields():
-            if not self.request.user_scopes.has_field_access(model.get_field_schema(model_field)):
+            if not is_index_view and not self.request.user_scopes.has_field_access(
+                model.get_field_schema(model_field)
+            ):
                 continue
 
             if isinstance(model_field, models.ForeignKey):

--- a/src/tests/test_dynamic_api/views/test_wfs.py
+++ b/src/tests/test_dynamic_api/views/test_wfs.py
@@ -249,6 +249,16 @@ class TestDatasetWFSViewAuth:
         response = self.request(api_client, fetch_auth_token, "geometry_authdataset", [])
         assert response.status_code == 403
 
+    def test_wfs_model_unauthorized_index_page_works(
+        self, api_client, geometry_authdataset_thing, filled_router
+    ):
+        response = api_client.get("/v1/wfs/geometry_authdataset/")
+        assert response.status_code == 200
+        content = str(response.content)
+        for field in ["id", "metadata", "geometry"]:
+            # all fields should be available on the index page, even though auth is present
+            assert f"<th><code>{field}</code></th>" in content
+
     def test_wfs_model_authorized(
         self, api_client, geometry_authdataset_thing, fetch_auth_token, filled_router
     ):


### PR DESCRIPTION
Velden misten als je geen auth had, terwijl op de index pagina alleen de metadata van de velden - type, description - wordt getoond. Deze data is ook al beschikbaar in het schema en in de docs. 

Zie discussie: https://datalab-amsterdam.slack.com/archives/CJW3HEAKH/p1742372795066099

Ticket: https://datalab-amsterdam.slack.com/lists/T067TBC4S/F07B2E8F21X?record_id=Rec08HAEWRLJK

NB voor het opvragen van records is natuurlijk nog wel steeds authorisatie nodig.