### PR TITLE
Warmup Django before exposing uWSGI worker

### DIFF
--- a/src/dso_api/wsgi.py
+++ b/src/dso_api/wsgi.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/3.0/howto/deployment/wsgi/
 """
 
 import os
+import sys
 
 from django.conf import settings
 from django.core.wsgi import get_wsgi_application
@@ -17,3 +18,16 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dso_api.settings")
 
 application = get_wsgi_application()
 application = WhiteNoise(application, root=settings.STATIC_ROOT)
+
+# Warm-up Django ahead of time instead of lazy-apps
+# From: http://uwsgi-docs.readthedocs.org/en/latest/articles/TheArtOfGracefulReloading.html#dealing-with-ultra-lazy-apps-like-django
+application(
+    {
+        "REQUEST_METHOD": "GET",
+        "SERVER_NAME": "127.0.0.1",
+        "SERVER_PORT": 80,
+        "PATH_INFO": "/v1/",
+        "wsgi.input": sys.stdin,
+    },
+    lambda x, y: None,
+)


### PR DESCRIPTION
This way endusers will not experience a slow response when a new pod starts or a worker is restarted.
Based on http://uwsgi-docs.readthedocs.org/en/latest/articles/TheArtOfGracefulReloading.html#dealing-with-ultra-lazy-apps-like-django

Gets rid of slow responses during redeploys and scaling operations in kubernetes.
