### PR TITLE
[BUGFIX] subfields

### DIFF
--- a/src/dso_api/dynamic_api/views/mvt.py
+++ b/src/dso_api/dynamic_api/views/mvt.py
@@ -173,7 +173,11 @@ class DatasetMVTView(CheckModelPermissionsMixin, StreamingMVTView):
 
             # We may have to use the db_name, because that usually has a suffix not
             # available on field.name.
-            field_name = toCamelCase(field.db_name) if field.is_relation else field.name
+            field_name = (
+                toCamelCase(field.db_name)
+                if field.is_relation or field.is_subfield
+                else field.name
+            )
 
             # When there is Row Level Auth, we omit the field.
             if schema.rla is not None and field_name in schema.rla.targets:

--- a/src/tests/test_dynamic_api/views/test_mvt.py
+++ b/src/tests/test_dynamic_api/views/test_mvt.py
@@ -482,6 +482,8 @@ def test_mvt_content_zoom(api_client, gebieden_dataset, buurten_model, filled_ro
                         "identificatie": "03630000000078",
                         "volgnummer": 2,
                         "ligtInWijkId": "03630012052035.1",
+                        "ligtInWijkIdentificatie": "03630012052035",
+                        "ligtInWijkVolgnummer": 1,
                         "naam": "AAA v2",
                     },
                     "id": 0,


### PR DESCRIPTION
field.name gebruikt alleen de parent prefix als die parent _geen_ relatie is. Dit zorgde ervoor dat als:
1. een veld een relatie is met subvelden
2. en de id van het subveld niet overeenkomt met het id van een van de velden in de tabel
er een 500 error kwam omdat het ongeprefixte veld werd opgevraagd. In het specifieke geval van meetbouten ging dat fout omdat er een aantal velden met subvelden was met een volgnummer, terwijl meetbouten zelf dat veld niet hebben. 

Heb geen zeer specifieke test ervoor geschreven, omdat het uitbreiden van de bestaande test al laat zien dat subvelden goed doorkomen. 