### PR TITLE
Use table zoom levels

### DIFF
--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -147,12 +147,12 @@ class DatasetMVTView(CheckPermissionsMixin, StreamingMVTView):
         tile_fields = tuple(id.name for id in identifiers)
 
         for field in schema.fields:
-            if not user_scopes.has_field_access(field) or self.zoom < 15:
-                # 403 or too zoomed out to include the field.
-                # The cutoff is arbitrary. Play around with
-                # https://www.maptiler.com/google-maps-coordinates-tile-bounds-projection/
-                # to get a feel for the MVT zoom levels and how much detail a single tile
-                # should contain.
+            if (
+                not user_scopes.has_field_access(field)
+                or self.zoom < schema.min_zoom
+                or self.zoom > schema.max_zoom
+            ):
+                # 403 or not within zoom range to include the field.
                 continue
 
             # We may have to use the db_name, because that usually has a suffix not

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 1.0.1
 djangorestframework == 3.15.2
 djangorestframework-csv == 3.0.2
 djangorestframework-gis == 1.1
-amsterdam-schema-tools[django] == 6.5.4
+amsterdam-schema-tools[django] == 6.6.0
 azure-identity == 1.21.0
 azure-monitor-opentelemetry == 1.6.5
 cachetools == 5.5.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==6.5.4 \
-    --hash=sha256:094eb8213ddd32d3c23c81b0927bf7e41493159eda40de78cb6cc4dba6460451 \
-    --hash=sha256:9f38f5a007281291d473ccb81274bd51c4efdd061f147d84f6db9efa8130b463
+amsterdam-schema-tools[django]==6.6.0 \
+    --hash=sha256:05ca5f715ad299c849ca890316c2118603bd41ec51c86eb2b943500382bfde95 \
+    --hash=sha256:7ed662fb6f67322f2a196c5cd1ce2eab3ab0614a33eb6fdc8ccc54a6357283dc
     # via -r requirements.in
 argparse==1.4.0 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4 \

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements_dev.txt requirements_dev.in
 #
-amsterdam-schema-tools[django]==6.5.4
+amsterdam-schema-tools[django]==6.6.0
     # via -r ./requirements.in
 argparse==1.4.0
     # via uwsgi-readiness-check

--- a/src/tests/files/datasets/gebieden.json
+++ b/src/tests/files/datasets/gebieden.json
@@ -88,6 +88,10 @@
           "geldigOp": ["beginGeldigheid", "eindGeldigheid"]
         }
       },
+      "zoom": {
+        "min": 12,
+        "max": 16
+      },
       "schema": {
         "$id": "https://github.com/Amsterdam/schemas/gebieden/buurten.json",
         "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Dit zorgt ervoor dat mvt details alleen worden getoond als de zoom zich tussen min en max bevindt (beiden inclusief).