### PR TITLE
Accept Entra auth tokens for system accounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,18 @@ services:
     user: postgres
     shm_size: 128mb
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "$${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      test: [ "CMD-SHELL", "pg_isready", "-U", "$${POSTGRES_DB} -U $${POSTGRES_USER}" ]
       interval: 10s
       timeout: 60s
       retries: 5
       start_period: 20s
     ports:
-       - "5415:5432"
+      - "5415:5432"
     environment:
       POSTGRES_DB: dataservices
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: insecure
-    command: ["postgres", "-c", "log_statement=all"]
+    command: [ "postgres", "-c", "log_statement=all" ]
 
   web:
     build:
@@ -51,8 +51,8 @@ services:
       OAUTH_JWKS_URLS: "${OAUTH_JWKS_URLS}"
       OAUTH_CHECK_CLAIMS: "${OAUTH_CHECK_CLAIMS}"
       PUB_JWKS: "${PUB_JWKS}"
-      OAUTH_URL:  "${OAUTH_URL}"
-      OAUTH_AUTHORITY_ENTRA:  "${OAUTH_AUTHORITY_ENTRA}"
+      OAUTH_URL: "${OAUTH_URL}"
+      OAUTH_AUTHORITY_ENTRA: "${OAUTH_AUTHORITY_ENTRA}"
       CLOUD_ENV: "${CLOUD_ENV}"
       DATAPUNT_API_URL: "${DATAPUNT_API_URL}"
       DJANGO_DEBUG: 1
@@ -72,5 +72,4 @@ services:
       - "../schema-tools:/tmp/schema-tools"
       - "../authorization_django:/tmp/authorization_django"
     command: >
-      /bin/bash -c "sh /app/initialize_db.sh
-      && uwsgi --py-auto-reload=1 --enable-threads --lazy-apps --buffer-size=65535"
+      /bin/bash -c "sh /app/initialize_db.sh && uwsgi --py-auto-reload=1 --enable-threads --lazy-apps --buffer-size=65535"

--- a/src/dso_api/dbroles.py
+++ b/src/dso_api/dbroles.py
@@ -71,6 +71,7 @@ class DatabaseRoles:
         if user_email is None:
             user_email = cls.ANONYMOUS
         cls.current_user.email = user_email
+        cls.current_user.issuer = token_issuer
 
         # Immediately activate the user too, in case a connection was already established.
         # Otherwise, the request waits for the 'connection_created' signal.
@@ -88,6 +89,11 @@ class DatabaseRoles:
     def _get_end_user(cls) -> str | None:
         """Tell which user was selected"""
         return getattr(cls.current_user, "email", None)
+
+    @classmethod
+    def _get_issuer(cls) -> str | None:
+        """Tell which issuer gave out the token (Keycloak or Entra)"""
+        return getattr(cls.current_user, "issuer", None)
 
     @classmethod
     def _role_from_user(cls, user: str | None) -> str:
@@ -132,10 +138,15 @@ class DatabaseRoles:
             cls._set_role(user_connection, settings.ANONYMOUS_ROLE, settings.ANONYMOUS_APP_NAME)
             return
 
-        # If the token was issued by keycloak
+        # If the token was issued by keycloak or entra
         # don't set role, because database role might not exist
         # Fallback to internal role but do write user email to database logs
-        if token_issuer and urlparse(token_issuer).netloc == "iam.amsterdam.nl":
+        # As of 10-4-2026, most authenticated requests are issued by Keycloak or Entra
+        token_issuer = cls._get_issuer()
+        if token_issuer and urlparse(token_issuer).netloc in {
+            "iam.amsterdam.nl",  # Keycloak
+            "sts.windows.net",  # Entra ID
+        }:
             cls._set_role(user_connection, settings.INTERNAL_ROLE, user_email)
             return
 

--- a/src/dso_api/middleware.py
+++ b/src/dso_api/middleware.py
@@ -37,9 +37,12 @@ class AuthMiddleware:
         # The token subject contains the username/email address of the user (on Azure)
         email = request.get_token_subject
         issuer = None
-        if getattr(request, "get_token_claims", None) and "email" in request.get_token_claims:
-            email = request.get_token_claims["email"]
-            issuer = request.get_token_claims["iss"]
+        if getattr(request, "get_token_claims", None):
+            if "email" in request.get_token_claims:
+                email = request.get_token_claims["email"]
+            # Entra ID tokens for system accounts don't have an email claim
+            if "iss" in request.get_token_claims:
+                issuer = request.get_token_claims["iss"]
         DatabaseRoles.set_end_user(email, issuer)
 
         return self._get_response(request)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -818,9 +818,12 @@ def vestiging_models(vestiging_dataset, dynamic_models):
 def fetch_tokendata(settings):
     """Fixture to create valid token data, scopes is flexible"""
 
-    def _fetcher(scopes, subject):
+    def _fetcher(scopes, subject, iss):
         now = int(time.time())
-        return {"iat": now, "exp": now + 30, "scopes": scopes, "sub": subject}
+        token_data = {"iat": now, "exp": now + 30, "scopes": scopes, "sub": subject}
+        if iss:
+            token_data["iss"] = iss
+        return token_data
 
     return _fetcher
 
@@ -829,11 +832,13 @@ def fetch_tokendata(settings):
 def fetch_auth_token(fetch_tokendata, settings):
     """Fixture to create an auth token, scopes is flexible"""
 
-    def _fetcher(scopes, subject=settings.TEST_USER_EMAIL):
+    def _fetcher(scopes, subject=settings.TEST_USER_EMAIL, iss=None):
         kid = "2aedafba-8170-4064-b704-ce92b7c89cc6"
         jwks = JWKSWrapper()
         key = jwks.keyset.get_key(kid)
-        token = JWT(header={"alg": "ES256", "kid": kid}, claims=fetch_tokendata(scopes, subject))
+        token = JWT(
+            header={"alg": "ES256", "kid": kid}, claims=fetch_tokendata(scopes, subject, iss)
+        )
         token.make_signed_token(key)
         return token.serialize()
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -271,7 +271,7 @@ def activate_dbroles(settings, movies_dataset, movies_data, directors_data):
                 CREATE ROLE scope_test_openbaar;
                 CREATE ROLE scope_test_director;
                 GRANT scope_test_openbaar to {0},{1},{2},{3};
-                GRANT scope_test_director to {2},{3};
+                GRANT scope_test_director to {1},{2},{3};
             """
             ).format(
                 Identifier(settings.ANONYMOUS_ROLE),

--- a/src/tests/test_user_context.py
+++ b/src/tests/test_user_context.py
@@ -184,6 +184,38 @@ def test_user_switches_on_consecutive_requests(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("issuer", ["https://iam.amsterdam.nl", "https://sts.windows.net"])
+def test_user_with_entra_keycloak_token(
+    filled_router, api_client, activate_dbroles, fetch_auth_token, settings, issuer
+):
+    """
+    When token issuer is Entra or Keycloak,
+    the INTERNAL_ROLE (medewerker_role.filtered)
+    is used for db access
+    """
+    url = reverse("dynamic_api:movies-director-list")
+    token = fetch_auth_token(["TEST_OPENBAAR", "TEST_DIRECTOR"], iss=issuer)
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+    assert response.status_code == 200
+    assert DatabaseRoles._get_end_user() == settings.TEST_USER_EMAIL
+
+    # The user context is terminated when content is streamed so we
+    # can make assertions about the session state here
+    with connection.cursor() as c:
+        c.execute("SELECT current_user;")
+        assert c.fetchone()[0] == settings.INTERNAL_ROLE
+
+    # The test user can see directors and movie data
+    assert json.loads("".join([x.decode() for x in response.streaming_content])) == director_data
+    # Ensure the connection session context is cleaned up
+    assert DatabaseRoles._get_role(connection) is None
+
+    with connection.cursor() as c:
+        c.execute("SELECT current_user;")
+        assert c.fetchone()[0] == settings.DB_USER
+
+
+@pytest.mark.django_db
 def test_internal_user_when_subject_without_role(
     filled_router,
     api_client,


### PR DESCRIPTION
Auth token claims are slightly different for Entra ID tokens.
This PR makes it possible to authorize a system account with an Entra auth token.

Granted TEST_DIRECTOR scope to INTERNAL_ROLE to match what happens in production. There, the INTERNAL_ROLE is linked to all available scopes.

In deze [handleiding in ADO](https://dev.azure.com/CloudCompetenceCenter/Data%20Diensten/_wiki/wikis/Datadiensten/108836/Service-accounts-toegang-geven-tot-DSO-API-(Entra-ID)) staat hoe system accounts de juiste scopes toegekend krijgen. Die graag ook even reviewen :-)