### PR TITLE
Fix header parameter filtering

### DIFF
--- a/src/dso_api/dynamic_api/filters/parser.py
+++ b/src/dso_api/dynamic_api/filters/parser.py
@@ -188,19 +188,20 @@ class QueryFilterEngine:
             if not key.startswith(cls.HEADER_PARAMS_PREFIX):
                 continue
 
-            # custom query headers are passed with a DSO- prefix
+            # custom query headers are passed with a DSO- prefix and | to separate the operator
             raw_key = key[len(cls.HEADER_PARAMS_PREFIX) :]
 
             # split on operator if passed
-            parts = raw_key.rsplit(".", 1)
+            parts = raw_key.rsplit("|", 1)
 
             has_operator = len(parts) == 2
 
             if has_operator:
                 raw_key, operator = parts[0], parts[1].lower()
 
-            # convert query param to camelCase
-            query_param = toCamelCase(raw_key.replace("-", ""))
+            # Get possible nested fields to turn snake-case into camelCase
+            fields = raw_key.split(".")
+            query_param = ".".join([toCamelCase(field.replace("-", "")) for field in fields])
 
             new_key = f"{query_param}[{operator}]" if has_operator else query_param
 

--- a/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
+++ b/src/templates/dso_api/dynamic_api/docs/rest/filtering.md
@@ -34,15 +34,29 @@ curl 'https://api.data.amsterdam.nl/v1/bag/verblijfsobjecten/?gebruiksdoel.code=
 
 ## Filteren via custom headers
 Er kan ook gefilterd worden op attributen via custom headers. Deze
-headers moeten dan wel geprefixed zijn met "DSO-" om verwarring
-met andere headers te voorkomen. Als er geen operatoren worden
-meegegeven is de default operator gelijk aan equals.
+headers moeten geprefixed zijn met "DSO-" gevolgd door het veldnaam
+en de operator. Als er geen operator wordt meegegeven is de
+default operator gelijk aan equals. Omdat HTTP Headers
+case-insensitive zijn, moet de camelCasing van de veldnaam worden
+aangepast naar snake-case. Dit geldt ook voor velden uit relaties.
 
-Deze query headers worden verwacht in een volgend soort structuur:
+Deze filter headers worden verwacht in de volgende structuur:
+
 ``` bash
+DSO-{veldnaam-snake-case}.{subveldnaam}|{operator}
+```
+Bijvoorbeeld:
+```
 DSO-aantal-bouwlagen
-DSO-aantal-bouwlagen.gte
-DSO-naam.like
+DSO-aantal-bouwlagen|gte
+DSO-naam|like
+DSO-gebruiksdoel.code
+```
+
+In een curl call ziet dit er dan als volgt uit:
+
+``` bash
+curl 'https://api.data.amsterdam.nl/v1/bag/verblijfsobjecten/' -H 'DSO-gebruiksdoel.code:1' -H 'DSO-naam|like:West*'
 ```
 
 ## Filteren in relaties

--- a/src/tests/test_dynamic_api/test_filters.py
+++ b/src/tests/test_dynamic_api/test_filters.py
@@ -106,6 +106,8 @@ class TestFilterEngine:
             ("name=Movie1", {"movie1"}),
             ("name[like]=movie1", {"movie1"}),
             ("name[like]=Movie1", {"movie1"}),
+            # Relation fields
+            ("category.name=bar", {"movie1"}),
         ],
     )
     def test_filter_logic(self, movies_model, movie1, movie2, query, expect):
@@ -113,18 +115,51 @@ class TestFilterEngine:
         qs = engine.filter_queryset(movies_model.objects.all())
         assert {obj.name for obj in qs} == expect, str(qs.query)
 
-    def test_dso_headers(self, movies_model, movie1, movie2):
+    @pytest.mark.parametrize(
+        "query,expect",
+        [
+            # Date less than
+            ({"dateAdded[lt]": ["2020-02-10"]}, {"movie1"}),
+            ({"dateAdded[lt]": ["2020-03-01"]}, {"movie1"}),
+            ({"dateAdded[lte]": ["2020-03-01"]}, {"movie1", "movie2"}),
+            # Date less than full datetime
+            ({"dateAdded[lt]": ["2020-03-01T23:00:00"]}, {"movie1", "movie2"}),
+            # Date greater than
+            ({"dateAdded[gt]": ["2020-02-10"]}, {"movie2"}),
+            ({"dateAdded[gt]": ["2020-03-01"]}, set()),
+            ({"dateAdded[gte]": ["2020-3-1"]}, {"movie2"}),
+            # Test in filter
+            ({"dateAdded[in]": ["2020-2-1,2022-5-5"]}, {"movie1"}),
+            ({"dateAdded[in]": ["2020-2-1,2020-3-1,2022-5-5"]}, {"movie1", "movie2"}),
+            # Not (can be repeated for "AND NOT" testing)
+            ({"dateAdded[not]": ["2020-2-1"]}, {"movie2"}),
+            ({"dateAdded[not]": ["2020-2-1", "2020-3-1"]}, set()),
+            # # Booleans
+            ({"enjoyable": ["true"]}, {"movie1"}),
+            ({"enjoyable": ["false"]}, set()),
+            ({"enjoyable[isnull]": ["true"]}, {"movie2"}),
+            ({"enjoyable[isnull]": ["false"]}, {"movie1"}),
+            # URLs have string-like comparison operators
+            ({"url[in]": ["foobar,http://example.com/someurl"]}, {"movie2"}),
+            ({"url[like]": ["http:*"]}, {"movie2"}),
+            ({"url[isnull]": ["true"]}, {"movie1"}),
+            # Case insensitive match
+            ({"name": ["movie1"]}, {"movie1"}),
+            ({"name": ["Movie1"]}, {"movie1"}),
+            ({"name[like]": ["movie1"]}, {"movie1"}),
+            ({"name[like]": ["Movie1"]}, {"movie1"}),
+            # Relation fields
+            ({"category.name": ["bar"]}, {"movie1"}),
+        ],
+    )
+    def test_dso_headers(self, movies_model, movie1, movie2, query, expect):
         """Prove that filtering with dso headers work."""
         engine = create_filter_engine(
-            "dateAdded[lt]=2020-3-1T23:00:00",
-            dso_headers=MultiValueDict(
-                {
-                    "name": ["movie1"],
-                }
-            ),
+            "",
+            dso_headers=MultiValueDict(query),
         )
         qs = engine.filter_queryset(movies_model.objects.all())
-        assert {obj.name for obj in qs} == {"movie1"}
+        assert {obj.name for obj in qs} == expect, str(qs.query)
 
     def test_dso_headers_overwrite_query(self, movies_model, movie1, movie2):
         """Prove that filtering with dso headers work."""
@@ -145,44 +180,23 @@ class TestFilterEngine:
             (
                 {
                     "DSO-aantal-bouwlagen": 5,
-                    "DSO-status": "active",
-                    "DSO-aantal-bouwlagen.gt": 2,
-                    "DSO-aantal-bouwlagen.lt": 10,
-                    "DSO-per-jaar-per-m2.isnull": "true",
-                    "DSO-numbers-33-in-the-middle-44.like": "somestring",
+                    "dso-status": "active",
+                    "DSO-aantal-bouwlagen|gt": 2,
+                    "DSO-aantal-bouwlagen|lte": 10,
+                    "DSO-per-jaar-per-m2|isnull": "true",
+                    "DSO-numbers-33-in-the-middle-44|like": "somestring",
+                    "DSO-field.subfield.subfield|eq": "somestring",
                     "other-header": "ignore-me",
                 },
                 {
                     "aantalBouwlagen": [5],
                     "status": ["active"],
                     "aantalBouwlagen[gt]": [2],
-                    "aantalBouwlagen[lt]": [10],
+                    "aantalBouwlagen[lte]": [10],
                     "perJaarPerM2[isnull]": ["true"],
                     "numbers33InTheMiddle44[like]": ["somestring"],
+                    "field.subfield.subfield[eq]": ["somestring"],
                 },
-            ),
-            (
-                {
-                    "dso-aantal-bouwlagen": 5,
-                    "DSO-status": "active",
-                    "DSO-aantal-BOUWLAGEN.gt": 2,
-                    "DSO-Aantal-bouwlagen.lt": 10,
-                    "other-header": "ignore-me",
-                },
-                {
-                    "aantalBouwlagen": [5],
-                    "status": ["active"],
-                    "aantalBouwlagen[gt]": [2],
-                    "aantalBouwlagen[lt]": [10],
-                },
-            ),
-            (
-                {
-                    "aantal-bouwlagen": 5,
-                    "status": "active",
-                    "other-header": "ignore-me",
-                },
-                {},
             ),
         ],
     )


### PR DESCRIPTION
Het filteren van velden werkte niet voor nested fields. Daarom de formatting van de header parameters wat aangepast zodat het meer in lijn is met de andere filters. Documentatie en tests zijn ook aangepast