### PR TITLE
Jasper/bugfixes

### DIFF
--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -141,7 +141,13 @@ class DynamicApiViewSet(DSOViewMixin, viewsets.ReadOnlyModelViewSet):
             # Allow fallback to old full id search (note this may need ?geldigOp=* to work)
             queryset = queryset.filter(models.Q(**{self.lookup_field: pk}) | models.Q(pk=pk))
         else:
-            queryset = queryset.filter(pk=pk)
+            try:
+                queryset = queryset.filter(pk=pk)
+            except ValueError as err:
+                raise NotFound(
+                    _("No %(verbose_name)s found matching the query")
+                    % {"verbose_name": queryset.model._meta.verbose_name}
+                ) from err
 
         # Only retrieve the correct temporal object, unless filters change this
         obj = queryset.order_by().first()  # reverse ordering already applied

--- a/src/dso_api/dynamic_api/views/api.py
+++ b/src/dso_api/dynamic_api/views/api.py
@@ -105,7 +105,7 @@ class DynamicApiViewSet(DSOViewMixin, viewsets.ReadOnlyModelViewSet):
         """Overwritten from GenericAPIView to filter on temporal identifier instead."""
         if self.temporal.is_versioned:
             # Take the first field as grouper from ["identificatie", "volgnummer"]
-            return self.model.table_schema().identifier[0]
+            return self.model.table_schema().identifier_fields[0].db_name
         else:
             return "pk"
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -492,6 +492,34 @@ def geometry_authdataset_thing(geometry_authdataset_model):
     )
 
 
+# Dataset with multiple geometries.
+
+
+@pytest.fixture()
+def geometry_multiple_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("geometry_multiple.json")
+
+
+@pytest.fixture()
+def geometry_multiple_dataset(geometry_multiple_schema):
+    return Dataset.create_for_schema(schema=geometry_multiple_schema)
+
+
+@pytest.fixture()
+def geometry_multiple_model(geometry_multiple_dataset, dynamic_models):
+    return dynamic_models["geometry_multiple"]["things"]
+
+
+@pytest.fixture()
+def geometry_multiple_thing(geometry_multiple_model):
+    return geometry_multiple_model.objects.create(
+        id=1,
+        metadata="secret",
+        geometrie=Point(10, 10),
+        main_geometrie=Point(10, 10),
+    )
+
+
 @pytest.fixture
 def category() -> Category:
     """A dummy model to test our API with"""

--- a/src/tests/files/datasets/geometry_multiple.json
+++ b/src/tests/files/datasets/geometry_multiple.json
@@ -1,0 +1,44 @@
+{
+  "id": "geometry_multiple",
+  "type": "dataset",
+  "title": "Geometry mulitple geometry fields test",
+  "status": "beschikbaar",
+  "publisher": "Nobody",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "things",
+      "type": "table",
+      "version": "1.0.0",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["id", "schema"],
+        "mainGeometry": "mainGeometrie",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Identifier"
+          },
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.0#/definitions/schema"
+          },
+          "metadata": {
+            "type": "string",
+            "auth": "TEST/META",
+            "description": ""
+          },
+          "geometrie": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Geometrie"
+          },
+          "mainGeometrie": {
+            "$ref": "https://geojson.org/schema/Point.json",
+            "description": "Main geometrie"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/test_dynamic_api/views/test_wfs.py
+++ b/src/tests/test_dynamic_api/views/test_wfs.py
@@ -349,3 +349,22 @@ class TestDatasetWFSViewAuth:
             "id": "1",
             "metadata": "secret",
         }
+
+    def test_wfs_model_multiple_geometries(
+        self, api_client, geometry_multiple_thing, fetch_auth_token, filled_router
+    ):
+        """
+        When having multiple geometries, expect the main geometry to be accessible by default.
+        This test will validate that the mainGeometry is added first.
+        """
+        response = self.request(api_client, fetch_auth_token, "geometry_multiple", [])
+        assert response.status_code == 200
+
+        # Expect other geometrie to be available as well
+        wfs_url = (
+            "/v1/wfs/geometry_multiple/"
+            "?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=things-geometrie"
+            "&OUTPUTFORMAT=application/gml+xml"
+        )
+        response = api_client.get(wfs_url)
+        assert response.status_code == 200


### PR DESCRIPTION
Solve a few bugs:

-  Fix FieldError when trying to lookup on id instead of db_name

For temporal tables the identifier field was searched based on the id instead of the dbname. This causes issues when an id with an underscore is used, e.g. verblijfsobjectIdentificatie instead of verblijfsobject_identificatie. This fix now uses the field.db_name
instead of the id

- Catch valueerror on incorrect urls

When someone tried to access an url with {id} instead of an actual id a ValueError was raised. This fix catches the error and returns a 404.

- Fix bug where mainGeometry is not added as the default feature

When there are multiple geometries defined in the schema and the mainGeometry comes after another geometry, it was not added as the default feature. When the other geometry has required permission, this caused an improperlyconfigured error.

This fix makes sure the maingeometry is added as the default/first feature in wfs.