### PR TITLE
Rephrase autorisation contact text for clarity

### DIFF
--- a/src/templates/dso_api/dynamic_api/_dataset_metadata.html
+++ b/src/templates/dso_api/dynamic_api/_dataset_metadata.html
@@ -21,5 +21,5 @@
   </dl>
 
   {% if dataset_has_auth %}
-    <p>Toegang kan worden aangevraagd bij: {{ schema.authorizationGrantor|urlize|default:'-' }}</p>
+    <p>Alleen toegankelijk met autorisatie. Voor vragen over toegang: {{ schema.authorizationGrantor|urlize|default:'-' }}</p>
   {% endif %}


### PR DESCRIPTION
Previous text was taken as meaning that access was available to anyone on request.

