### PR TITLE
Remove --execute flag from import_schemas

### DIFF
--- a/src/initialize_db.sh
+++ b/src/initialize_db.sh
@@ -3,7 +3,7 @@
 if ! django migrate --check && "$INITIALIZE_DB" = "true";
 then
     ./manage.py migrate;
-    ./manage.py import_schemas --create-tables --execute;
+    ./manage.py import_schemas --create-tables;
     schema permissions apply --auto --revoke --create-roles --execute  -a "datasets_dataset:SELECT;scope_openbaar" -a "datasets_datasettable:SELECT;scope_openbaar" -a "datasets_datasetfield:SELECT;scope_openbaar"  -a "datasets_datasetprofile:SELECT;scope_openbaar";
 
     # Fill tables with mock data if MOCK_DATA is set. Continue on errors.


### PR DESCRIPTION
--execute flag is removed, import_schemas now fails because it doesn't recognize this flag