### PR TITLE
Fix crash during early WSGI warmup when OpenTelemetry is active

### DIFF
--- a/src/dso_api/wsgi.py
+++ b/src/dso_api/wsgi.py
@@ -28,6 +28,9 @@ application(
         "SERVER_PORT": 80,
         "PATH_INFO": "/v1/",
         "wsgi.input": sys.stdin,
+        "wsgi.url_scheme": "https",
+        "wsgi.errors": sys.stderr,
+        "wsgi.version": (1, 0),
     },
     lambda x, y: None,
 )


### PR DESCRIPTION
The OpenTelemetry code reads "wsgi.url_schema".
Added some other typical keys there too for completeness.
