### PR TITLE
Unittests for nested datasets

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -407,6 +407,18 @@ def array_auth(schema_loader):
 
 
 @pytest.fixture()
+def beheerkaar_basis_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("beheerkaart/basis/dataset.json")
+
+
+@pytest.fixture()
+def beheerkaart_basis_dataset(schema_loader, beheerkaar_basis_schema) -> Dataset:
+    # path is needed to create a nested route, use same logic as `import schemas`.
+    path = schema_loader._get_dataset_path(beheerkaar_basis_schema.id)
+    return Dataset.create_for_schema(beheerkaar_basis_schema, path)
+
+
+@pytest.fixture()
 def bommen_schema_json() -> dict:
     """Fixture to return the schema json for"""
     path = HERE / "files/datasets/bommen.json"

--- a/src/tests/files/datasets/beheerkaart/basis/bgt/v1.json
+++ b/src/tests/files/datasets/beheerkaart/basis/bgt/v1.json
@@ -1,0 +1,33 @@
+{
+  "id": "bgt",
+  "type": "table",
+  "provenance": "bkt_bgt",
+  "description": "Hulptabel beheerkaart_basis_bgt bevat de gegevens van alle BGT-objecten van geselecteerde objectklassen en wordt gebruikt om samen met hulptabel beheerkaart_basis_eigendomsrecht de hoofdtabel beheerkaart_basis_kaart te vullen.",
+  "version": "1.0.0",
+  "schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "schema",
+      "id"
+    ],
+    "display": "id",
+    "properties": {
+      "schema": {
+        "$ref": "https://schemas.data.amsterdam.nl/schema@v3.1.0#/definitions/schema"
+      },
+      "id": {
+        "provenance": "bk_bkt_bgt",
+        "description": "Business-key: unieke aanduiding per voorkomen in tabel beheerkaart_basis_bgt (bestaande uit bk_bgt_object).",
+        "type": "string"
+      },
+      "geometrie": {
+        "$ref": "https://geojson.org/schema/MultiPolygon.json",
+        "description": "Vlak-coördinaten van het BGT-object."
+      }
+    },
+    "mainGeometry": "geometrie"
+  },
+  "lifecycleStatus": "stable"
+}

--- a/src/tests/files/datasets/beheerkaart/basis/dataset.json
+++ b/src/tests/files/datasets/beheerkaart/basis/dataset.json
@@ -1,0 +1,28 @@
+{
+  "type": "dataset",
+  "id": "beheerkaartBasis",
+  "title": "beheerkaart basis",
+  "description": "De Beheerkaart Publieke Ruimte is een combinatie van kadastrale en topografische informatie, namelijk van de kadastrale percelen waarop een eigendomsrecht rust van de gemeente Amsterdam (inclusief Weesp), zoals vastgelegd in de Basisregistratie Kadaster (BRK), gekoppeld met de topografische objecten in de opdeling van de publieke ruimte, zoals vastgelegd in de Basisregistratie Grootschalige Topografie (BGT). Hiervoor wordt een criterium van minimaal 20% overlap gehanteerd tussen het kadastraal perceel waarop een eigendomsrecht rust met het topografisch object in de publieke ruimte. Zo’n eigendomsrecht van de gemeente Amsterdam, mits onbelast (zie onderstaande optie 1), geeft de gemeente in principe de verantwoordelijkheid voor het beheer. Echter als dit eigendomsrecht van de gemeente is belast door een erop rustend eigendomsrecht van een andere partij (zie onderstaande optie 2) heeft deze andere partij de beheerverantwoordelijkheid. Tot slot, voor kadastrale en gekoppelde topografische objecten waarop de gemeente in het geheel geen eigendomsrecht heeft, heeft de gemeente ook geen beheerverantwoordelijkheid. Die verantwoordelijkheid ligt dan vaak bij andere overheden zoals provincie, waterschap of andere gemeente, of ProRail. Deze objecten vallen niet onder een van beide onderstaande opties 1 of 2, en worden in de Beheerkaart in het geheel niet getoond.  Let op: een eigendomsrecht in dit verband kan zijn: recht van eigendom, erfpacht, erfpacht-en-opstal of opstal. Op de kaart kunt u voor elk onderdeel in eigendom bij de gemeente Amsterdam zien of de gemeente op grond van eigendomsrechten wel of geen verantwoordelijkheid heeft voor het beheer. (1(voetnoot) Er bestaan mogelijk afspraken waarin het beheer is overgedragen aan een andere partij, zoals bijvoorbeeld een volkstuinvereniging, begraafplaats of sportvereniging.). 1) Selecteer in tabel beheerkaart_basis_kaart de rijen met attribuut agg_indicatie_belast_recht = FALSE (d.w.z. onbelast). Dit toont de publieke ruimte in eigendom bij de gemeente Amsterdam, waarbij op het eigendomsrecht van de gemeente geen andere, belastende eigendomsrechten (opstal en/of erfpacht) van andere partijen rusten en waarvoor de gemeente dus volledig verantwoordelijk is voor het beheer. Daar waar de gemeente niet volledig verantwoordelijk is, wordt het betreffende object niet getoond. 2) Selecteer in tabel beheerkaart_basis_kaart de rijen met attribuut agg_indicatie_belast_recht = TRUE (d.w.z. belast). Dit toont de publieke ruimte in eigendom bij de gemeente Amsterdam waarvoor de gemeente niet of niet volledig verantwoordelijk is voor het beheer, ten gevolge van de belastende eigendomsrechten (opstal en/of erfpacht) van andere partijen (andere overheden, organisaties of particulieren) op het eigendomsrecht van de gemeente.",
+  "crs": "EPSG:28992",
+  "owner": "Gemeente Amsterdam, Directie Data",
+  "publisher": {
+    "$ref": "publishers/NOBODY"
+  },
+  "creator": "Datateam Stedelijke Ontwikkeling en Beheer",
+  "auth": "OPENBAAR",
+  "authorizationGrantor": "datateamstedelijkeonwikkelingenbeheer@amsterdam.nl",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "status": "beschikbaar",
+      "lifecycleStatus": "stable",
+      "version": "1.0.0",
+      "tables": [
+        {
+          "id": "bgt",
+          "$ref": "bgt/v1"
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/test_dynamic_api/views/test_api.py
+++ b/src/tests/test_dynamic_api/views/test_api.py
@@ -64,6 +64,18 @@ def test_nested_routes_work(api_client, beheerkaart_basis_dataset, filled_router
 
 
 @pytest.mark.django_db
+def test_nested_routes_versioned_datasets_works(
+    api_client, beheerkaart_basis_dataset, filled_router
+):
+    url = reverse("dynamic_api:beheerkaart_basis-v1-bgt-list")
+    response = api_client.get(url)
+    assert response.status_code == 200, response.data
+
+    # url shows nested path with version
+    assert url == "/v1/beheerkaart/basis/v1/bgt"
+
+
+@pytest.mark.django_db
 def test_list_dynamic_view_unregister(api_client, bommen_dataset, filled_router):
     """Prove that unregistering works."""
     url = reverse("dynamic_api:bommen-bommen-list")

--- a/src/tests/test_dynamic_api/views/test_api.py
+++ b/src/tests/test_dynamic_api/views/test_api.py
@@ -53,6 +53,17 @@ def test_filled_router(api_client, bommen_dataset, filled_router):
 
 
 @pytest.mark.django_db
+def test_nested_routes_work(api_client, beheerkaart_basis_dataset, filled_router):
+    """Prove that nested routes work."""
+    url = reverse("dynamic_api:beheerkaart_basis-bgt-list")
+    response = api_client.get(url)
+    assert response.status_code == 200, response.data
+
+    # url shows nested path
+    assert url == "/v1/beheerkaart/basis/bgt"
+
+
+@pytest.mark.django_db
 def test_list_dynamic_view_unregister(api_client, bommen_dataset, filled_router):
     """Prove that unregistering works."""
     url = reverse("dynamic_api:bommen-bommen-list")


### PR DESCRIPTION
This broke in prod after versioned datasets were released. Schematools 8.1.1 contains the fix on the schema-tools side and was already applied to dso-api. This is just a couple tests to ensure it won't break.  