### PR TITLE
Set db role settings to filtered variants

### DIFF
--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -225,8 +225,8 @@ DATABASES["default"]["OPTIONS"]["application_name"] = "DSO-API"
 
 # These constants that are used for end-user context switching
 # are configured in our dp-infra repo
-USER_ROLE = "{user_email}_role"
-INTERNAL_ROLE = "medewerker_role"
+USER_ROLE = "{user_email}_role.filtered"
+INTERNAL_ROLE = "medewerker_role.filtered"
 ANONYMOUS_ROLE = "anonymous_role"
 ANONYMOUS_APP_NAME = "DSO-openbaar"
 

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -9,7 +9,7 @@ django-vectortiles == 1.0.1
 djangorestframework == 3.16.0
 djangorestframework-csv == 3.0.2
 djangorestframework-gis == 1.2.0
-amsterdam-schema-tools[django] == 8.1.2
+amsterdam-schema-tools[django] == 8.2.1
 azure-identity == 1.23.0
 azure-monitor-opentelemetry == 1.6.10
 cachetools == 6.1.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.txt requirements.in
 #
-amsterdam-schema-tools[django]==8.1.2 \
-    --hash=sha256:6bef79697a3d98d9b19c177f39fd0a228e550c8d4a263d5cb5bacad98d888086 \
-    --hash=sha256:ae135f24f6d46b6345fc966e3b297381aa9ee1918167ea92bc2b94c13ddbf410
+amsterdam-schema-tools[django]==8.2.1 \
+    --hash=sha256:1b655e5ecca5d07f8b27ab63af502ab4cada2583f765c17a032f958c100ec1ca \
+    --hash=sha256:a4fda7c0847672b299ba40fdb51f2ef598d7686926f07823d24ad637b2d1fd64
     # via -r requirements.in
 argparse==1.4.0 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4 \

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements_dev.txt requirements_dev.in
 #
-amsterdam-schema-tools[django]==8.1.2
+amsterdam-schema-tools[django]==8.2.1
     # via -r ./requirements.in
 argparse==1.4.0
     # via uwsgi-readiness-check

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -237,6 +237,7 @@ def activate_dbroles(settings, movies_dataset, movies_data, directors_data):
         movies_director SELECT -> scope_test_director
     """
     test_user_role = Identifier(f"{settings.TEST_USER_EMAIL}_role")
+    test_user_role_filtered = Identifier(f"{settings.TEST_USER_EMAIL}_role.filtered")
 
     with connection.cursor() as curs:
         curs.execute(
@@ -245,14 +246,16 @@ def activate_dbroles(settings, movies_dataset, movies_data, directors_data):
                     CREATE ROLE {0};
                     CREATE ROLE {1};
                     CREATE ROLE {2};
-                    CREATE ROLE {3} NOINHERIT;
-                    GRANT {0},{1},{2} TO {3};
-                    GRANT {3} TO {4};
+                    CREATE ROLE {3};
+                    CREATE ROLE {4} NOINHERIT;
+                    GRANT {0},{1},{2},{3} TO {4};
+                    GRANT {4} TO {5};
                 """
             ).format(
                 Identifier(settings.INTERNAL_ROLE),
                 Identifier(settings.ANONYMOUS_ROLE),
                 test_user_role,
+                test_user_role_filtered,
                 Identifier(settings.TEST_NOINHERIT_ROLE),
                 Identifier(settings.DB_USER),
             )
@@ -269,13 +272,14 @@ def activate_dbroles(settings, movies_dataset, movies_data, directors_data):
                 """
                 CREATE ROLE scope_test_openbaar;
                 CREATE ROLE scope_test_director;
-                GRANT scope_test_openbaar to {0},{1},{2};
-                GRANT scope_test_director to {2};
+                GRANT scope_test_openbaar to {0},{1},{2},{3};
+                GRANT scope_test_director to {2},{3};
             """
             ).format(
                 Identifier(settings.ANONYMOUS_ROLE),
                 Identifier(settings.INTERNAL_ROLE),
                 test_user_role,
+                test_user_role_filtered,
             )
         )
 
@@ -308,7 +312,7 @@ def activate_dbroles(settings, movies_dataset, movies_data, directors_data):
             SQL(
                 """
                 DROP OWNED BY scope_test_openbaar,scope_test_director;
-                DROP ROLE IF EXISTS {0},{1},{2},{3};
+                DROP ROLE IF EXISTS {0},{1},{2},{3},{4};
                 DROP ROLE IF EXISTS scope_test_openbaar,scope_test_director;
             """
             ).format(
@@ -316,6 +320,7 @@ def activate_dbroles(settings, movies_dataset, movies_data, directors_data):
                 Identifier(settings.ANONYMOUS_ROLE),
                 Identifier(settings.TEST_NOINHERIT_ROLE),
                 test_user_role,
+                test_user_role_filtered,
             )
         )
 

--- a/src/tests/test_user_context.py
+++ b/src/tests/test_user_context.py
@@ -123,7 +123,7 @@ def test_user_when_token(
     # can make assertions about the session state here
     with connection.cursor() as c:
         c.execute("SELECT current_user;")
-        assert c.fetchone()[0] == f"{settings.TEST_USER_EMAIL}_role"
+        assert c.fetchone()[0] == f"{settings.TEST_USER_EMAIL}_role.filtered"
 
     # The test user can see directors and movie data
     assert json.loads("".join([x.decode() for x in response.streaming_content])) == director_data
@@ -153,7 +153,7 @@ def test_user_switches_on_consecutive_requests(
     # can make assertions about the session state here
     with connection.cursor() as c:
         c.execute("SELECT current_user;")
-        assert c.fetchone()[0] == f"{settings.TEST_USER_EMAIL}_role"
+        assert c.fetchone()[0] == f"{settings.TEST_USER_EMAIL}_role.filtered"
 
     # The test user can see directors and movie data
     assert json.loads("".join([x.decode() for x in response.streaming_content])) == director_data


### PR DESCRIPTION
So extra permissions for mandatoryFilterSets can be applied

> Don't forget about...
> * Tests
> * Documentation in `dev-docs/`
> * Readable commit messages explaining the reason for changes
>
> Replace this text with a summary of the PR.
> Use `AB#xyz` to reference issue *xyz* on Azure DevOps.
