### PR TITLE
Add correct Entra ID token claims to DSO logs

### DIFF
--- a/src/dso_api/dbroles.py
+++ b/src/dso_api/dbroles.py
@@ -28,9 +28,9 @@ from django.core.signals import got_request_exception, request_finished
 from django.db import connection as default_connection
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.signals import connection_created
-from django.db.utils import DatabaseError
+from django.db.utils import DatabaseError, DataError
 from django.dispatch import receiver
-from psycopg.errors import DataError
+from psycopg.errors import DataError as psycopgDataError
 from psycopg.pq import TransactionStatus
 
 logger = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ class DatabaseRoles:
         try:
             # BBN2: Exact account for specific access.
             cls._set_role(user_connection, role_name, user_email)
-        except DataError as e:
+        except (DataError, psycopgDataError) as e:
             # The role didn't exist.
             if is_internal(user_email):
                 # BBN1: Internal employee, no specific account

--- a/src/dso_api/dbroles.py
+++ b/src/dso_api/dbroles.py
@@ -25,12 +25,12 @@ from urllib.parse import urlparse
 from asgiref.local import Local
 from django.conf import settings
 from django.core.signals import got_request_exception, request_finished
-from django.db import DataError
 from django.db import connection as default_connection
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.signals import connection_created
 from django.db.utils import DatabaseError
 from django.dispatch import receiver
+from psycopg.errors import DataError
 from psycopg.pq import TransactionStatus
 
 logger = logging.getLogger(__name__)

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -16,16 +16,18 @@ audit_log = logging.getLogger("dso_api.audit")
 def log_access(request, access: bool):
     if access:
         audit_log.info(
-            "%s %s: access granted with %s",
+            "%s %s: access granted to %s with %s",
             request.method,
             request.path,
+            request.account_id,
             request.user_scopes,
         )
     else:
         audit_log.info(
-            "%s %s: access denied with %s",
+            "%s %s: access denied to %s with %s",
             request.method,
             request.path,
+            request.account_id,
             request.user_scopes,
         )
 

--- a/src/dso_api/dynamic_api/permissions.py
+++ b/src/dso_api/dynamic_api/permissions.py
@@ -19,7 +19,7 @@ def log_access(request, access: bool):
             "%s %s: access granted to %s with %s",
             request.method,
             request.path,
-            request.account_id,
+            request.account_id if request.account_id else "anonymous",
             request.user_scopes,
         )
     else:
@@ -27,7 +27,7 @@ def log_access(request, access: bool):
             "%s %s: access denied to %s with %s",
             request.method,
             request.path,
-            request.account_id,
+            request.account_id if request.account_id else "anonymous",
             request.user_scopes,
         )
 

--- a/src/dso_api/middleware.py
+++ b/src/dso_api/middleware.py
@@ -34,24 +34,14 @@ class AuthMiddleware:
             scopes.update(self.feature_scopes)
             request.user_scopes = UserScopes(request.GET, scopes, self._all_profiles)
 
-        # Extract user/system account id to be used for logging
-        account = None
-        if "email" in request.get_token_claims:  # User email in Keycloak tokens
-            account = request.get_token_claims["email"]
-        elif "upn" in request.get_token_claims:  # User email in Entra ID tokens
-            account = request.get_token_claims["upn"]
-        elif "appid" in request.get_token_claims:  # Appid for Entra ID system accounts
-            account = request.get_token_claims["appid"]
-        # If none of the above, fall back to token subject
-        else:
-            account = request.get_token_subject
-        if account:
-            request.account_id = account
+        # Extract user account id (email address or app id)
+        account_id = getattr(request, "account_id", None)
+        print(account_id)
 
         # Set database role with account id and issuer
         issuer = None
         if getattr(request, "get_token_claims", None) and "iss" in request.get_token_claims:
             issuer = request.get_token_claims["iss"]
-        DatabaseRoles.set_end_user(account, issuer)
+        DatabaseRoles.set_end_user(account_id, issuer)
 
         return self._get_response(request)

--- a/src/dso_api/middleware.py
+++ b/src/dso_api/middleware.py
@@ -34,15 +34,24 @@ class AuthMiddleware:
             scopes.update(self.feature_scopes)
             request.user_scopes = UserScopes(request.GET, scopes, self._all_profiles)
 
-        # The token subject contains the username/email address of the user (on Azure)
-        email = request.get_token_subject
+        # Extract user/system account id to be used for logging
+        account = None
+        if "email" in request.get_token_claims:  # User email in Keycloak tokens
+            account = request.get_token_claims["email"]
+        elif "upn" in request.get_token_claims:  # User email in Entra ID tokens
+            account = request.get_token_claims["upn"]
+        elif "appid" in request.get_token_claims:  # Appid for Entra ID system accounts
+            account = request.get_token_claims["appid"]
+        # If none of the above, fall back to token subject
+        else:
+            account = request.get_token_subject
+        if account:
+            request.account_id = account
+
+        # Set database role with account id and issuer
         issuer = None
-        if getattr(request, "get_token_claims", None):
-            if "email" in request.get_token_claims:
-                email = request.get_token_claims["email"]
-            # Entra ID tokens for system accounts don't have an email claim
-            if "iss" in request.get_token_claims:
-                issuer = request.get_token_claims["iss"]
-        DatabaseRoles.set_end_user(email, issuer)
+        if getattr(request, "get_token_claims", None) and "iss" in request.get_token_claims:
+            issuer = request.get_token_claims["iss"]
+        DatabaseRoles.set_end_user(account, issuer)
 
         return self._get_response(request)

--- a/src/dso_api/middleware.py
+++ b/src/dso_api/middleware.py
@@ -36,7 +36,6 @@ class AuthMiddleware:
 
         # Extract user account id (email address or app id)
         account_id = getattr(request, "account_id", None)
-        print(account_id)
 
         # Set database role with account id and issuer
         issuer = None

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -362,8 +362,8 @@ if CLOUD_ENV.startswith("azure"):
         def response_hook(span, request, response):
             if span.is_recording():
                 # Add user email / system app id to the trace for authenticated accounts
-                if hasattr(request, "account"):
-                    span.set_attribute("account", request.account)
+                if hasattr(request, "account_id"):
+                    span.set_attribute("account_id", request.account_id)
 
                 # Add API key subject to the trace.
                 # This attribute is added by ApiKeyMiddleware if a key is provided in the request.

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -362,10 +362,21 @@ if CLOUD_ENV.startswith("azure"):
         def response_hook(span, request, response):
             if span.is_recording():
                 # Add user email to the trace for authenticated users.
-                if hasattr(request, "get_token_claims") and (
-                    email := request.get_token_claims.get("email", request.get_token_subject)
-                ):
-                    span.set_attribute("user.AuthenticatedId", email)
+                if hasattr(request, "get_token_claims"):
+
+                    account = None
+                    if "email" in request.get_token_claims:  # User email in Keycloak tokens
+                        account = request.get_token_claims["email"]
+                    elif "upn" in request.get_token_claims:  # User email in Entra ID tokens
+                        account = request.get_token_claims["upn"]
+                    elif "appid" in request.get_token_claims:  # Appid for Entra ID system accounts
+                        account = request.get_token_claims["appid"]
+
+                    # If none of the above, fall back to token subject
+                    else:
+                        account = request.get_token_subject
+                    if account:
+                        span.set_attribute("account", account)
 
                 # Add API key subject to the trace.
                 # This attribute is added by ApiKeyMiddleware if a key is provided in the request.

--- a/src/dso_api/settings.py
+++ b/src/dso_api/settings.py
@@ -361,22 +361,9 @@ if CLOUD_ENV.startswith("azure"):
 
         def response_hook(span, request, response):
             if span.is_recording():
-                # Add user email to the trace for authenticated users.
-                if hasattr(request, "get_token_claims"):
-
-                    account = None
-                    if "email" in request.get_token_claims:  # User email in Keycloak tokens
-                        account = request.get_token_claims["email"]
-                    elif "upn" in request.get_token_claims:  # User email in Entra ID tokens
-                        account = request.get_token_claims["upn"]
-                    elif "appid" in request.get_token_claims:  # Appid for Entra ID system accounts
-                        account = request.get_token_claims["appid"]
-
-                    # If none of the above, fall back to token subject
-                    else:
-                        account = request.get_token_subject
-                    if account:
-                        span.set_attribute("account", account)
+                # Add user email / system app id to the trace for authenticated accounts
+                if hasattr(request, "account"):
+                    span.set_attribute("account", request.account)
 
                 # Add API key subject to the trace.
                 # This attribute is added by ApiKeyMiddleware if a key is provided in the request.

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,7 +13,7 @@ azure-monitor-opentelemetry == 1.6.12
 beautifulsoup4==4.14.3
 cachetools == 7.0.5
 datadiensten-apikeyclient == 0.7.5
-datapunt-authorization-django==2.0.4
+datapunt-authorization-django==2.1.0
 drf-spectacular == 0.29.0
 Geoalchemy2 == 0.19.0
 jsonschema == 4.26.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -438,9 +438,9 @@ datadiensten-apikeyclient==0.7.5 \
     --hash=sha256:af794d2b36baca2981461ed60942780107ce91f8b800f6e9698f0e8139efceb6 \
     --hash=sha256:f33f3b5fa1a8f3c238e23d6a009dd68eb67231d410ff1bd9fa925203df6ce07c
     # via -r requirements.in
-datapunt-authorization-django==2.0.4 \
-    --hash=sha256:1d93d042e85febd2d9aa8b042dd3cd29b5633fd1726676b75b40375c9506b780 \
-    --hash=sha256:88b700739397747a6e2f89a8cb3daba0b67aaf3929d02168c8a330869af7a503
+datapunt-authorization-django==2.1.0 \
+    --hash=sha256:dcf5013b2e64d3abbb75fc510eac611b7715fc0648b85792f7066e9a10635ce2 \
+    --hash=sha256:fc6907bf48c38ea09dc20b88233b5ba9d8b1a7e48021d679c07d38fde55769de
     # via -r requirements.in
 decorator==5.2.1 \
     --hash=sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360 \

--- a/src/requirements_dev.txt
+++ b/src/requirements_dev.txt
@@ -83,7 +83,7 @@ cryptography==46.0.7
     #   pyjwt
 datadiensten-apikeyclient==0.7.5
     # via -r requirements.in
-datapunt-authorization-django==2.0.4
+datapunt-authorization-django==2.1.0
     # via -r requirements.in
 debugpy==1.8.20
     # via -r requirements_dev.in


### PR DESCRIPTION
- authorization_django geeft nu het e-mail adres of app id mee in een request property account_id. Die property wordt nu gebruikt als id van de database user, en voor de (audit) logging.
- Als er geen dbrole bestaat, geeft de DSO een DataError terug. In de tests komt deze DataError vanuit Django, op het cluster komt deze vanuit psycopg. Beide errors moeten goed opgevangen worden
- Logs en audit logs komen goed binnen op test, acc en dev (getest)

