### PR TITLE
Confirm coordinate for REST API and GeoJSON

### DIFF
--- a/src/rest_framework_dso/crs.py
+++ b/src/rest_framework_dso/crs.py
@@ -32,4 +32,5 @@ ETRS89 = CRS.from_string("urn:ogc:def:crs:EPSG::4258")
 DEFAULT_CRS = RD_NEW
 
 #: All coordinate reference systems exposed by this file.
-ALL_CRS = [DEFAULT_CRS, WGS84, WEB_MERCATOR, ETRS89]
+#: These are accepted by the Accept-Crs header, and exposed in the WFS.
+ALL_CRS = [WGS84, CRS84, WEB_MERCATOR, ETRS89, RD_NEW]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -28,6 +28,19 @@ HERE = Path(__file__).parent
 DATE_2021_FEB = datetime(2021, 2, 28, 10, 0, tzinfo=get_current_timezone())
 DATE_2021_JUNE = datetime(2021, 6, 11, 10, 0, tzinfo=get_current_timezone())
 
+# Database formats
+DAM_SQUARE_LATLON = "SRID=4326;POINT (4.8936582 52.3731716)"  # x,y ordering in database
+DAM_SQUARE_RD = "SRID=28992;POINT (121389 487369)"
+
+# Django formats
+DAM_SQUARE_POINT_NO_SRID = Point(121389, 487369)  # uses django model field srid.
+DAM_SQUARE_POINT = Point(121389, 487369, srid=28992)
+
+# Allow comparing on systems that have different gdal/proj4 versions
+DAM_SQUARE_LATLON_APPROX = pytest.approx([4.8936582, 52.3731716], rel=1e-6)  # x,y ordering
+DAM_SQUARE_WGS84_APPROX = pytest.approx([52.3731716, 4.8936582], rel=1e-6)  # north,east (y,x)
+DAM_SQUARE_RD_APPROX = pytest.approx([121389, 487369], rel=0.001)
+
 
 # In test files we use a lot of non-existent scopes, so instead of writing scope
 # json files we monkeypatch this method.
@@ -375,7 +388,7 @@ def afval_container(afval_container_model, afval_cluster):
         datum_creatie=date(2021, 1, 3),
         datum_leegmaken=datetime(2021, 1, 3, 12, 13, 14, tzinfo=get_current_timezone()),
         cluster=afval_cluster,
-        geometry=Point(10, 10),  # no SRID on purpose, should use django model field.
+        geometry=DAM_SQUARE_POINT_NO_SRID,
     )
 
 
@@ -460,7 +473,7 @@ def geometry_auth_thing(geometry_auth_model):
     return geometry_auth_model.objects.create(
         id=1,
         metadata="secret",
-        geometry_with_auth=Point(10, 10),
+        geometry_with_auth=DAM_SQUARE_POINT_NO_SRID,
     )
 
 
@@ -487,7 +500,7 @@ def geometry_authdataset_thing(geometry_authdataset_model):
     return geometry_authdataset_model.objects.create(
         id=1,
         metadata="secret",
-        geometry=Point(10, 10),
+        geometry=DAM_SQUARE_POINT_NO_SRID,
     )
 
 
@@ -514,8 +527,8 @@ def geometry_multiple_thing(geometry_multiple_model):
     return geometry_multiple_model.objects.create(
         id=1,
         metadata="secret",
-        geometrie=Point(10, 10),
-        main_geometrie=Point(10, 10),
+        geometrie=DAM_SQUARE_POINT_NO_SRID,
+        main_geometrie=DAM_SQUARE_POINT_NO_SRID,
     )
 
 

--- a/src/tests/test_dynamic_api/test_serializers.py
+++ b/src/tests/test_dynamic_api/test_serializers.py
@@ -728,7 +728,7 @@ class TestDynamicSerializer:
             "datumCreatie": "2021-01-03",
             "datumLeegmaken": "2021-01-03T11:13:14",
             "eigenaarNaam": "Dataservices",
-            "geometry": {"coordinates": [10.0, 10.0], "type": "Point"},
+            "geometry": {"coordinates": [121389, 487369], "type": "Point"},
             "id": 1,
             "serienummer": "foobar-123",
         }

--- a/src/tests/test_dynamic_api/views/test_api.py
+++ b/src/tests/test_dynamic_api/views/test_api.py
@@ -74,20 +74,20 @@ class TestDSOViewMixin:
     def test_not_supported_crs(self, api_client, afval_dataset, filled_router):
         """Prove that invalid CRS leads to a 406 status"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        response = api_client.get(url, HTTP_ACCEPT_CRS="EPSG:2000")
+        response = api_client.get(url, headers={"Accept-Crs": "EPSG:2000"})
         assert response.status_code == 406, response.data
 
     def test_bogus_crs(self, api_client, afval_dataset, filled_router):
         """Prove that invalid CRS leads to a 406 status"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
         for crs in ("nonsense", "EPSG:", "EPSG:foo"):
-            response = api_client.get(url, HTTP_ACCEPT_CRS=crs)
+            response = api_client.get(url, headers={"Accept-Crs": crs})
             assert response.status_code == 406, response.data
 
     def test_response_has_crs_from_accept_crs(self, api_client, afval_dataset, filled_router):
         """Prove that response has a CRS header taken from the Accept-Crs header"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        response = api_client.get(url, HTTP_ACCEPT_CRS="EPSG:4258")
+        response = api_client.get(url, headers={"Accept-Crs": "EPSG:4258"})
         assert response.status_code == 200, response.data
         assert response.has_header("Content-Crs"), dict(response.items())
         assert CRS.from_string("EPSG:4258") == CRS.from_string(response["Content-Crs"])
@@ -97,7 +97,7 @@ class TestDSOViewMixin:
     ):
         """Prove that response has a CRS header taken from the Accept-Crs header"""
         url = reverse("dynamic_api:afvalwegingen-containers-list")
-        response = api_client.get(url, HTTP_ACCEPT_CRS="EPSG:4258")
+        response = api_client.get(url, headers={"Accept-Crs": "EPSG:4258"})
         assert response.status_code == 200, response.data
         assert response.has_header("Content-Crs"), dict(response.items())
         assert CRS.from_string("EPSG:4258") == CRS.from_string(response["Content-Crs"])

--- a/src/tests/test_dynamic_api/views/test_api_filters.py
+++ b/src/tests/test_dynamic_api/views/test_api_filters.py
@@ -212,7 +212,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[contains]": "121137.7,489046.9"},
-            HTTP_ACCEPT_CRS="EPSG:28992",
+            headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 1, "inside with R/D"
@@ -221,7 +221,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[contains]": "52.388231,4.8897865"},
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         assert response.status_code == 200, data
@@ -231,7 +231,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[contains]": "52.3883019,4.8900356"},
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 0, "Outside using WGS84"
@@ -240,7 +240,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[contains]": "52.388231,48897865"},
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         assert response.status_code == 400, "Outside WGS84 range"
 
@@ -269,7 +269,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[intersects]": "121137.7,489046.9"},
-            HTTP_ACCEPT_CRS="EPSG:28992",
+            headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 1, "inside with R/D"
@@ -278,7 +278,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[intersects]": "52.388231,4.8897865"},
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         assert response.status_code == 200, data
@@ -290,7 +290,7 @@ class TestFilterFieldTypes:
             data={
                 "geometry[intersects]": "POLYGON ((4.8982259 52.3748037, 4.8989231 52.3744369, 4.9008431 52.3739718, 4.9011541 52.3751508, 4.899985 52.3761922, 4.8982367 52.3748037, 4.8982259 52.3748037))"  # noqa: E501
             },
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         assert response.status_code == 200, data
@@ -301,7 +301,7 @@ class TestFilterFieldTypes:
             data={
                 "geometry[intersects]": "MULTIPOLYGON (((5.639762878417969 51.70404205550062, 5.47222137451172 51.54050328936586, 5.984265804290771 51.445328182347936, 6.050591468811035 51.57152179108081, 5.639762878417969 51.70404205550062)), ((5.268545150756836 51.8780408523543, 5.039935111999512 51.700837165629764, 5.2266597747802725 51.65603805162954, 5.515286922454835 51.827171560252935, 5.268545150756836 51.8780408523543)))"  # noqa: E501
             },
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         print("Response data:", data)  # Debug print
@@ -312,7 +312,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[intersects]": "52.3883019,4.8900356"},
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 0, "Outside using WGS84"
@@ -323,7 +323,7 @@ class TestFilterFieldTypes:
             data={
                 "geometry[intersects]": "POLYGON ((4.894892 52.5949621, 4.8935187 52.5957963, 4.9772894 52.6262334, 4.9395239 52.6982808, 4.8070014 52.6762211, 4.894892 52.5949621))"  # noqa: E501
             },
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         assert len(data["_embedded"]["parkeervakken"]) == 0, "Outside using WGS84"
@@ -334,7 +334,7 @@ class TestFilterFieldTypes:
             data={
                 "geometry[intersects]": "MULTIPOLYGON (((5.639762878417969 51.70404205550062, 5.47222137451172 51.54050328936586, 5.984265804290771 51.445328182347936, 6.050591468811035 51.57152179108081, 5.639762878417969 51.70404205550062)), ((5.268545150756836 51.8780408523543, 5.039935111999512 51.700837165629764, 5.2266597747802725 51.65603805162954, 5.515286922454835 51.827171560252935, 5.268545150756836 51.8780408523543)))"  # noqa: E501
             },
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
         print("Response data:", data)  # Debug print
@@ -345,7 +345,7 @@ class TestFilterFieldTypes:
         response = api_client.get(
             "/v1/parkeervakken/parkeervakken/",
             data={"geometry[intersects]": "52.388231,48897865"},
-            HTTP_ACCEPT_CRS="EPSG:4326",
+            headers={"Accept-Crs": "EPSG:4326"},
         )
         assert response.status_code == 400, "Outside WGS84 range"
 

--- a/src/tests/test_dynamic_api/views/test_wfs.py
+++ b/src/tests/test_dynamic_api/views/test_wfs.py
@@ -289,8 +289,10 @@ class TestDatasetWFSViewAuth:
         # if we have access to the dataset.
         data = self.parse_response(response)
         assert data == {
-            "boundedBy": {"Envelope": [{"lowerCorner": "10 10"}, {"upperCorner": "10 10"}]},
-            "geometry": {"Point": {"pos": "10 10"}},
+            "boundedBy": {
+                "Envelope": [{"lowerCorner": "121389 487369"}, {"upperCorner": "121389 487369"}]
+            },
+            "geometry": {"Point": {"pos": "121389 487369"}},
             "id": "1",
             "metadata": "secret",
         }
@@ -302,9 +304,11 @@ class TestDatasetWFSViewAuth:
         assert response.status_code == 200
         data = self.parse_response(response)
         assert data == {
-            "boundedBy": {"Envelope": [{"lowerCorner": "10 10"}, {"upperCorner": "10 10"}]},
+            "boundedBy": {
+                "Envelope": [{"lowerCorner": "121389 487369"}, {"upperCorner": "121389 487369"}]
+            },
             "id": "1",
-            "geometry_with_auth": {"Point": {"pos": "10 10"}},
+            "geometry_with_auth": {"Point": {"pos": "121389 487369"}},
         }
 
     @pytest.mark.parametrize("scopes", [[], ["TEST/META"]])
@@ -367,8 +371,10 @@ class TestDatasetWFSViewAuth:
         assert response.status_code == 200, response
         data = self.parse_response(response)
         assert data == {
-            "boundedBy": {"Envelope": [{"lowerCorner": "10 10"}, {"upperCorner": "10 10"}]},
-            "geometry_with_auth": {"Point": {"pos": "10 10"}},
+            "boundedBy": {
+                "Envelope": [{"lowerCorner": "121389 487369"}, {"upperCorner": "121389 487369"}]
+            },
+            "geometry_with_auth": {"Point": {"pos": "121389 487369"}},
             "id": "1",
             "metadata": "secret",
         }

--- a/src/tests/test_rest_framework_dso/test_views.py
+++ b/src/tests/test_rest_framework_dso/test_views.py
@@ -14,7 +14,7 @@ from .models import Location, Movie
 from .serializers import LocationSerializer, MovieSerializer
 
 
-class MovieDetailAPIView(generics.RetrieveAPIView):
+class MovieDetailAPIView(views.DSOViewMixin, generics.RetrieveAPIView):
     serializer_class = MovieSerializer
     queryset = Movie.objects.all()
 


### PR DESCRIPTION
Even when asking "Accept-Crs: EPSG:4326", the ordering was previously x/y.
Since django-gisserver 2.0 we follow the axis ordering of the format, making it y/x in the REST API.

In GeoJSON this isn't changed, as the standard mandates that all coordinates are in x/y format.