### PR TITLE
fix bulk data links

### DIFF
--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -180,6 +180,7 @@ class DatasetDocView(TemplateView):
                 "dataset_has_auth": bool(_fix_auth(ds_schema.auth)),
                 "main_title": main_title,
                 "tables": tables,
+                "oauth_url": settings.OAUTH_URL,
                 "swagger_url": reverse(
                     f"dynamic_api:openapi{pattern_suffix}",
                     kwargs={"dataset_name": ds_schema.id, "dataset_version": dataset_version},
@@ -312,16 +313,19 @@ def _table_context(ds: Dataset, table: DatasetTableSchema, dataset_version: str)
                     f"{settings.CONFIDENTIAL_EXPORT_BASE_URI}/{type_}/"
                     f"{dataset_name}_{table_name}.{extension}.zip"
                 )
+                kind = "confidential"
             else:
                 url = (
                     f"{settings.EXPORT_BASE_URI}/{type_}/"
                     f"{dataset_name}_{table_name}.{extension}.zip"
                 )
+                kind = "public"
             ext_info = {
                 "extension": extension,
                 "type": type_,
                 "description": description,
                 "url": url,
+                "kind": kind,
             }
             export_info.append(ext_info)
         exports.append(export_info)

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -569,6 +569,9 @@ SEAL_WARN_ONLY = True
 
 # Configuration for canned exports
 EXPORT_BASE_URI = env.str("BULK_ENDPOINT", "https://api.data.amsterdam.nl/bulk-data")
+CONFIDENTIAL_EXPORT_BASE_URI = env.str(
+    "CONFIDENTIAL_BULK_ENDPOINT", "https://api.data.amsterdam.nl/bulk-data-fp-mdw"
+)
 
 # Setting for django-gisserver, disabling this makes WFS much faster
 GISSERVER_CAPABILITIES_BOUNDING_BOX = False

--- a/src/dso_api/static/dso_api/dynamic_api/js/docs.js
+++ b/src/dso_api/static/dso_api/dynamic_api/js/docs.js
@@ -1,0 +1,75 @@
+if (document.addEventListener) {
+    document.addEventListener("DOMContentLoaded", onPageLoad)
+}
+
+// Override the same object from browsable_api.js, as this one we don't want to alter the DOM
+const swaggerUIRedirectOauth2 = {
+    state: null,
+    redirectUrl: REDIRECTURI,
+    auth: {
+        schema: {
+            get: (t) => {
+                return "implicit"
+            },
+        },
+        code: null,
+    },
+    errCb: (err) => console.log("err callback", err),
+    callback: (authorizationResult) => {
+        const token = authorizationResult.token
+        window.localStorage.setItem("authToken", JSON.stringify(token))
+    },
+}
+
+function onPageLoad() {
+    confidential_links = Array.from(
+        document.getElementsByClassName("confidential")
+    )
+    confidential_links.map((link) => {
+        link.addEventListener("click", (e) => {
+            e.preventDefault()
+            const url = link.href
+            const token = JSON.parse(window.localStorage.getItem("authToken"))
+            if (token) {
+                getData(url, {
+                    Authorization: `Bearer ${token.access_token}`,
+                })
+            } else {
+                authorize()
+            }
+        })
+    })
+}
+
+function authorize() {
+    // Start authorization flow
+    authUrl = new URL(OAUTHURI)
+    authUrl.searchParams.set("client_id", CLIENTID)
+    authUrl.searchParams.set("redirect_uri", REDIRECTURI)
+    authUrl.searchParams.set("response_type", "token")
+    window.open(authUrl, "_blank")
+}
+
+async function getData(url, headers) {
+    await fetch(url, { method: "GET", headers })
+        .then((response) => {
+            if (!response.ok) {
+                throw new Error(response.statusText)
+            }
+            return response.blob()
+        })
+        .then((response) => {
+            const fileName = url.replace(/^.*[\\/]/, "")
+            const url = window.URL.createObjectURL(response)
+            const a = document.createElement("a")
+            a.style.display = "none"
+            a.href = url
+            a.download = fileName
+            document.body.appendChild(a)
+            a.click()
+            window.URL.revokeObjectURL(url)
+        })
+        .catch((error) => {
+            console.error("Error downloading file:", error)
+        })
+}

--- a/src/templates/dso_api/dynamic_api/docs/base.html
+++ b/src/templates/dso_api/dynamic_api/docs/base.html
@@ -32,4 +32,10 @@
     </div>
 </div>
 </body>
+<script>
+    const CLIENTID = "dso-api-open-api";
+    const REDIRECTURI = window.location.origin + "/v1/oauth2-redirect.html";
+    const OAUTHURI = "{{ oauth_url }}"
+</script>
+<script src="{% static 'dso_api/dynamic_api/js/docs.js' %}"></script>
 </html>

--- a/src/templates/dso_api/dynamic_api/docs/dataset.html
+++ b/src/templates/dso_api/dynamic_api/docs/dataset.html
@@ -34,7 +34,7 @@
       {% for export_info in table_data.exports %}
         {% for ext_info in export_info %}
             <dt class="col-xs-2">Downloadable {{ ext_info.description }}-export:</dt>
-            <dd><a href="{{ ext_info.url }}">{{ ext_info.url }}</a></dd>
+            <dd><a href="{{ ext_info.url }}" class="{{ ext_info.kind }}">{{ ext_info.url }}</a></dd>
         {% endfor %}
       {% endfor %}
     </dl>

--- a/src/tests/test_dynamic_api/test_doc.py
+++ b/src/tests/test_dynamic_api/test_doc.py
@@ -70,9 +70,88 @@ def test_table_for_export_links(api_client, filled_router, gebieden_dataset):
     content = response.rendered_content
     # Extensions for exported format followed by ".zip"
     # are signalling links to the generated exports.
-    assert "gebieden_bouwblokken.gpkg.zip" in content
-    assert "gebieden_bouwblokken.jsonl.zip" in content
-    assert "gebieden_bouwblokken.csv.zip" in content
+    assert "bulk-data/geopackage/gebieden_bouwblokken.gpkg.zip" in content
+    assert "bulk-data/jsonlines/gebieden_bouwblokken.jsonl.zip" in content
+    assert "bulk-data/csv/gebieden_bouwblokken.csv.zip" in content
+
+    assert "gebieden_buurten.csv.zip" not in content
+    assert "gebieden_buurten.jsonl.zip" not in content
+    assert "gebieden_buurten.gpkg.zip" not in content
+
+
+@pytest.mark.django_db
+def test_table_for_confidential_dataset_export_links(api_client, filled_router, gebieden_dataset):
+    """Tests documentation for a single dataset."""
+    table = gebieden_dataset.tables.get(name="bouwblokken")
+    table.enable_export = True
+    table.save()
+    gebieden_dataset.auth = "FP/MDW"
+    gebieden_dataset.save()
+
+    # Gebieden has relationships between its tables.
+    gebieden_doc = reverse("dynamic_api:docs-dataset", kwargs={"dataset_name": "gebieden"})
+    assert gebieden_doc
+
+    response = api_client.get(gebieden_doc)
+    assert response.status_code == 200
+    content = response.rendered_content
+    # Extensions for exported format followed by ".zip"
+    # are signalling links to the generated exports.
+    assert "bulk-data-fp-mdw/geopackage/gebieden_bouwblokken.gpkg.zip" in content
+    assert "bulk-data-fp-mdw/jsonlines/gebieden_bouwblokken.jsonl.zip" in content
+    assert "bulk-data-fp-mdw/csv/gebieden_bouwblokken.csv.zip" in content
+
+    assert "gebieden_buurten.csv.zip" not in content
+    assert "gebieden_buurten.jsonl.zip" not in content
+    assert "gebieden_buurten.gpkg.zip" not in content
+
+
+@pytest.mark.django_db
+def test_table_for_confidential_table_export_links(api_client, filled_router, gebieden_dataset):
+    """Tests documentation for a single dataset."""
+    table = gebieden_dataset.tables.get(name="bouwblokken")
+    table.auth = "FP/MDW"
+    table.enable_export = True
+    table.save()
+    # Gebieden has relationships between its tables.
+    gebieden_doc = reverse("dynamic_api:docs-dataset", kwargs={"dataset_name": "gebieden"})
+    assert gebieden_doc
+
+    response = api_client.get(gebieden_doc)
+    assert response.status_code == 200
+    content = response.rendered_content
+    # Extensions for exported format followed by ".zip"
+    # are signalling links to the generated exports.
+    assert "bulk-data-fp-mdw/geopackage/gebieden_bouwblokken.gpkg.zip" in content
+    assert "bulk-data-fp-mdw/jsonlines/gebieden_bouwblokken.jsonl.zip" in content
+    assert "bulk-data-fp-mdw/csv/gebieden_bouwblokken.csv.zip" in content
+
+    assert "gebieden_buurten.csv.zip" not in content
+    assert "gebieden_buurten.jsonl.zip" not in content
+    assert "gebieden_buurten.gpkg.zip" not in content
+
+
+@pytest.mark.django_db
+def test_table_for_confidential_field_export_links(api_client, filled_router, gebieden_dataset):
+    """Tests documentation for a single dataset."""
+    table = gebieden_dataset.tables.get(name="bouwblokken")
+    table.enable_export = True
+    table.save()
+    field = table.fields.first()
+    field.auth = "FP/MDW"
+    field.save()
+    # Gebieden has relationships between its tables.
+    gebieden_doc = reverse("dynamic_api:docs-dataset", kwargs={"dataset_name": "gebieden"})
+    assert gebieden_doc
+
+    response = api_client.get(gebieden_doc)
+    assert response.status_code == 200
+    content = response.rendered_content
+    # Extensions for exported format followed by ".zip"
+    # are signalling links to the generated exports.
+    assert "bulk-data-fp-mdw/geopackage/gebieden_bouwblokken.gpkg.zip" in content
+    assert "bulk-data-fp-mdw/jsonlines/gebieden_bouwblokken.jsonl.zip" in content
+    assert "bulk-data-fp-mdw/csv/gebieden_bouwblokken.csv.zip" in content
 
     assert "gebieden_buurten.csv.zip" not in content
     assert "gebieden_buurten.jsonl.zip" not in content


### PR DESCRIPTION
- vertrouwelijke datasets (i.e. sets met auth != OPENBAAR op welk niveau dan ook) hebben nu een aparte url die naar de vertrouwelijke data proxy gaat => dit stuk is getest
- heb wat JS toegevoegd op de doc pagina om automatisch aan te melden wanneer dit nog niet het geval is => kon hiervoor alleen handmatig testen of de browser requests kloppen en niet het hele rondje ivm oauth redirect die niet goed gaat lokaal 