### PR TITLE
DSO within-filter voor geovelden

### DIFF
--- a/src/dso_api/dynamic_api/filters/openapi.py
+++ b/src/dso_api/dynamic_api/filters/openapi.py
@@ -44,7 +44,7 @@ OPENAPI_LOOKUP_PREFIX = {
     "not": "Exclude matches; ",
     "contains": "Should contain; ",
     "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",
-    "within": "Within distance of;",
+    "within": "Within distance of; ",
 }
 
 OPENAPI_LOOKUP_EXAMPLES = {
@@ -61,6 +61,7 @@ OPENAPI_TYPE_LOOKUP_EXAMPLES = {
     "https://geojson.org/schema/Point.json": {
         "": "Use x,y or POINT(x y)",  # only for no lookup
         "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",
+        "within": "Use x,y,d or WKT POINT(x y),d",
     },
     "https://geojson.org/schema/LineString.json": {
         "within": "Use x,y,d or WKT POINT(x y),d",
@@ -68,10 +69,12 @@ OPENAPI_TYPE_LOOKUP_EXAMPLES = {
     "https://geojson.org/schema/Polygon.json": {
         "contains": "Use x,y or POINT(x y)",
         "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",
+        "within": "Use x,y,d or WKT POINT(x y),d",
     },
     "https://geojson.org/schema/MultiPolygon.json": {
         "contains": "Use x,y or POINT(x y)",
         "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",
+        "within": "Use x,y,d or WKT POINT(x y),d",
     },
 }
 

--- a/src/dso_api/dynamic_api/filters/openapi.py
+++ b/src/dso_api/dynamic_api/filters/openapi.py
@@ -44,6 +44,7 @@ OPENAPI_LOOKUP_PREFIX = {
     "not": "Exclude matches; ",
     "contains": "Should contain; ",
     "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",
+    "within": "Within distance of;",
 }
 
 OPENAPI_LOOKUP_EXAMPLES = {

--- a/src/dso_api/dynamic_api/filters/openapi.py
+++ b/src/dso_api/dynamic_api/filters/openapi.py
@@ -62,6 +62,9 @@ OPENAPI_TYPE_LOOKUP_EXAMPLES = {
         "": "Use x,y or POINT(x y)",  # only for no lookup
         "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",
     },
+    "https://geojson.org/schema/LineString.json": {
+        "within": "Use x,y,d or WKT POINT(x y),d",
+    },
     "https://geojson.org/schema/Polygon.json": {
         "contains": "Use x,y or POINT(x y)",
         "intersects": "Use WKT (POLYGON((x1 y1, x2 y2, ...))) or GeoJSON",

--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -412,7 +412,7 @@ class QueryFilterEngine:
                 # Some lookups have a type that is different from the field type.
                 # For example, isnull/isempty/like.
 
-                # TODO within filter
+                # within filter is a special case AND applies to geo fields
                 if field_schema.is_geo:
                     return lookup_parser(filter_input.raw_value, self.input_crs)
 

--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -23,7 +23,7 @@ from schematools.types import AdditionalRelationSchema, DatasetFieldSchema, Data
 from dso_api.dynamic_api.permissions import check_filter_field_access
 from dso_api.dynamic_api.temporal import TemporalTableQuery, get_request_date
 
-from .values import str2bool, str2geo, str2isodate, str2number, str2time
+from .values import str2bool, str2geo, str2geodist, str2isodate, str2number, str2time
 
 # Lookups that have specific value types:
 
@@ -31,6 +31,8 @@ LOOKUP_PARSERS = {
     "isnull": str2bool,
     "isempty": str2bool,
     "like": str,  # e.g. uri is parsed as string for like.
+    # within parser?
+    "within": str2geodist,
 }
 
 # Array field lookups are not mentioned here, but handled with if/else cases
@@ -53,7 +55,7 @@ SCALAR_PARSERS = {
 # The empty value is there to indicate the field also supports no lookup operator.
 # This is mostly used by the OpenAPI generator.
 _comparison_lookups = {"", "gte", "gt", "lt", "lte", "in", "not", "isnull"}
-_polygon_lookups = {"", "contains", "isnull", "not", "intersects"}
+_polygon_lookups = {"", "contains", "isnull", "not", "intersects", "within"}
 _string_lookups = {"", "in", "isnull", "not", "isempty", "like"}
 
 ALLOWED_IDENTIFIER_LOOKUPS = {"", "in", "not", "isnull"}
@@ -68,7 +70,7 @@ ALLOWED_SCALAR_LOOKUPS = {
     "array": {"", "contains"},
     "object": set(),
     "https://geojson.org/schema/Geometry.json": _polygon_lookups,  # Assume it works.
-    "https://geojson.org/schema/Point.json": {"", "isnull", "not", "intersects"},
+    "https://geojson.org/schema/Point.json": {"", "isnull", "not", "intersects", "within"},
     "https://geojson.org/schema/Polygon.json": _polygon_lookups,
     "https://geojson.org/schema/MultiPolygon.json": _polygon_lookups,
     # Format variants for type string:
@@ -391,6 +393,11 @@ class QueryFilterEngine:
         ):
             return "iexact"
 
+        # within filter in called dwithin in postgis
+        # TODO don't hard code it? Maybe call filter dwithin everywhere?
+        if lookup == "within":
+            return "dwithin"
+
         return lookup or "exact"
 
     def _translate_raw_value(  # noqa: C901
@@ -405,6 +412,11 @@ class QueryFilterEngine:
             if lookup_parser := LOOKUP_PARSERS.get(filter_input.lookup):
                 # Some lookups have a type that is different from the field type.
                 # For example, isnull/isempty/like.
+
+                # TODO within filter
+                if field_schema.is_geo:
+                    return lookup_parser(filter_input.raw_value, self.input_crs)
+
                 return lookup_parser(filter_input.raw_value)
             elif field_schema.is_geo:
                 # Geometry fields need a CRS to handle the input
@@ -440,6 +452,7 @@ class QueryFilterEngine:
                     field_schema.is_array_of_scalars or filter_input.lookup in SPLIT_VALUE_LOOKUPS
                 )
                 values = filter_input.split_values if use_split else filter_input.raw_values
+
                 return [parser(v) for v in values]
             else:
                 return parser(filter_input.raw_value)

--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -31,7 +31,6 @@ LOOKUP_PARSERS = {
     "isnull": str2bool,
     "isempty": str2bool,
     "like": str,  # e.g. uri is parsed as string for like.
-    # within parser?
     "within": str2geodist,
 }
 
@@ -394,7 +393,6 @@ class QueryFilterEngine:
             return "iexact"
 
         # within filter in called dwithin in postgis
-        # TODO don't hard code it? Maybe call filter dwithin everywhere?
         if lookup == "within":
             return "dwithin"
 

--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -70,6 +70,7 @@ ALLOWED_SCALAR_LOOKUPS = {
     "object": set(),
     "https://geojson.org/schema/Geometry.json": _polygon_lookups,  # Assume it works.
     "https://geojson.org/schema/Point.json": {"", "isnull", "not", "intersects", "within"},
+    "https://geojson.org/schema/LineString.json": {"", "within"},
     "https://geojson.org/schema/Polygon.json": _polygon_lookups,
     "https://geojson.org/schema/MultiPolygon.json": _polygon_lookups,
     # Format variants for type string:

--- a/src/dso_api/dynamic_api/filters/values.py
+++ b/src/dso_api/dynamic_api/filters/values.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.geos import GEOSException, GEOSGeometry, Point
 from django.contrib.gis.geos.prototypes import geom  # noqa: F401
+from django.contrib.gis.measure import D
 from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 from gisserver.geometries import CRS
@@ -97,6 +98,25 @@ def str2geo(value: str, crs: CRS | None = None) -> GEOSGeometry:
         return _parse_wkt_geometry(stripped_value, srid)
     else:
         return _parse_point_geometry(stripped_value, srid)
+
+
+def str2geodist(value: str, crs: CRS | None = None) -> tuple[GEOSGeometry, D]:
+    """Convert a string with a distance value to a geometry object and a Distance object
+    Supports Point, Polygon and MultiPolygon objects in WKT or GeoJSON format.
+
+    Args:
+        value: String representation of geometry (WKT, GeoJSON, or x,y format)
+          with a distance value
+        crs: Optional coordinate reference system
+
+    Returns:
+        Tuple of GEOSGeometry object and PostGis Distance object
+    """
+    # Split value string into coordinates and distance
+    coordinates, distance = value.rsplit(",", 1)
+
+    # TODO ik hardcode hier meters, is dat goed?
+    return str2geo(coordinates, crs), D(m=distance)
 
 
 def _parse_geojson(value: str, srid: int | None) -> GEOSGeometry:

--- a/src/dso_api/dynamic_api/filters/values.py
+++ b/src/dso_api/dynamic_api/filters/values.py
@@ -125,7 +125,6 @@ def str2geodist(value: str, crs: CRS | None = None) -> tuple[GEOSGeometry, D]:
         # Split value string into coordinates and distance
         coordinates, distance = value.rsplit(",", 1)
 
-        # TODO ik hardcode hier meters, is dat goed?
         return str2geo(coordinates, crs), D(m=distance)
     else:
         raise ValidationError(

--- a/src/dso_api/dynamic_api/filters/values.py
+++ b/src/dso_api/dynamic_api/filters/values.py
@@ -112,11 +112,25 @@ def str2geodist(value: str, crs: CRS | None = None) -> tuple[GEOSGeometry, D]:
     Returns:
         Tuple of GEOSGeometry object and PostGis Distance object
     """
-    # Split value string into coordinates and distance
-    coordinates, distance = value.rsplit(",", 1)
 
-    # TODO ik hardcode hier meters, is dat goed?
-    return str2geo(coordinates, crs), D(m=distance)
+    # Validate format of input value
+    input_params = value.split(",")
+    if len(input_params) in [2, 3]:
+        if len(input_params) == 2 and not input_params[0].startswith("POINT"):
+            raise ValidationError(
+                "Invalid input parameters. Must be x,y,d or POINT(x y),d. d "
+                "should be whole meters."
+            )
+
+        # Split value string into coordinates and distance
+        coordinates, distance = value.rsplit(",", 1)
+
+        # TODO ik hardcode hier meters, is dat goed?
+        return str2geo(coordinates, crs), D(m=distance)
+    else:
+        raise ValidationError(
+            "Invalid input parameters. Must be x,y,d or POINT(x y),d. d should be whole meters."
+        )
 
 
 def _parse_geojson(value: str, srid: int | None) -> GEOSGeometry:

--- a/src/dso_api/dynamic_api/views/doc.py
+++ b/src/dso_api/dynamic_api/views/doc.py
@@ -280,6 +280,11 @@ LOOKUP_CONTEXT = {
             "Test of er een intersectie is met de waarde.",
         ),
         lookup_context(
+            "within",
+            "GeoJSON of <code>POINT(x y), d</code>",
+            "Test of de waarde binnen een bepaalde afstand van een punt ligt",
+        ),
+        lookup_context(
             "isnull",
             "<code>true</code> | <code>false</code>",
             "Test op ontbrekende waarden (<code>IS NULL</code> / <code>IS NOT NULL</code>).",

--- a/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
+++ b/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
@@ -143,16 +143,19 @@ als `exact`. Er is geen *escaping* van de jokertekens mogelijk.
 
 ### Bij waarden met een geometrie
 
-| Operator                                            | Werking                                                 | SQL Equivalent                                       |
-| --------------------------------------------------- | --------------------------------------------------------|------------------------------------------------------|
-| `?{geoveld}[contains]={x},{y}`                      | Geometrie moet voorkomen op een punt (intersectie)      | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[contains]=POINT(x y)`                   | Idem, nu in de WKT (well-known text) notatie.           | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[intersects]={x},{y}`                    | Geometrie moet voorkomen op een punt (intersectie)      | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[intersects]=POINT(x y)`                 | Idem, nu in de WKT (well-known text) notatie.           | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[intersects]=POLYGON ((4.89...))`        | Geometry moet overlappen met een polygon (intersectie). | `ST_Intersects({geoveld}, POLYGON ((4.89...)))`      |
-| `?{geoveld}[intersects]=MULTIPOLYGON (((4.89...)))` | Geometry moet overlappen met een MULTIPOLYGON           | `ST_Intersects({geoveld}, MULTIPOLYGON ((4.89...)))` |
-| `?{geoveld}[within]={x},{y},{d}`                    | Geometrie moet voorkomen binnen de straal vanaf een punt| `ST_DWithin({geoveld}, POINT({x} {y}), D={d})`       |
-| `?{geoveld}[within]=POINT(x y),{d}}`                | Idem, nu in de WKT (well-known text) notatie.           | `ST_DWithin({geoveld}, POINT({x} {y}), D={d})`       |
+| Operator                                            | Werking                                                  | SQL Equivalent                                       |
+| --------------------------------------------------- | ---------------------------------------------------------|------------------------------------------------------|
+| `?{geoveld}[contains]={x},{y}`                      | Geometrie moet voorkomen op een punt (intersectie)       | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[contains]=POINT(x y)`                   | Idem, nu in de WKT (well-known text) notatie.            | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[intersects]={x},{y}`                    | Geometrie moet voorkomen op een punt (intersectie)       | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[intersects]=POINT(x y)`                 | Idem, nu in de WKT (well-known text) notatie.            | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[intersects]=POLYGON ((4.89...))`        | Geometry moet overlappen met een polygon (intersectie).  | `ST_Intersects({geoveld}, POLYGON ((4.89...)))`      |
+| `?{geoveld}[intersects]=MULTIPOLYGON (((4.89...)))` | Geometry moet overlappen met een MULTIPOLYGON            | `ST_Intersects({geoveld}, MULTIPOLYGON ((4.89...)))` |
+| `?{geoveld}[within]={x},{y},{d}`                    | Geometrie moet voorkomen binnen de straal vanaf een punt*| `ST_DWithin({geoveld}, POINT({x} {y}), D(m={d})`       |
+| `?{geoveld}[within]=POINT(x y),{d}}`                | Idem, nu in de WKT (well-known text) notatie.            | `ST_DWithin({geoveld}, POINT({x} {y}), D=(m{d})`       |
+
+* Geometrieën van het type `MultiPoint`, `LineString`, `MultiLineString`, `Polygon` en `MultiPolygon` hoeven niet volledig binnen de straal te liggen om binnen het `{geoveld}[within]`-filter te vallen.
+Wanneer de geometrie overlapt met de straal rondom het punt, wordt deze teruggegeven door de `{geoveld}[within]`-filter.
 
 Bij het doorzoeken van geometrievelden wordt gebruik gemaakt van de
 projectie opgegeven in de header `Accept-CRS`. Afhankelijk van de

--- a/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
+++ b/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
@@ -157,7 +157,7 @@ als `exact`. Er is geen *escaping* van de jokertekens mogelijk.
 * Geometrieën van het type `MultiPoint`, `LineString`, `MultiLineString`, `Polygon` en `MultiPolygon` hoeven niet volledig binnen de straal te liggen om binnen het `?{geoveld}[within]`-filter te vallen.
 Wanneer de geometrie overlapt met de straal rondom het punt, wordt deze teruggegeven door de `?{geoveld}[within]`-filter.
 
-3D-geovelden zoals velden met EPSG: 7415 (Rijksdriehoek + NAP-diepte) worden ondersteund door de `?{geoveld}[within]`-filter, maar de z-as wordt niet meegenomen in de filterin. Het veld wordt dus behandeld als een 2D-geoveld. Dit betekent bijvoorbeeld dat de diepte van kabels in de grond geen invloed heeft op de filtering.
+3D-geovelden zoals velden met EPSG: 7415 (Rijksdriehoek + NAP-diepte) worden ondersteund door de `?{geoveld}[within]`-filter, maar de z-as wordt niet meegenomen in de filtering. Het veld wordt dus behandeld als een 2D-geoveld. Dit betekent bijvoorbeeld dat de diepte van kabels in de grond geen invloed heeft op de filtering.
 
 Bij het doorzoeken van geometrievelden wordt gebruik gemaakt van de
 projectie opgegeven in de header `Accept-CRS`. Afhankelijk van de

--- a/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
+++ b/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
@@ -154,8 +154,10 @@ als `exact`. Er is geen *escaping* van de jokertekens mogelijk.
 | `?{geoveld}[within]={x},{y},{d}`                    | Geometrie moet voorkomen binnen de straal vanaf een punt*| `ST_DWithin({geoveld}, POINT({x} {y}), D(m={d})`       |
 | `?{geoveld}[within]=POINT(x y),{d}}`                | Idem, nu in de WKT (well-known text) notatie.            | `ST_DWithin({geoveld}, POINT({x} {y}), D=(m{d})`       |
 
-* Geometrieën van het type `MultiPoint`, `LineString`, `MultiLineString`, `Polygon` en `MultiPolygon` hoeven niet volledig binnen de straal te liggen om binnen het `{geoveld}[within]`-filter te vallen.
-Wanneer de geometrie overlapt met de straal rondom het punt, wordt deze teruggegeven door de `{geoveld}[within]`-filter.
+* Geometrieën van het type `MultiPoint`, `LineString`, `MultiLineString`, `Polygon` en `MultiPolygon` hoeven niet volledig binnen de straal te liggen om binnen het `?{geoveld}[within]`-filter te vallen.
+Wanneer de geometrie overlapt met de straal rondom het punt, wordt deze teruggegeven door de `?{geoveld}[within]`-filter.
+
+3D-geovelden zoals velden met EPSG: 7415 (Rijksdriehoek + NAP-diepte) worden ondersteund door de `?{geoveld}[within]`-filter, maar de z-as wordt niet meegenomen in de filterin. Het veld wordt dus behandeld als een 2D-geoveld. Dit betekent bijvoorbeeld dat de diepte van kabels in de grond geen invloed heeft op de filtering.
 
 Bij het doorzoeken van geometrievelden wordt gebruik gemaakt van de
 projectie opgegeven in de header `Accept-CRS`. Afhankelijk van de

--- a/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
+++ b/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
@@ -143,14 +143,16 @@ als `exact`. Er is geen *escaping* van de jokertekens mogelijk.
 
 ### Bij waarden met een geometrie
 
-| Operator                                            | Werking                                                | SQL Equivalent                                       |
-| --------------------------------------------------- | ------------------------------------------------------ | -----------------------------------------------------|
-| `?{geoveld}[contains]={x},{y}`                      | Geometrie moet voorkomen op een punt (intersectie)     | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[contains]=POINT(x y)`                   | Idem, nu in de WKT (well-known text) notatie.          | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[intersects]={x},{y}`                    | Geometrie moet voorkomen op een punt (intersectie)     | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[intersects]=POINT(x y)`                 | Idem, nu in de WKT (well-known text) notatie.          | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
-| `?{geoveld}[intersects]=POLYGON ((4.89...))`        | Geometry moet overlappen met een polygon (intersectie).| `ST_Intersects({geoveld}, POLYGON ((4.89...)))`      |
-| `?{geoveld}[intersects]=MULTIPOLYGON (((4.89...)))` | Geometry moet overlappen met een MULTIPOLYGON          | `ST_Intersects({geoveld}, MULTIPOLYGON ((4.89...)))` |
+| Operator                                            | Werking                                                 | SQL Equivalent                                       |
+| --------------------------------------------------- | --------------------------------------------------------|------------------------------------------------------|
+| `?{geoveld}[contains]={x},{y}`                      | Geometrie moet voorkomen op een punt (intersectie)      | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[contains]=POINT(x y)`                   | Idem, nu in de WKT (well-known text) notatie.           | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[intersects]={x},{y}`                    | Geometrie moet voorkomen op een punt (intersectie)      | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[intersects]=POINT(x y)`                 | Idem, nu in de WKT (well-known text) notatie.           | `ST_Intersects({geoveld}, POINT({x} {y}))`           |
+| `?{geoveld}[intersects]=POLYGON ((4.89...))`        | Geometry moet overlappen met een polygon (intersectie). | `ST_Intersects({geoveld}, POLYGON ((4.89...)))`      |
+| `?{geoveld}[intersects]=MULTIPOLYGON (((4.89...)))` | Geometry moet overlappen met een MULTIPOLYGON           | `ST_Intersects({geoveld}, MULTIPOLYGON ((4.89...)))` |
+| `?{geoveld}[within]={x},{y},{d}`                    | Geometrie moet voorkomen binnen de straal vanaf een punt| `ST_DWithin({geoveld}, POINT({x} {y}), D={d})`       |
+| `?{geoveld}[within]=POINT(x y),{d}}`                | Idem, nu in de WKT (well-known text) notatie.           | `ST_DWithin({geoveld}, POINT({x} {y}), D={d})`       |
 
 Bij het doorzoeken van geometrievelden wordt gebruik gemaakt van de
 projectie opgegeven in de header `Accept-CRS`. Afhankelijk van de

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -691,6 +691,80 @@ def location() -> Location:
 
 
 @pytest.fixture()
+def all_geometries_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("alle_geometrieen.json")
+
+
+@pytest.fixture()
+def all_geometries_dataset(all_geometries_schema) -> Dataset:
+    return Dataset.create_for_schema(all_geometries_schema)
+
+
+@pytest.fixture()
+def all_geometries_model(all_geometries_dataset, dynamic_models) -> DynamicModel:
+    return dynamic_models["alle_geometrien"]["alle_geometrien"]
+
+
+@pytest.fixture()
+def all_geometries_data(all_geometries_model):
+
+    # Point (within 100 meters of Dam Square point used in test)
+    all_geometries_model.objects.create(
+        id=1,
+        geometry=GEOSGeometry(
+            "POINT(121050 487050)",
+            srid=28992,
+        ),
+    )
+
+    # LineString
+    all_geometries_model.objects.create(
+        id=2,
+        geometry=GEOSGeometry(
+            "LINESTRING(120950 486950, 121050 487050, 121150 487150)",
+            srid=28992,
+        ),
+    )
+
+    # Polygon
+    all_geometries_model.objects.create(
+        id=3,
+        geometry=GEOSGeometry(
+            "POLYGON((120900 486900, 120900 487100, 121100 487100, 121100 486900, 120900 486900))",
+            srid=28992,
+        ),
+    )
+
+    # MultiPoint
+    all_geometries_model.objects.create(
+        id=4,
+        geometry=GEOSGeometry(
+            "MULTIPOINT((121000 487000), (121050 487050), (122000 488000))", srid=28992
+        ),
+    )
+
+    # MultiLineString
+    all_geometries_model.objects.create(
+        id=5,
+        geometry=GEOSGeometry(
+            "MULTILINESTRING((120950 486950, 121050 487050), (123000 486000, 124000 486000))",
+            srid=28992,
+        ),
+    )
+
+    # MultiLineString
+    all_geometries_model.objects.create(
+        id=6,
+        geometry=GEOSGeometry(
+            "MULTIPOLYGON(((120900 486900, 120900 487100, 121100 487100, 121100 486900, "
+            "120900 486900)), ((125000 485000, 125000 485500, 125500 485500, 125500 485000,"
+            " 125000 485000)))",
+            srid=28992,
+        ),
+    )
+
+
+@pytest.fixture()
 def parkeervakken_schema(schema_loader) -> DatasetSchema:
     return schema_loader.get_dataset_from_file("parkeervakken.json")
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -752,7 +752,7 @@ def all_geometries_data(all_geometries_model):
         ),
     )
 
-    # MultiLineString
+    # MultiPolygon
     all_geometries_model.objects.create(
         id=6,
         geometry=GEOSGeometry(
@@ -762,6 +762,21 @@ def all_geometries_data(all_geometries_model):
             srid=28992,
         ),
     )
+
+
+@pytest.fixture()
+def drie_d_geometrie_schema(schema_loader) -> DatasetSchema:
+    return schema_loader.get_dataset_from_file("drie_d_geometrie.json")
+
+
+@pytest.fixture()
+def drie_d_geometrie_dataset(drie_d_geometrie_schema) -> Dataset:
+    return Dataset.create_for_schema(drie_d_geometrie_schema)
+
+
+@pytest.fixture()
+def drie_d_geometrie_model(drie_d_geometrie_dataset, dynamic_models) -> DynamicModel:
+    return dynamic_models["drie_d_geometrie"]["drie_d_geometrie"]
 
 
 @pytest.fixture()

--- a/src/tests/files/datasets/alle_geometrieen.json
+++ b/src/tests/files/datasets/alle_geometrieen.json
@@ -1,0 +1,44 @@
+{
+  "id": "alle_geometrien",
+  "type": "dataset",
+  "title": "",
+  "publisher": "Nobody",
+  "default_version": "0.0.1",
+  "crs": "EPSG:28992",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "0.0.1",
+      "tables": [
+        {
+          "id": "alle_geometrien",
+          "type": "table",
+          "version": "1.0.0",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "schema"
+            ],
+            "display": "id",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "uniek"
+              },
+              "geometry": {
+                "$ref": "https://geojson.org/schema/Geometry.json",
+                "description": "Geometrie"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/files/datasets/drie_d_geometrie.json
+++ b/src/tests/files/datasets/drie_d_geometrie.json
@@ -1,0 +1,45 @@
+{
+  "id": "drie_d_geometrie",
+  "type": "dataset",
+  "title": "",
+  "publisher": "Nobody",
+  "default_version": "0.0.1",
+  "crs": "EPSG:7415",
+  "defaultVersion": "v1",
+  "versions": {
+    "v1": {
+      "enableAPI": true,
+      "status": "stable",
+      "version": "0.0.1",
+      "tables": [
+        {
+          "id": "drie_d_geometrie",
+          "type": "table",
+          "version": "1.0.0",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "schema"
+            ],
+            "display": "id",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "uniek"
+              },
+              "geometry": {
+                "title": "Geometrie",
+                "$ref": "https://geojson.org/schema/LineString.json",
+                "description": "Geometrie in RD (epsg:7415)"
+              }
+            }
+          },
+          "status": "stable"
+        }
+      ]
+    }
+  }
+}

--- a/src/tests/test_dynamic_api/test_openapi.py
+++ b/src/tests/test_dynamic_api/test_openapi.py
@@ -205,6 +205,7 @@ def test_openapi_dataset(api_client, afval_dataset, fietspaaltjes_dataset, fille
         "geometry[not]",
         "geometry[isnull]",
         "geometry[intersects]",
+        "geometry[within]",
         "id",
         "id[gt]",
         "id[gte]",

--- a/src/tests/test_dynamic_api/views/test_api_filters.py
+++ b/src/tests/test_dynamic_api/views/test_api_filters.py
@@ -303,7 +303,8 @@ class TestFilterFieldTypes:
     @staticmethod
     def test_geofilter_within(api_client, all_geometries_data, filled_router):
         """
-        Prove that geofilter within filters work as expected."""
+        Prove that geofilter within filters work as expected.
+        """
 
         # Inside using RD (string)
         response = api_client.get(
@@ -312,6 +313,7 @@ class TestFilterFieldTypes:
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
+        print(data)
         assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using R/D (string)"
 
         returned_types = {
@@ -333,6 +335,7 @@ class TestFilterFieldTypes:
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
+        print(data)
         assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using R/D (WKT)"
 
         # Outside using RD
@@ -361,6 +364,33 @@ class TestFilterFieldTypes:
             headers={"Accept-Crs": "EPSG:4326"},
         )
         assert response.status_code == 400, "Outside WGS84 range"
+
+        # No distance value supplied in request
+        response = api_client.get(
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "52.388231,4.8897865"},
+            headers={"Accept-Crs": "EPSG:4326"},
+        )
+        assert response.status_code == 400, "No distance parameter provided "
+        assert "Must be x,y,d or POINT(x y),d" in response.text
+
+        # No distance value supplied in request
+        response = api_client.get(
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "121000,487000"},
+            headers={"Accept-Crs": "EPSG:4326"},
+        )
+        assert response.status_code == 400, "No distance parameter provided"
+        assert "Must be x,y,d or POINT(x y),d" in response.text
+
+        # No distance value supplied in request
+        response = api_client.get(
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "POINT(121000 487000)"},
+            headers={"Accept-Crs": "EPSG:4326"},
+        )
+        assert response.status_code == 400, "No distance parameter provided"
+        assert "Must be x,y,d or POINT(x y),d" in response.text
 
     @staticmethod
     def test_geofilter_intersects(api_client, parkeervakken_parkeervak_model, filled_router):

--- a/src/tests/test_dynamic_api/views/test_api_filters.py
+++ b/src/tests/test_dynamic_api/views/test_api_filters.py
@@ -301,68 +301,63 @@ class TestFilterFieldTypes:
         assert response.status_code == 400, "Outside WGS84 range"
 
     @staticmethod
-    def test_geofilter_within(api_client, parkeervakken_parkeervak_model, filled_router):
+    def test_geofilter_within(api_client, all_geometries_data, filled_router):
         """
         Prove that geofilter within filters work as expected."""
 
-        parkeervakken_parkeervak_model.objects.create(
-            id="121138489006",
-            type="File",
-            soort="MULDER",
-            aantal=1.0,
-            e_type="E6b",
-            buurtcode="A05d",
-            straatnaam="Zoutkeetsgracht",
-            geometry=GEOSGeometry(
-                "POLYGON((121140.66 489048.21, 121140.72 489047.1, 121140.8 489046.9, 121140.94 "
-                "489046.74,121141.11 489046.62, 121141.31 489046.55, 121141.52 489046.53, "
-                "121134.67 489045.85, 121134.47 489047.87, 121140.66 489048.21))",
-                28992,
-            ),
-        )
-
         # Inside using RD (string)
         response = api_client.get(
-            "/v1/parkeervakken/parkeervakken/",
-            data={"geometry[within]": "121142,489049,100"},
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "121000,487000,100"},
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
-        print(data)
-        assert len(data["_embedded"]["parkeervakken"]) == 1, "Inside using R/D (string)"
+        assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using R/D (string)"
+
+        returned_types = {
+            item["geometry"]["type"] for item in data["_embedded"]["alle_geometrien"]
+        }
+        assert returned_types == {
+            "Point",
+            "LineString",
+            "Polygon",
+            "MultiPoint",
+            "MultiLineString",
+            "MultiPolygon",
+        }
 
         # Inside using RD (WKT)
         response = api_client.get(
-            "/v1/parkeervakken/parkeervakken/",
-            data={"geometry[within]": "POINT(121142 489049),100"},
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "POINT(121000 487000),1000"},
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
-        print(data)
-        assert len(data["_embedded"]["parkeervakken"]) == 1, "Inside using R/D (WKT)"
+        assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using R/D (WKT)"
 
         # Outside using RD
         response = api_client.get(
-            "/v1/parkeervakken/parkeervakken/",
-            data={"geometry[within]": "121200,489200,100"},
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "123000,489000,1000"},
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
-        assert len(data["_embedded"]["parkeervakken"]) == 0, "Outside using R/D"
+        assert len(data["_embedded"]["alle_geometrien"]) == 0, "Outside using R/D"
 
         # Inside using WGS84
         response = api_client.get(
-            "/v1/parkeervakken/parkeervakken/",
-            data={"geometry[within]": "4.890401,52.388521,100"},
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "52.3700,4.9000,1000"},
             headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
-        assert len(data["_embedded"]["parkeervakken"]) == 1, "Inside using WGS84"
+        print(data)
+        assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using WGS84"
 
         # Invalid WGS84 coords
         response = api_client.get(
-            "/v1/parkeervakken/parkeervakken/",
-            data={"geometry[intersects]": "52.388231,48897865"},
+            "/v1/alle_geometrien/alle_geometrien/",
+            data={"geometry[within]": "52.388231,48897865,1000"},
             headers={"Accept-Crs": "EPSG:4326"},
         )
         assert response.status_code == 400, "Outside WGS84 range"

--- a/src/tests/test_dynamic_api/views/test_api_filters.py
+++ b/src/tests/test_dynamic_api/views/test_api_filters.py
@@ -303,17 +303,16 @@ class TestFilterFieldTypes:
     @staticmethod
     def test_geofilter_within(api_client, all_geometries_data, filled_router):
         """
-        Prove that geofilter within filters work as expected.
+        Prove that geofilter within filters work as expected (for 2D geometries).
         """
 
         # Inside using RD (string)
         response = api_client.get(
             "/v1/alle_geometrien/alle_geometrien/",
-            data={"geometry[within]": "121000,487000,100"},
+            data={"geometry[within]": "121000,487000,1000"},
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
-        print(data)
         assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using R/D (string)"
 
         returned_types = {
@@ -335,7 +334,6 @@ class TestFilterFieldTypes:
             headers={"Accept-Crs": "EPSG:28992"},
         )
         data = read_response_json(response)
-        print(data)
         assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using R/D (WKT)"
 
         # Outside using RD
@@ -354,7 +352,6 @@ class TestFilterFieldTypes:
             headers={"Accept-Crs": "EPSG:4326"},
         )
         data = read_response_json(response)
-        print(data)
         assert len(data["_embedded"]["alle_geometrien"]) == 6, "Inside using WGS84"
 
         # Invalid WGS84 coords
@@ -391,6 +388,62 @@ class TestFilterFieldTypes:
         )
         assert response.status_code == 400, "No distance parameter provided"
         assert "Must be x,y,d or POINT(x y),d" in response.text
+
+    @staticmethod
+    def test_geofilter_within_drie_d(api_client, drie_d_geometrie_model, filled_router):
+        """
+        Some tables use 3D-geometry (e.gleidingeninfrastructuur/waternetRioolleidingen)
+        LineString geometry with EPSG 7415 (Rijksdriehoek + NAP-depth)
+        We currently don't support actual 3D geometry filtering, so the z-axis is ignored and
+        the 3D fields are treated as 2D fields.
+        These tests prove that 3D LineString geometries are filtered correctly.
+        """
+
+        # Create LineString with realistic depth value -0.06 (NAP)
+        drie_d_geometrie_model.objects.create(
+            id=1,
+            geometry=GEOSGeometry(
+                "LINESTRING(120950 486950 -0.06, 121050 487050 -0.06, 121150 487150 -0.6)",
+                srid=7415,
+            ),
+        )
+        # Inside using RD (string)
+        response = api_client.get(
+            "/v1/drie_d_geometrie/drie_d_geometrie/",
+            data={"geometry[within]": "121000,487000,10"},
+            headers={"Accept-Crs": "EPSG:28992"},
+        )
+        data = read_response_json(response)
+        assert len(data["_embedded"]["drie_d_geometrie"]) == 1, "Inside using R/D+NAP (string)"
+
+        # Outside using RD (string)
+        response = api_client.get(
+            "/v1/drie_d_geometrie/drie_d_geometrie/",
+            data={"geometry[within]": "123000,489000,10"},
+            headers={"Accept-Crs": "EPSG:28992"},
+        )
+        data = read_response_json(response)
+        assert len(data["_embedded"]["drie_d_geometrie"]) == 0, "Outside using R/D+NAP (string)"
+
+        # LineString with big depth value of -50 (NAP)
+        drie_d_geometrie_model.objects.create(
+            id=2,
+            geometry=GEOSGeometry(
+                "LINESTRING(120950 486950 -0.06, 121050 487050 -50, 121150 487150 -50)",
+                srid=7415,
+            ),
+        )
+
+        # Inside using RD (string), even when cable is deeper (-50) than distance value (10)
+        # If we would use PostGis 3D filtering, this test should fail
+        response = api_client.get(
+            "/v1/drie_d_geometrie/drie_d_geometrie/",
+            data={"geometry[within]": "121000,487000,10"},
+            headers={"Accept-Crs": "EPSG:28992"},
+        )
+        data = read_response_json(response)
+        assert len(data["_embedded"]["drie_d_geometrie"]) == 2, "Outside using R/D+NAP (string)"
+        assert 2 in [item["id"] for item in data["_embedded"]["drie_d_geometrie"]]
 
     @staticmethod
     def test_geofilter_intersects(api_client, parkeervakken_parkeervak_model, filled_router):

--- a/src/tests/test_dynamic_api/views/test_api_filters.py
+++ b/src/tests/test_dynamic_api/views/test_api_filters.py
@@ -368,25 +368,25 @@ class TestFilterFieldTypes:
             data={"geometry[within]": "52.388231,4.8897865"},
             headers={"Accept-Crs": "EPSG:4326"},
         )
-        assert response.status_code == 400, "No distance parameter provided "
+        assert response.status_code == 400, "No distance parameter provided (WGS84)"
         assert "Must be x,y,d or POINT(x y),d" in response.text
 
         # No distance value supplied in request
         response = api_client.get(
             "/v1/alle_geometrien/alle_geometrien/",
             data={"geometry[within]": "121000,487000"},
-            headers={"Accept-Crs": "EPSG:4326"},
+            headers={"Accept-Crs": "EPSG:28992"},
         )
-        assert response.status_code == 400, "No distance parameter provided"
+        assert response.status_code == 400, "No distance parameter provided (R/D)"
         assert "Must be x,y,d or POINT(x y),d" in response.text
 
         # No distance value supplied in request
         response = api_client.get(
             "/v1/alle_geometrien/alle_geometrien/",
             data={"geometry[within]": "POINT(121000 487000)"},
-            headers={"Accept-Crs": "EPSG:4326"},
+            headers={"Accept-Crs": "EPSG:28992"},
         )
-        assert response.status_code == 400, "No distance parameter provided"
+        assert response.status_code == 400, "No distance parameter provided (R/D WKT)"
         assert "Must be x,y,d or POINT(x y),d" in response.text
 
     @staticmethod
@@ -435,7 +435,7 @@ class TestFilterFieldTypes:
         )
 
         # Inside using RD (string), even when cable is deeper (-50) than distance value (10)
-        # If we would use PostGis 3D filtering, this test should fail
+        # If we used PostGis 3D filtering, this test should fail
         response = api_client.get(
             "/v1/drie_d_geometrie/drie_d_geometrie/",
             data={"geometry[within]": "121000,487000,10"},

--- a/src/tests/test_dynamic_api/views/test_api_filters.py
+++ b/src/tests/test_dynamic_api/views/test_api_filters.py
@@ -301,6 +301,73 @@ class TestFilterFieldTypes:
         assert response.status_code == 400, "Outside WGS84 range"
 
     @staticmethod
+    def test_geofilter_within(api_client, parkeervakken_parkeervak_model, filled_router):
+        """
+        Prove that geofilter within filters work as expected."""
+
+        parkeervakken_parkeervak_model.objects.create(
+            id="121138489006",
+            type="File",
+            soort="MULDER",
+            aantal=1.0,
+            e_type="E6b",
+            buurtcode="A05d",
+            straatnaam="Zoutkeetsgracht",
+            geometry=GEOSGeometry(
+                "POLYGON((121140.66 489048.21, 121140.72 489047.1, 121140.8 489046.9, 121140.94 "
+                "489046.74,121141.11 489046.62, 121141.31 489046.55, 121141.52 489046.53, "
+                "121134.67 489045.85, 121134.47 489047.87, 121140.66 489048.21))",
+                28992,
+            ),
+        )
+
+        # Inside using RD (string)
+        response = api_client.get(
+            "/v1/parkeervakken/parkeervakken/",
+            data={"geometry[within]": "121142,489049,100"},
+            headers={"Accept-Crs": "EPSG:28992"},
+        )
+        data = read_response_json(response)
+        print(data)
+        assert len(data["_embedded"]["parkeervakken"]) == 1, "Inside using R/D (string)"
+
+        # Inside using RD (WKT)
+        response = api_client.get(
+            "/v1/parkeervakken/parkeervakken/",
+            data={"geometry[within]": "POINT(121142 489049),100"},
+            headers={"Accept-Crs": "EPSG:28992"},
+        )
+        data = read_response_json(response)
+        print(data)
+        assert len(data["_embedded"]["parkeervakken"]) == 1, "Inside using R/D (WKT)"
+
+        # Outside using RD
+        response = api_client.get(
+            "/v1/parkeervakken/parkeervakken/",
+            data={"geometry[within]": "121200,489200,100"},
+            headers={"Accept-Crs": "EPSG:28992"},
+        )
+        data = read_response_json(response)
+        assert len(data["_embedded"]["parkeervakken"]) == 0, "Outside using R/D"
+
+        # Inside using WGS84
+        response = api_client.get(
+            "/v1/parkeervakken/parkeervakken/",
+            data={"geometry[within]": "4.890401,52.388521,100"},
+            headers={"Accept-Crs": "EPSG:4326"},
+        )
+        data = read_response_json(response)
+        assert len(data["_embedded"]["parkeervakken"]) == 1, "Inside using WGS84"
+
+        # Invalid WGS84 coords
+        response = api_client.get(
+            "/v1/parkeervakken/parkeervakken/",
+            data={"geometry[intersects]": "52.388231,48897865"},
+            headers={"Accept-Crs": "EPSG:4326"},
+        )
+        assert response.status_code == 400, "Outside WGS84 range"
+
+    @staticmethod
     def test_geofilter_intersects(api_client, parkeervakken_parkeervak_model, filled_router):
         """
         Prove that geofilter intersects filters work as expected.


### PR DESCRIPTION
within-filter voor geovelden om alle records binnen te halen die binnen de straal vanaf een punt liggen.

De gebruiker kan een punt (x,y of Point(x y) en een distance-waarde meegeven om de geometrien in de tabel te filteren die binnen de straal van dit punt vallen.

- Validatie voor dat de distance waarde altijd meegegeven moet worden bij gebruik van de within filter
- Nieuwe test fixture met alle soorten GeosGeometry gemaakt zodat die allemaal getest worden. Dit kan eventueel worden hergebruikt voor nieuwe filters / andere functionaliteiten in de toekomst
- Extra notitie toegevoegd in de documentatie over hoe de filter werkt met geometrieen die niet volledig binnen de straal vallen
- Bij 3D geometrieen wordt de z-as buiten beschouwing gelaten en wordt het veld behandeld als een 2D veld

Zijn de laatste 2 punten duidelijk genoeg omschreven in filters.md?

